### PR TITLE
feat: add agent availability control plane

### DIFF
--- a/src/by_framework/__init__.py
+++ b/src/by_framework/__init__.py
@@ -20,6 +20,18 @@ from .common.emitter import (
 )
 from .common.logger import logger, setup_logging
 from .common.redis_client import Redis, close_redis, get_redis, init_redis
+from .core.availability import (
+    AvailabilityResult,
+    AvailabilityRouter,
+    AvailabilityStatus,
+    DeliveryIntent,
+    PendingDelivery,
+    RoutePolicy,
+    WakeupDecision,
+    WakeupDecisionStatus,
+    WakeupRequest,
+)
+from .core.delivery_gate import DeliveryGate
 from .core.extensions import (
     AgentConfig,
     AgentConfigsSnapshot,
@@ -82,6 +94,7 @@ from .core.registry import (
     check_agent_type_online,
     check_worker_online,
 )
+from .core.wakeup_controller import WakeupController, WakeupProvider
 from .core.workspace import WorkspaceManager
 from .worker.app import run_worker
 from .worker.byai_context import ByaiAgentContext, ByaiAgentTask
@@ -171,4 +184,16 @@ __all__ = [
     "ProcessCommandResult",
     "ensure_json_serializable",
     "normalize_process_result",
+    "AvailabilityResult",
+    "AvailabilityRouter",
+    "AvailabilityStatus",
+    "DeliveryIntent",
+    "PendingDelivery",
+    "RoutePolicy",
+    "WakeupDecision",
+    "WakeupDecisionStatus",
+    "WakeupRequest",
+    "DeliveryGate",
+    "WakeupController",
+    "WakeupProvider",
 ]

--- a/src/by_framework/client/byai_client.py
+++ b/src/by_framework/client/byai_client.py
@@ -3,6 +3,7 @@
 from typing import List, Optional, Union
 
 from by_framework.common.redis_client import Redis
+from by_framework.core.availability import RoutePolicy
 from by_framework.core.protocol.byai_codec import serialize_byai_content
 from by_framework.core.protocol.message import BaiYingMessage
 from by_framework.core.registry import WorkerRegistry
@@ -43,7 +44,10 @@ class ByaiGatewayClient(GatewayClient):
         extra_payload: Optional[dict] = None,
         metadata: Optional[dict] = None,
         target_worker_id: Optional[str] = None,
-        require_online_worker: bool = True,
+        route_policy: str = RoutePolicy.FAIL_FAST,
+        availability_timeout_ms: int = 30000,
+        region: Optional[str] = None,
+        priority: int = 0,
     ):
         serialized_content = serialize_byai_content(content)
         return await super().send_message(
@@ -59,5 +63,8 @@ class ByaiGatewayClient(GatewayClient):
             extra_payload=extra_payload,
             metadata=metadata,
             target_worker_id=target_worker_id,
-            require_online_worker=require_online_worker,
+            route_policy=route_policy,
+            availability_timeout_ms=availability_timeout_ms,
+            region=region,
+            priority=priority,
         )

--- a/src/by_framework/client/client.py
+++ b/src/by_framework/client/client.py
@@ -18,6 +18,12 @@ from by_framework.common.constants import (
     RedisKeys,
 )
 from by_framework.common.redis_client import Redis, get_redis
+from by_framework.core.availability import (
+    AvailabilityRouter,
+    AvailabilityStatus,
+    DeliveryIntent,
+    RoutePolicy,
+)
 from by_framework.core.protocol.action_type import ActionType
 from by_framework.core.protocol.commands import (
     AskAgentCommand,
@@ -156,7 +162,7 @@ class GatewayClient:
         return results
 
     async def _resolve_agent_type_route(
-        self, target_agent_type: str, require_online_worker: bool
+        self, target_agent_type: str, route_policy: str
     ) -> RouteResolution:
         """Resolve agent-type-mode routing.
 
@@ -166,7 +172,7 @@ class GatewayClient:
         if self.registry is None:
             raise WorkerRegistryNotSetError("send messages")
 
-        if not require_online_worker:
+        if route_policy == RoutePolicy.SEND_ANYWAY:
             return RouteResolution(stream_name=RedisKeys.ctrl_stream(target_agent_type))
 
         has_online_agent_type, _workers = await self.registry.has_online_agent_type(  # pylint: disable=C0103,unused-variable
@@ -180,10 +186,10 @@ class GatewayClient:
     async def _resolve_direct_worker_route(
         self,
         target_worker_id: str,
-        require_online_worker: bool,
+        check_online: bool,
     ) -> RouteResolution:
         """Resolve direct-worker routing for debug or worker-specific control."""
-        if self.registry is not None and require_online_worker:
+        if self.registry is not None and check_online:
             is_online = await self.registry.is_worker_online(target_worker_id)
             if not is_online:
                 raise LookupError(
@@ -373,7 +379,10 @@ class GatewayClient:
         extra_payload: Optional[Dict[str, Any]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         target_worker_id: Optional[str] = None,
-        require_online_worker: bool = True,
+        route_policy: str = RoutePolicy.FAIL_FAST,
+        availability_timeout_ms: int = 30000,
+        region: Optional[str] = None,
+        priority: int = 0,
     ) -> SendMessageResponse:
         """
         Send a message to the gateway.
@@ -385,9 +394,7 @@ class GatewayClient:
           and routed to any available worker that declares the target_agent_type.
 
         Args:
-            require_online_worker: If True (default), require the target route to
-              have at least one online worker before sending. If False, skips the
-              online check and sends directly to the target stream.
+            route_policy: Controls online checks and unavailable-agent behavior.
         """
         # 1. Prepare parameters for interceptors
         params = {
@@ -406,16 +413,83 @@ class GatewayClient:
         for interceptor in self.interceptors:
             params = interceptor.before_send(params)
 
+        if not message_id:
+            message_id = f"{MESSAGE_ID_PREFIX}{uuid.uuid4().hex[:8]}"
+        if not trace_id:
+            trace_id = uuid.uuid4().hex
+
+        header = MessageHeader(
+            message_id=message_id,
+            session_id=params["session_id"],
+            trace_id=trace_id,
+            target_agent_type=params["target_agent_type"],
+            parent_message_id=params["parent_message_id"],
+            user_code=params["user_code"],
+            user_name=params["user_name"],
+            metadata=params["metadata"],
+        )
+        command = self._build_gateway_command(
+            action_type=params["action_type"],
+            header=header,
+            content=params["content"],
+            extra_payload=params["extra_payload"],
+        )
+        execution_id = f"{EXECUTION_ID_PREFIX}{uuid.uuid4().hex[:8]}"
+
         # 3. Resolve route and optionally probe agent type/liveness
+        should_dispatch_control = True
         try:
             if target_worker_id:
                 route = await self._resolve_direct_worker_route(
-                    target_worker_id, require_online_worker
+                    target_worker_id,
+                    route_policy != RoutePolicy.SEND_ANYWAY,
                 )
             else:
-                route = await self._resolve_agent_type_route(
-                    params["target_agent_type"], require_online_worker
+                availability = await AvailabilityRouter(
+                    self.redis, self.registry
+                ).prepare_delivery(
+                    DeliveryIntent(
+                        execution_id=execution_id,
+                        message_id=message_id,
+                        session_id=params["session_id"],
+                        trace_id=trace_id,
+                        source="client",
+                        target_agent_type=params["target_agent_type"],
+                        user_code=params["user_code"],
+                        region=region or "",
+                        priority=priority,
+                        policy=route_policy,
+                        timeout_ms=availability_timeout_ms,
+                        command_payload=command.to_dict(),
+                        metadata=params["metadata"],
+                    )
                 )
+                if availability.status not in (
+                    AvailabilityStatus.DELIVER_NOW,
+                    AvailabilityStatus.WAIT_AND_DELIVER,
+                    AvailabilityStatus.FALLBACK_TO_OTHER_AGENT_TYPE,
+                    AvailabilityStatus.QUEUE_PENDING,
+                ):
+                    return SendMessageResponse(
+                        success=False,
+                        status=ExecutionStatus.FAILED,
+                        message_id="",
+                        trace_id="",
+                        target_worker_id="",
+                        timestamp=int(time.time() * 1000),
+                        error=availability.error,
+                        error_code=availability.error_code
+                        or ExecutionStatus.ERR_AGENT_TYPE_UNAVAILABLE,
+                    )
+                if availability.status == AvailabilityStatus.QUEUE_PENDING:
+                    should_dispatch_control = False
+                route = RouteResolution(
+                    stream_name=availability.stream_name,
+                    target_worker_id=availability.target_worker_id,
+                )
+                if availability.selected_agent_type:
+                    params["target_agent_type"] = availability.selected_agent_type
+                    command.header.target_agent_type = availability.selected_agent_type
         except LookupError as err:
             return SendMessageResponse(
                 success=False,
@@ -439,30 +513,7 @@ class GatewayClient:
                 error_code=ExecutionStatus.ERR_AGENT_TYPE_UNAVAILABLE,
             )
 
-        if not message_id:
-            message_id = f"{MESSAGE_ID_PREFIX}{uuid.uuid4().hex[:8]}"
-        if not trace_id:
-            trace_id = uuid.uuid4().hex
-
-        header = MessageHeader(
-            message_id=message_id,
-            session_id=params["session_id"],
-            trace_id=trace_id,
-            target_agent_type=params["target_agent_type"],
-            parent_message_id=params["parent_message_id"],
-            user_code=params["user_code"],
-            user_name=params["user_name"],
-            metadata=params["metadata"],
-        )
-        command = self._build_gateway_command(
-            action_type=params["action_type"],
-            header=header,
-            content=params["content"],
-            extra_payload=params["extra_payload"],
-        )
-
         # Initialize execution tracking
-        execution_id = f"{EXECUTION_ID_PREFIX}{uuid.uuid4().hex[:8]}"
         if self.registry and hasattr(self.registry, "initialize_execution"):
             try:
                 await self.registry.initialize_execution(
@@ -482,7 +533,8 @@ class GatewayClient:
                 pass  # Fallback if registry fails
 
         # 4. Route to the appropriate stream
-        await self.redis.xadd(route.stream_name, command.to_redis_payload())
+        if should_dispatch_control:
+            await self.redis.xadd(route.stream_name, command.to_redis_payload())
 
         return SendMessageResponse(
             success=True,

--- a/src/by_framework/common/constants.py
+++ b/src/by_framework/common/constants.py
@@ -9,6 +9,8 @@ are centrally managed in this file. Do not hardcode literal strings in business 
 class RedisKeys:
     """Gateway SDK global Redis Key naming conventions and constants."""
 
+    CONTROL_PLANE_PREFIX = "byai_gateway:control_plane"
+
     # --- Queues and Streams ---
     @staticmethod
     def ctrl_stream(agent_type: str) -> str:
@@ -24,6 +26,61 @@ class RedisKeys:
     def plugin_reload_ack_stream(reload_id: str) -> str:
         """Stream for worker ACKs emitted after handling a plugin reload command."""
         return f"byai_gateway:plugin_reload:{reload_id}:ack"
+
+    @classmethod
+    def control_plane_wakeup_stream(cls) -> str:
+        """Management stream for agent availability wakeup requests."""
+        return f"{cls.CONTROL_PLANE_PREFIX}:mgmt:wakeup"
+
+    @classmethod
+    def control_plane_wakeup_result_stream(cls, execution_id: str) -> str:
+        """Management stream for wakeup controller decisions."""
+        return f"{cls.CONTROL_PLANE_PREFIX}:mgmt:wakeup:result:{execution_id}"
+
+    @classmethod
+    def control_plane_delivery_pending_stream(cls) -> str:
+        """Management stream for pending control-message delivery."""
+        return f"{cls.CONTROL_PLANE_PREFIX}:mgmt:delivery:pending"
+
+    @classmethod
+    def control_plane_deadletter_stream(cls) -> str:
+        """Management stream for failed control-plane work."""
+        return f"{cls.CONTROL_PLANE_PREFIX}:mgmt:deadletter"
+
+    @classmethod
+    def control_plane_agent_availability(cls, agent_type: str) -> str:
+        """Availability state key for an agent type."""
+        return f"{cls.CONTROL_PLANE_PREFIX}:availability:agent_type:{agent_type}"
+
+    @classmethod
+    def control_plane_agent_circuit(cls, agent_type: str) -> str:
+        """Circuit-breaker state key for an agent type."""
+        return f"{cls.CONTROL_PLANE_PREFIX}:circuit:agent_type:{agent_type}"
+
+    @classmethod
+    def control_plane_agent_fallback(cls, agent_type: str) -> str:
+        """Fallback routing state key for an agent type."""
+        return f"{cls.CONTROL_PLANE_PREFIX}:fallback:agent_type:{agent_type}"
+
+    @classmethod
+    def control_plane_user_quota(cls, user_code: str) -> str:
+        """User quota state key for control-plane scheduling."""
+        return f"{cls.CONTROL_PLANE_PREFIX}:quota:user:{user_code}"
+
+    @classmethod
+    def control_plane_tenant_quota(cls, tenant_id: str) -> str:
+        """Backward-compatible alias for user-code based quota state."""
+        return cls.control_plane_user_quota(tenant_id)
+
+    @classmethod
+    def control_plane_wakeup_dedupe(
+        cls, agent_type: str, user_code: str, region: str
+    ) -> str:
+        """Dedupe key for concurrent wakeup requests."""
+        return (
+            f"{cls.CONTROL_PLANE_PREFIX}:wakeup:dedupe:"
+            f"{agent_type}:{user_code}:{region}"
+        )
 
     @staticmethod
     def agent_configs_snapshot(snapshot_key: str) -> str:

--- a/src/by_framework/core/__init__.py
+++ b/src/by_framework/core/__init__.py
@@ -5,6 +5,18 @@ Provides core components including protocol definitions, worker registry,
 and workspace management.
 """
 
+from .availability import (
+    AvailabilityResult,
+    AvailabilityRouter,
+    AvailabilityStatus,
+    DeliveryIntent,
+    PendingDelivery,
+    RoutePolicy,
+    WakeupDecision,
+    WakeupDecisionStatus,
+    WakeupRequest,
+)
+from .delivery_gate import DeliveryGate
 from .protocol import (
     ActionType,
     AgentState,
@@ -35,6 +47,7 @@ from .protocol import (
     unregister_command,
 )
 from .registry import WorkerRegistry
+from .wakeup_controller import WakeupController, WakeupProvider
 from .workspace import WorkspaceManager
 
 __all__ = [
@@ -67,4 +80,16 @@ __all__ = [
     "get_registered_command",
     "WorkerRegistry",
     "WorkspaceManager",
+    "AvailabilityRouter",
+    "AvailabilityStatus",
+    "AvailabilityResult",
+    "DeliveryIntent",
+    "RoutePolicy",
+    "PendingDelivery",
+    "WakeupRequest",
+    "WakeupDecision",
+    "WakeupDecisionStatus",
+    "WakeupController",
+    "WakeupProvider",
+    "DeliveryGate",
 ]

--- a/src/by_framework/core/availability.py
+++ b/src/by_framework/core/availability.py
@@ -1,0 +1,495 @@
+"""Agent availability control-plane routing.
+
+This module centralizes online-worker checks and wakeup handshakes so client
+calls and inter-agent calls share the same offline routing behavior.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any, Optional
+
+from by_framework.common.constants import RedisKeys
+from by_framework.common.redis_client import Redis
+from by_framework.core.registry import WorkerRegistry, check_agent_type_online
+
+
+class RoutePolicy:
+    """Policy values for routing and availability checks."""
+
+    FAIL_FAST = "FAIL_FAST"
+    SEND_ANYWAY = "SEND_ANYWAY"
+    WAKE_AND_WAIT = "WAKE_AND_WAIT"
+    WAKE_AND_QUEUE = "WAKE_AND_QUEUE"
+    QUEUE_ONLY = "QUEUE_ONLY"
+
+
+class WakeupDecisionStatus:
+    """Wakeup controller decision status values."""
+
+    READY = "READY"
+    STARTING = "STARTING"
+    QUEUED = "QUEUED"
+    REJECTED = "REJECTED"
+    FAILED = "FAILED"
+    FALLBACK = "FALLBACK"
+
+
+class AvailabilityStatus:
+    """Availability router result values."""
+
+    DELIVER_NOW = "DELIVER_NOW"
+    WAIT_AND_DELIVER = "WAIT_AND_DELIVER"
+    QUEUE_PENDING = "QUEUE_PENDING"
+    REJECT = "REJECT"
+    FALLBACK_TO_OTHER_AGENT_TYPE = "FALLBACK_TO_OTHER_AGENT_TYPE"
+
+
+@dataclass(frozen=True)
+class DeliveryIntent:
+    """Framework-internal representation of a control-message delivery."""
+
+    execution_id: str
+    message_id: str
+    session_id: str
+    trace_id: str
+    source: str
+    target_agent_type: str
+    user_code: str = ""
+    region: str = ""
+    priority: int = 0
+    policy: str = RoutePolicy.FAIL_FAST
+    timeout_ms: int = 30000
+    command_payload: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class WakeupRequest:
+    """Redis management event emitted when a target agent type is unavailable."""
+
+    execution_id: str
+    target_agent_type: str
+    session_id: str
+    trace_id: str
+    message_id: str
+    source: str
+    policy: str
+    timeout_ms: int
+    user_code: str = ""
+    region: str = ""
+    priority: int = 0
+    metadata: dict[str, Any] = field(default_factory=dict)
+    command_payload: dict[str, Any] = field(default_factory=dict)
+
+    def to_redis_payload(self) -> dict[str, str]:
+        return {"data": json.dumps(asdict(self))}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "WakeupRequest":
+        return cls(
+            execution_id=str(data.get("execution_id", "")),
+            target_agent_type=str(data.get("target_agent_type", "")),
+            session_id=str(data.get("session_id", "")),
+            trace_id=str(data.get("trace_id", "")),
+            message_id=str(data.get("message_id", "")),
+            source=str(data.get("source", "")),
+            policy=str(data.get("policy", RoutePolicy.FAIL_FAST)),
+            timeout_ms=int(data.get("timeout_ms", 30000)),
+            user_code=str(data.get("user_code") or data.get("tenant_id", "")),
+            region=str(data.get("region", "")),
+            priority=int(data.get("priority", 0)),
+            metadata=dict(data.get("metadata", {})),
+            command_payload=dict(data.get("command_payload", {})),
+        )
+
+
+@dataclass(frozen=True)
+class PendingDelivery:
+    """Control command held until a wakeup decision allows dispatch."""
+
+    execution_id: str
+    message_id: str
+    session_id: str
+    trace_id: str
+    target_agent_type: str
+    delivery_stream: str
+    command_payload: dict[str, Any]
+    user_code: str = ""
+    region: str = ""
+    priority: int = 0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_redis_payload(self) -> dict[str, str]:
+        return {"data": json.dumps(asdict(self))}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "PendingDelivery":
+        return cls(
+            execution_id=str(data.get("execution_id", "")),
+            message_id=str(data.get("message_id", "")),
+            session_id=str(data.get("session_id", "")),
+            trace_id=str(data.get("trace_id", "")),
+            target_agent_type=str(data.get("target_agent_type", "")),
+            delivery_stream=str(data.get("delivery_stream", "")),
+            command_payload=dict(data.get("command_payload", {})),
+            user_code=str(data.get("user_code") or data.get("tenant_id", "")),
+            region=str(data.get("region", "")),
+            priority=int(data.get("priority", 0)),
+            metadata=dict(data.get("metadata", {})),
+        )
+
+
+@dataclass(frozen=True)
+class WakeupDecision:
+    """Decision returned by the manager-owned wakeup controller."""
+
+    execution_id: str = ""
+    target_agent_type: str = ""
+    status: str = WakeupDecisionStatus.FAILED
+    selected_agent_type: str = ""
+    worker_ids: list[str] = field(default_factory=list)
+    region: str = ""
+    retry_after_ms: Optional[int] = None
+    reason: str = ""
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "WakeupDecision":
+        return cls(
+            execution_id=str(data.get("execution_id", "")),
+            target_agent_type=str(data.get("target_agent_type", "")),
+            status=str(data.get("status", WakeupDecisionStatus.FAILED)),
+            selected_agent_type=str(data.get("selected_agent_type", "")),
+            worker_ids=list(data.get("worker_ids", [])),
+            region=str(data.get("region", "")),
+            retry_after_ms=data.get("retry_after_ms"),
+            reason=str(data.get("reason", "")),
+        )
+
+
+@dataclass(frozen=True)
+class AvailabilityResult:
+    """Result returned by AvailabilityRouter before control-message delivery."""
+
+    status: str
+    stream_name: str = ""
+    target_worker_id: str = ""
+    error: str = ""
+    error_code: str = ""
+    selected_agent_type: str = ""
+    execution_id: str = ""
+
+
+class AvailabilityRouter:
+    """Shared availability and wakeup router for client and agent calls."""
+
+    def __init__(
+        self,
+        redis: Redis,
+        registry: Optional[WorkerRegistry] = None,
+    ):
+        self.redis = redis
+        self.registry = registry
+
+    async def prepare_delivery(
+        self,
+        intent: DeliveryIntent,
+    ) -> AvailabilityResult:
+        """Resolve whether a command can be delivered now or needs wakeup."""
+        policy_rejection = await self._check_control_plane_policy(intent)
+        if policy_rejection is not None:
+            return policy_rejection
+
+        if intent.policy == RoutePolicy.SEND_ANYWAY:
+            return AvailabilityResult(
+                status=AvailabilityStatus.DELIVER_NOW,
+                stream_name=RedisKeys.ctrl_stream(intent.target_agent_type),
+                execution_id=intent.execution_id,
+            )
+
+        has_online_worker = await self._has_online_agent_type(intent.target_agent_type)
+        if has_online_worker:
+            return AvailabilityResult(
+                status=AvailabilityStatus.DELIVER_NOW,
+                stream_name=RedisKeys.ctrl_stream(intent.target_agent_type),
+                execution_id=intent.execution_id,
+            )
+
+        fallback = await self._resolve_configured_fallback(intent)
+        if fallback is not None:
+            return fallback
+
+        if intent.policy == RoutePolicy.FAIL_FAST:
+            return self._unavailable(intent)
+
+        if intent.policy == RoutePolicy.WAKE_AND_WAIT:
+            return await self._wake_and_wait(intent)
+
+        if intent.policy == RoutePolicy.WAKE_AND_QUEUE:
+            return await self._wake_and_queue(intent)
+
+        if intent.policy == RoutePolicy.QUEUE_ONLY:
+            return await self._queue_pending(intent)
+
+        return AvailabilityResult(
+            status=AvailabilityStatus.REJECT,
+            error=f"Unsupported offline route policy '{intent.policy}'",
+            error_code="AGENT_TYPE_UNAVAILABLE",
+            execution_id=intent.execution_id,
+        )
+
+    async def _check_control_plane_policy(
+        self, intent: DeliveryIntent
+    ) -> Optional[AvailabilityResult]:
+        circuit = await self._read_json_key(
+            RedisKeys.control_plane_agent_circuit(intent.target_agent_type)
+        )
+        if circuit and str(circuit.get("state", "")).upper() == "OPEN":
+            return AvailabilityResult(
+                status=AvailabilityStatus.REJECT,
+                error=str(circuit.get("reason") or "agent circuit is open"),
+                error_code="AGENT_CIRCUIT_OPEN",
+                execution_id=intent.execution_id,
+            )
+
+        if intent.user_code:
+            quota = await self._read_json_key(
+                RedisKeys.control_plane_user_quota(intent.user_code)
+            )
+            if quota and quota.get("available") is False:
+                return AvailabilityResult(
+                    status=AvailabilityStatus.REJECT,
+                    error=str(quota.get("reason") or "tenant quota exceeded"),
+                    error_code="TENANT_QUOTA_EXCEEDED",
+                    execution_id=intent.execution_id,
+                )
+
+        return None
+
+    async def _resolve_configured_fallback(
+        self, intent: DeliveryIntent
+    ) -> Optional[AvailabilityResult]:
+        fallback = await self._read_json_key(
+            RedisKeys.control_plane_agent_fallback(intent.target_agent_type)
+        )
+        if not fallback:
+            return None
+
+        selected = str(
+            fallback.get("selected_agent_type")
+            or fallback.get("agent_type")
+            or fallback.get("target_agent_type")
+            or ""
+        )
+        if not selected:
+            return None
+
+        if await self._has_online_agent_type(selected):
+            return AvailabilityResult(
+                status=AvailabilityStatus.FALLBACK_TO_OTHER_AGENT_TYPE,
+                stream_name=RedisKeys.ctrl_stream(selected),
+                selected_agent_type=selected,
+                execution_id=intent.execution_id,
+            )
+
+        return None
+
+    async def _wake_and_queue(self, intent: DeliveryIntent) -> AvailabilityResult:
+        request = WakeupRequest(
+            execution_id=intent.execution_id,
+            target_agent_type=intent.target_agent_type,
+            session_id=intent.session_id,
+            trace_id=intent.trace_id,
+            message_id=intent.message_id,
+            source=intent.source,
+            policy=intent.policy,
+            timeout_ms=intent.timeout_ms,
+            user_code=intent.user_code,
+            region=intent.region,
+            priority=intent.priority,
+            metadata=intent.metadata,
+            command_payload=intent.command_payload,
+        )
+        await self.redis.xadd(
+            RedisKeys.control_plane_wakeup_stream(), request.to_redis_payload()
+        )
+        return await self._queue_pending(intent)
+
+    async def _queue_pending(self, intent: DeliveryIntent) -> AvailabilityResult:
+        pending = PendingDelivery(
+            execution_id=intent.execution_id,
+            message_id=intent.message_id,
+            session_id=intent.session_id,
+            trace_id=intent.trace_id,
+            target_agent_type=intent.target_agent_type,
+            delivery_stream=RedisKeys.ctrl_stream(intent.target_agent_type),
+            command_payload=intent.command_payload,
+            user_code=intent.user_code,
+            region=intent.region,
+            priority=intent.priority,
+            metadata=intent.metadata,
+        )
+        await self.redis.xadd(
+            RedisKeys.control_plane_delivery_pending_stream(),
+            pending.to_redis_payload(),
+        )
+        return AvailabilityResult(
+            status=AvailabilityStatus.QUEUE_PENDING,
+            stream_name=RedisKeys.control_plane_delivery_pending_stream(),
+            execution_id=intent.execution_id,
+        )
+
+    async def _wake_and_wait(self, intent: DeliveryIntent) -> AvailabilityResult:
+        request = WakeupRequest(
+            execution_id=intent.execution_id,
+            target_agent_type=intent.target_agent_type,
+            session_id=intent.session_id,
+            trace_id=intent.trace_id,
+            message_id=intent.message_id,
+            source=intent.source,
+            policy=intent.policy,
+            timeout_ms=intent.timeout_ms,
+            user_code=intent.user_code,
+            region=intent.region,
+            priority=intent.priority,
+            metadata=intent.metadata,
+            command_payload=intent.command_payload,
+        )
+        await self.redis.xadd(
+            RedisKeys.control_plane_wakeup_stream(), request.to_redis_payload()
+        )
+
+        decision = await self._wait_for_wakeup_decision(intent)
+        if decision is None:
+            return AvailabilityResult(
+                status=AvailabilityStatus.REJECT,
+                error=(
+                    f"Timed out waiting for worker wakeup for agent_type "
+                    f"'{intent.target_agent_type}'"
+                ),
+                error_code="AGENT_TYPE_UNAVAILABLE",
+                execution_id=intent.execution_id,
+            )
+
+        if decision.status == WakeupDecisionStatus.READY:
+            has_online_worker = await self._has_online_agent_type(
+                intent.target_agent_type
+            )
+            if has_online_worker:
+                return AvailabilityResult(
+                    status=AvailabilityStatus.WAIT_AND_DELIVER,
+                    stream_name=RedisKeys.ctrl_stream(intent.target_agent_type),
+                    execution_id=intent.execution_id,
+                )
+            return self._unavailable(intent)
+
+        if decision.status == WakeupDecisionStatus.FALLBACK:
+            selected = decision.selected_agent_type
+            return AvailabilityResult(
+                status=AvailabilityStatus.FALLBACK_TO_OTHER_AGENT_TYPE,
+                stream_name=RedisKeys.ctrl_stream(selected) if selected else "",
+                selected_agent_type=selected,
+                execution_id=intent.execution_id,
+            )
+
+        return AvailabilityResult(
+            status=AvailabilityStatus.REJECT,
+            error=decision.reason
+            or f"Wakeup rejected for agent_type '{intent.target_agent_type}'",
+            error_code="AGENT_TYPE_UNAVAILABLE",
+            execution_id=intent.execution_id,
+        )
+
+    async def _wait_for_wakeup_decision(
+        self, intent: DeliveryIntent
+    ) -> Optional[WakeupDecision]:
+        deadline = time.monotonic() + max(intent.timeout_ms, 0) / 1000
+        result_stream = RedisKeys.control_plane_wakeup_result_stream(
+            intent.execution_id
+        )
+        last_id = "0-0"
+
+        while True:
+            remaining_ms = int((deadline - time.monotonic()) * 1000)
+            if remaining_ms <= 0:
+                return None
+
+            messages = await self.redis.xread(
+                streams={result_stream: last_id},
+                count=1,
+                block=remaining_ms,
+            )
+            if not messages:
+                return None
+
+            for _, entries in messages:
+                for entry_id, fields in entries:
+                    last_id = (
+                        entry_id.decode("utf-8")
+                        if isinstance(entry_id, bytes)
+                        else str(entry_id)
+                    )
+                    decision = self._decode_decision(fields)
+                    if decision is None:
+                        continue
+                    if (
+                        decision.execution_id
+                        and decision.execution_id != intent.execution_id
+                    ):
+                        continue
+                    if decision.status in (
+                        WakeupDecisionStatus.STARTING,
+                        WakeupDecisionStatus.QUEUED,
+                    ):
+                        break
+                    return decision
+
+    async def _has_online_agent_type(self, agent_type: str) -> bool:
+        if self.registry is not None:
+            has_online_agent_type, _ = await self.registry.has_online_agent_type(
+                agent_type
+            )
+            return bool(has_online_agent_type)
+
+        has_online_agent_type, _ = await check_agent_type_online(
+            self.redis, agent_type, check_active=True
+        )
+        return bool(has_online_agent_type)
+
+    @staticmethod
+    def _decode_decision(fields: dict[Any, Any]) -> Optional[WakeupDecision]:
+        raw = fields.get(b"data") if isinstance(fields, dict) else None
+        if raw is None and isinstance(fields, dict):
+            raw = fields.get("data")
+        if raw is None:
+            return None
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        return WakeupDecision.from_dict(json.loads(raw))
+
+    async def _read_json_key(self, key: str) -> Optional[dict[str, Any]]:
+        if not hasattr(self.redis, "get"):
+            return None
+        raw = await self.redis.get(key)
+        if raw is None:
+            return None
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        if not isinstance(raw, str):
+            return None
+        try:
+            decoded = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        return decoded if isinstance(decoded, dict) else None
+
+    @staticmethod
+    def _unavailable(intent: DeliveryIntent) -> AvailabilityResult:
+        return AvailabilityResult(
+            status=AvailabilityStatus.REJECT,
+            error=f"No online worker found for agent_type '{intent.target_agent_type}'",
+            error_code="AGENT_TYPE_UNAVAILABLE",
+            execution_id=intent.execution_id,
+        )

--- a/src/by_framework/core/delivery_gate.py
+++ b/src/by_framework/core/delivery_gate.py
@@ -1,0 +1,60 @@
+"""Pending-delivery gate for the availability control plane."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from by_framework.common.constants import RedisKeys
+from by_framework.common.redis_client import Redis
+from by_framework.core.availability import PendingDelivery
+
+
+class DeliveryGate:
+    """Reference component that releases pending deliveries after wakeup."""
+
+    def __init__(self, redis: Redis):
+        self.redis = redis
+
+    async def dispatch_ready(
+        self,
+        execution_id: str,
+        *,
+        last_id: str = "0-0",
+        count: int = 100,
+    ) -> int:
+        """Dispatch pending deliveries matching a ready wakeup request."""
+        messages = await self.redis.xread(
+            streams={RedisKeys.control_plane_delivery_pending_stream(): last_id},
+            count=count,
+            block=0,
+        )
+        dispatched = 0
+        pending_deliveries: list[PendingDelivery] = []
+        for _, entries in messages or []:
+            for _, fields in entries:
+                pending = self._decode_pending(fields)
+                if pending is None or pending.execution_id != execution_id:
+                    continue
+                pending_deliveries.append(pending)
+
+        for pending in sorted(
+            pending_deliveries, key=lambda delivery: delivery.priority, reverse=True
+        ):
+            await self.redis.xadd(
+                pending.delivery_stream,
+                {"data": json.dumps(pending.command_payload)},
+            )
+            dispatched += 1
+        return dispatched
+
+    @staticmethod
+    def _decode_pending(fields: dict[Any, Any]) -> PendingDelivery | None:
+        raw = fields.get(b"data") if isinstance(fields, dict) else None
+        if raw is None and isinstance(fields, dict):
+            raw = fields.get("data")
+        if raw is None:
+            return None
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        return PendingDelivery.from_dict(json.loads(raw))

--- a/src/by_framework/core/wakeup_controller.py
+++ b/src/by_framework/core/wakeup_controller.py
@@ -1,0 +1,151 @@
+"""Reference wakeup controller for the availability control plane."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from typing import Any, Protocol
+
+from by_framework.common.constants import RedisKeys
+from by_framework.common.redis_client import Redis
+from by_framework.core.availability import (
+    WakeupDecision,
+    WakeupDecisionStatus,
+    WakeupRequest,
+)
+
+
+class WakeupProvider(Protocol):
+    """Manager-owned adapter that starts or signals workers."""
+
+    async def wakeup(self, request: WakeupRequest) -> WakeupDecision | dict[str, Any]:
+        """Handle a wakeup request and return a controller decision."""
+        ...  # pylint: disable=unnecessary-ellipsis
+
+
+class WakeupController:
+    """Small reference controller for processing wakeup management events."""
+
+    def __init__(
+        self,
+        redis: Redis,
+        provider: WakeupProvider,
+        dedupe_ttl_seconds: int = 30,
+        max_attempts: int = 1,
+    ):
+        self.redis = redis
+        self.provider = provider
+        self.dedupe_ttl_seconds = dedupe_ttl_seconds
+        self.max_attempts = max(1, max_attempts)
+
+    async def run_once(self, last_id: str = "0-0", block_ms: int = 0) -> str:
+        """Process at most one wakeup request and return the next stream id."""
+        messages = await self.redis.xread(
+            streams={RedisKeys.control_plane_wakeup_stream(): last_id},
+            count=1,
+            block=block_ms,
+        )
+        if not messages:
+            return last_id
+
+        for _, entries in messages:
+            for entry_id, fields in entries:
+                request = self._decode_request(fields)
+                next_id = (
+                    entry_id.decode("utf-8")
+                    if isinstance(entry_id, bytes)
+                    else str(entry_id)
+                )
+                if request is None:
+                    return next_id
+                decision = await self._handle_request(request)
+                await self.redis.xadd(
+                    RedisKeys.control_plane_wakeup_result_stream(request.execution_id),
+                    {"data": json.dumps(asdict(decision))},
+                )
+                if decision.status == WakeupDecisionStatus.FAILED:
+                    await self.redis.xadd(
+                        RedisKeys.control_plane_deadletter_stream(),
+                        {"data": json.dumps(asdict(decision))},
+                    )
+                return next_id
+
+        return last_id
+
+    async def _handle_request(self, request: WakeupRequest) -> WakeupDecision:
+        if not await self._claim_wakeup(request):
+            return WakeupDecision(
+                execution_id=request.execution_id,
+                target_agent_type=request.target_agent_type,
+                status=WakeupDecisionStatus.QUEUED,
+                reason="wakeup already in progress",
+            )
+        return await self._call_provider(request)
+
+    async def _call_provider(self, request: WakeupRequest) -> WakeupDecision:
+        last_error = ""
+        for _ in range(self.max_attempts):
+            try:
+                raw_decision = await self.provider.wakeup(request)
+            except Exception as error:  # pylint: disable=broad-exception-caught
+                last_error = str(error)
+                continue
+
+            return self._normalize_decision(raw_decision, request)
+
+        return WakeupDecision(
+            execution_id=request.execution_id,
+            target_agent_type=request.target_agent_type,
+            status=WakeupDecisionStatus.FAILED,
+            reason=last_error,
+        )
+
+    @staticmethod
+    def _normalize_decision(
+        raw_decision: WakeupDecision | dict[str, Any],
+        request: WakeupRequest,
+    ) -> WakeupDecision:
+        if isinstance(raw_decision, WakeupDecision):
+            return WakeupDecision(
+                execution_id=raw_decision.execution_id or request.execution_id,
+                target_agent_type=raw_decision.target_agent_type
+                or request.target_agent_type,
+                status=raw_decision.status,
+                selected_agent_type=raw_decision.selected_agent_type,
+                worker_ids=raw_decision.worker_ids,
+                region=raw_decision.region,
+                retry_after_ms=raw_decision.retry_after_ms,
+                reason=raw_decision.reason,
+            )
+
+        data = dict(raw_decision)
+        data.setdefault("execution_id", request.execution_id)
+        data.setdefault("target_agent_type", request.target_agent_type)
+        return WakeupDecision.from_dict(data)
+
+    async def _claim_wakeup(self, request: WakeupRequest) -> bool:
+        if not hasattr(self.redis, "set"):
+            return True
+        dedupe_key = RedisKeys.control_plane_wakeup_dedupe(
+            request.target_agent_type,
+            request.user_code or "_",
+            request.region or "_",
+        )
+        claimed = await self.redis.set(
+            dedupe_key,
+            request.execution_id,
+            ex=self.dedupe_ttl_seconds,
+            nx=True,
+        )
+        return bool(claimed)
+
+    @staticmethod
+    def _decode_request(fields: dict[Any, Any]) -> WakeupRequest | None:
+        raw = fields.get(b"data") if isinstance(fields, dict) else None
+        if raw is None and isinstance(fields, dict):
+            raw = fields.get("data")
+        if raw is None:
+            return None
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        return WakeupRequest.from_dict(json.loads(raw))

--- a/src/by_framework/worker/byai_context.py
+++ b/src/by_framework/worker/byai_context.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Optional
 
+from by_framework.core.availability import RoutePolicy
 from by_framework.core.protocol.byai_types import ByaiContent
 
 from .context import AgentContext
@@ -32,7 +33,10 @@ class ByaiAgentContext(AgentContext):
         metadata: Optional[dict[str, Any]] = None,
         message_id: Optional[str] = None,
         parent_message_id: Optional[str] = None,
-        require_online_worker: bool = True,
+        route_policy: str = RoutePolicy.FAIL_FAST,
+        availability_timeout_ms: int = 30000,
+        region: Optional[str] = None,
+        priority: int = 0,
     ) -> dict:
         return await super().call_agent(
             target_agent_type=target_agent_type,
@@ -42,7 +46,10 @@ class ByaiAgentContext(AgentContext):
             metadata=metadata,
             message_id=message_id,
             parent_message_id=parent_message_id,
-            require_online_worker=require_online_worker,
+            route_policy=route_policy,
+            availability_timeout_ms=availability_timeout_ms,
+            region=region,
+            priority=priority,
         )
 
     async def dispatch_group(

--- a/src/by_framework/worker/context.py
+++ b/src/by_framework/worker/context.py
@@ -30,6 +30,12 @@ from by_framework.common.constants import (
 from by_framework.common.emitter import DataLayoutBuilder, GatewayDataEmitter
 from by_framework.common.logger import logger
 from by_framework.common.redis_client import Redis, get_redis
+from by_framework.core.availability import (
+    AvailabilityRouter,
+    AvailabilityStatus,
+    DeliveryIntent,
+    RoutePolicy,
+)
 from by_framework.core.extensions import AgentConfig
 from by_framework.core.protocol.agent_state import AgentState
 from by_framework.core.protocol.commands import AskAgentCommand, ResumeCommand
@@ -43,7 +49,6 @@ from by_framework.core.protocol.events import (
     StreamChunkEvent,
 )
 from by_framework.core.protocol.message_header import MessageHeader
-from by_framework.core.registry import check_agent_type_online
 from by_framework.core.runtime import AgentRuntimeState
 from by_framework.core.runtime.file_permissions import FilePermissionPolicy
 from by_framework.core.runtime.filestore.base import FileStorage
@@ -447,34 +452,18 @@ class AgentContext:
         metadata: Optional[Dict[str, Any]] = None,
         message_id: Optional[str] = None,
         parent_message_id: Optional[str] = None,
-        require_online_worker: bool = True,
+        route_policy: str = RoutePolicy.FAIL_FAST,
+        availability_timeout_ms: int = 30000,
+        region: Optional[str] = None,
+        priority: int = 0,
     ) -> dict:
         """Push a control-flow message to another agent.
 
         If wait_for_reply is True, source_agent_type is injected for routing.
 
         Args:
-            require_online_worker: If True (default), require the target
-              agent_type to currently have at least one online worker before
-              sending. If no worker is online, returns immediately with FAILED
-              status.
+            route_policy: Controls online checks and unavailable-agent behavior.
         """
-        if require_online_worker:
-            has_cap, _ = await check_agent_type_online(
-                self.redis, target_agent_type, check_active=True
-            )
-            if not has_cap:
-                return {
-                    "status": AgentState.FAILED.value,
-                    "message_id": "",
-                    "parent_message_id": parent_message_id or "",
-                    "target_agent_type": target_agent_type,
-                    "error": (
-                        f"No online worker found for agent_type '{target_agent_type}'"
-                    ),
-                    "error_code": "AGENT_TYPE_UNAVAILABLE",
-                }
-
         message_id = message_id or self.generate_message_id()
         parent_message_id = parent_message_id if parent_message_id else self.message_id
         merged_extra_payload = dict(extra_payload or {})
@@ -504,11 +493,52 @@ class AgentContext:
                 k: v for k, v in merged_extra_payload.items() if k != "wait_for_reply"
             },
         )
+        execution_id = f"{EXECUTION_ID_PREFIX}{uuid.uuid4().hex[:8]}"
+
+        availability = await AvailabilityRouter(self.redis).prepare_delivery(
+            DeliveryIntent(
+                execution_id=execution_id,
+                message_id=message_id,
+                session_id=self.session_id,
+                trace_id=self.trace_id,
+                source=self.current_agent_id,
+                target_agent_type=target_agent_type,
+                user_code=self.agent_runtime_state.session_manager.user_code,
+                region=region or "",
+                priority=priority,
+                policy=route_policy,
+                timeout_ms=availability_timeout_ms,
+                command_payload=command.to_dict(),
+                metadata=metadata or {},
+            )
+        )
+        if availability.status not in (
+            AvailabilityStatus.DELIVER_NOW,
+            AvailabilityStatus.WAIT_AND_DELIVER,
+            AvailabilityStatus.FALLBACK_TO_OTHER_AGENT_TYPE,
+            AvailabilityStatus.QUEUE_PENDING,
+        ):
+            return {
+                "status": AgentState.FAILED.value,
+                "message_id": "",
+                "parent_message_id": parent_message_id or "",
+                "target_agent_type": target_agent_type,
+                "error": availability.error,
+                "error_code": availability.error_code or "AGENT_TYPE_UNAVAILABLE",
+            }
+        should_dispatch_control = (
+            availability.status != AvailabilityStatus.QUEUE_PENDING
+        )
+        if availability.selected_agent_type:
+            target_agent_type = availability.selected_agent_type
+            command.header.target_agent_type = availability.selected_agent_type
+        delivery_stream = availability.stream_name or RedisKeys.ctrl_stream(
+            target_agent_type
+        )
 
         if self.plugin_registry:
             await self.plugin_registry.on_call_agent_start(self, command)
 
-        execution_id = f"{EXECUTION_ID_PREFIX}{uuid.uuid4().hex[:8]}"
         from by_framework.core.registry import WorkerRegistry
 
         registry = WorkerRegistry(self.redis)
@@ -525,7 +555,7 @@ class AgentContext:
                         if wait_for_reply
                         else "",
                         "target_agent_type": target_agent_type,
-                        "stream_name": RedisKeys.ctrl_stream(target_agent_type),
+                        "stream_name": delivery_stream,
                         "status": "QUEUED",
                     }
                 )
@@ -533,9 +563,8 @@ class AgentContext:
                 pass  # Fallback if registry fails
 
         try:
-            await self.redis.xadd(
-                RedisKeys.ctrl_stream(target_agent_type), command.to_redis_payload()
-            )
+            if should_dispatch_control:
+                await self.redis.xadd(delivery_stream, command.to_redis_payload())
         except Exception as error:
             if self.plugin_registry:
                 await self.plugin_registry.on_call_agent_error(self, command, error)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -6,6 +6,7 @@ import pytest
 
 from by_framework import ByaiGatewayClient, GatewayClient
 from by_framework.common.constants import RedisKeys
+from by_framework.core.availability import RoutePolicy
 from by_framework.core.protocol.commands import (
     AskAgentCommand,
     CancelTaskCommand,
@@ -53,7 +54,7 @@ async def test_resolve_direct_worker_route():
 
     route = await client._resolve_direct_worker_route(
         "worker-42",
-        require_online_worker=True,
+        check_online=True,
     )
 
     assert asdict(route) == {
@@ -72,7 +73,7 @@ async def test_resolve_agent_type_route():
 
     route = await client._resolve_agent_type_route(
         "langgraph_agent",
-        require_online_worker=True,
+        route_policy=RoutePolicy.FAIL_FAST,
     )
 
     assert asdict(route) == {
@@ -181,8 +182,8 @@ async def test_client_cancel_task_returns_not_found():
 
 
 @pytest.mark.asyncio
-async def test_client_send_message_require_online_worker_no_worker():
-    """Test that send_message returns FAILED when require_online_worker=True
+async def test_client_send_message_fail_fast_no_worker():
+    """Test that send_message returns FAILED with FAIL_FAST
     and no worker exists."""
     mock_redis = AsyncMock()
     mock_registry = AsyncMock()
@@ -193,7 +194,6 @@ async def test_client_send_message_require_online_worker_no_worker():
         target_agent_type="nonexistent_agent",
         session_id="s1",
         content="hello",
-        require_online_worker=True,
     )
 
     assert result.success is False
@@ -206,8 +206,8 @@ async def test_client_send_message_require_online_worker_no_worker():
 
 
 @pytest.mark.asyncio
-async def test_client_send_message_require_online_worker_with_worker():
-    """Test that send_message sends normally when require_online_worker=True
+async def test_client_send_message_fail_fast_with_worker():
+    """Test that send_message sends normally with FAIL_FAST
     and worker exists."""
     mock_redis = AsyncMock()
     mock_registry = AsyncMock()
@@ -218,7 +218,6 @@ async def test_client_send_message_require_online_worker_with_worker():
         target_agent_type="test_agent",
         session_id="s1",
         content="hello",
-        require_online_worker=True,
     )
 
     assert result.success is True
@@ -233,7 +232,7 @@ async def test_client_send_message_require_online_worker_with_worker():
 @pytest.mark.asyncio
 async def test_client_send_message_no_probe():
     """Test that send_message sends to agent-type stream directly when
-    require_online_worker=False."""
+    route_policy=SEND_ANYWAY."""
     mock_redis = AsyncMock()
     mock_registry = AsyncMock()
 
@@ -242,7 +241,7 @@ async def test_client_send_message_no_probe():
         target_agent_type="any_agent",
         session_id="s1",
         content="hello",
-        require_online_worker=False,
+        route_policy=RoutePolicy.SEND_ANYWAY,
     )
 
     assert result.success is True
@@ -267,7 +266,6 @@ async def test_client_send_message_target_worker_id_skips_probe():
         session_id="s1",
         content="hello",
         target_worker_id="worker-42",
-        require_online_worker=True,
     )
 
     assert result.success is True
@@ -293,7 +291,6 @@ async def test_client_send_message_target_worker_id_dead():
         session_id="s1",
         content="hello",
         target_worker_id="dead_worker",
-        require_online_worker=True,
     )
 
     assert result.success is False

--- a/tests/core/test_availability.py
+++ b/tests/core/test_availability.py
@@ -1,0 +1,606 @@
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from by_framework import AgentContext, GatewayClient
+from by_framework.common.constants import RedisKeys
+from by_framework.core.availability import (
+    PendingDelivery,
+    RoutePolicy,
+    WakeupDecisionStatus,
+    WakeupRequest,
+)
+from by_framework.core.delivery_gate import DeliveryGate
+from by_framework.core.protocol.commands import command_from_dict
+from by_framework.core.wakeup_controller import WakeupController
+
+
+def test_control_plane_types_are_exported_from_top_level_package():
+    from by_framework import DeliveryGate as ExportedDeliveryGate  # pylint: disable=import-outside-toplevel
+    from by_framework import RoutePolicy as ExportedRoutePolicy  # pylint: disable=import-outside-toplevel
+    from by_framework import WakeupController as ExportedWakeupController  # pylint: disable=import-outside-toplevel
+
+    assert ExportedRoutePolicy.WAKE_AND_QUEUE == "WAKE_AND_QUEUE"
+    assert ExportedWakeupController is WakeupController
+    assert ExportedDeliveryGate is DeliveryGate
+
+
+def test_route_policy_includes_send_anyway():
+    assert RoutePolicy.SEND_ANYWAY == "SEND_ANYWAY"
+
+
+def test_control_plane_redis_keys_share_namespace():
+    prefix = "byai_gateway:control_plane:"
+
+    assert RedisKeys.control_plane_wakeup_stream().startswith(prefix)
+    assert RedisKeys.control_plane_wakeup_result_stream("wake-1").startswith(prefix)
+    assert RedisKeys.control_plane_delivery_pending_stream().startswith(prefix)
+    assert RedisKeys.control_plane_deadletter_stream().startswith(prefix)
+    assert RedisKeys.control_plane_agent_availability("agent-a").startswith(prefix)
+    assert RedisKeys.control_plane_agent_circuit("agent-a").startswith(prefix)
+    assert RedisKeys.control_plane_agent_fallback("agent-a").startswith(prefix)
+    assert RedisKeys.control_plane_user_quota("u-1").startswith(prefix)
+    assert RedisKeys.control_plane_wakeup_dedupe(
+        "agent-a", "u-1", "us-east"
+    ).startswith(prefix)
+
+
+@pytest.mark.asyncio
+async def test_client_wake_and_wait_dispatches_after_ready_decision():
+    redis = AsyncMock()
+    registry = AsyncMock()
+    registry.has_online_agent_type.side_effect = [
+        (False, []),
+        (True, ["worker-1"]),
+    ]
+    redis.xread.return_value = [
+        [
+            RedisKeys.control_plane_wakeup_result_stream("unused"),
+            [
+                (
+                    b"1-0",
+                    {
+                        b"data": json.dumps(
+                            {"status": WakeupDecisionStatus.READY}
+                        ).encode()
+                    },
+                )
+            ],
+        ]
+    ]
+
+    client = GatewayClient(redis_client=redis, registry=registry)
+    result = await client.send_message(
+        target_agent_type="cold-agent",
+        session_id="s1",
+        content="hello",
+        route_policy=RoutePolicy.WAKE_AND_WAIT,
+        availability_timeout_ms=100,
+        user_code="u-1",
+        region="us-east",
+        priority=7,
+    )
+
+    assert result.success is True
+    assert result.status == "QUEUED"
+    assert redis.xadd.await_count == 2
+    wakeup_stream = redis.xadd.await_args_list[0].args[0]
+    ctrl_stream = redis.xadd.await_args_list[1].args[0]
+    assert wakeup_stream == RedisKeys.control_plane_wakeup_stream()
+    assert ctrl_stream == RedisKeys.ctrl_stream("cold-agent")
+
+    wakeup_payload = json.loads(redis.xadd.await_args_list[0].args[1]["data"])
+    execution = registry.initialize_execution.await_args.args[0]
+    assert wakeup_payload["execution_id"] == execution["execution_id"]
+    assert wakeup_payload["execution_id"].startswith("exec-")
+    assert wakeup_payload["target_agent_type"] == "cold-agent"
+    assert wakeup_payload["user_code"] == "u-1"
+    assert wakeup_payload["region"] == "us-east"
+    assert wakeup_payload["priority"] == 7
+
+
+@pytest.mark.asyncio
+async def test_client_wake_and_wait_timeout_does_not_dispatch_control_message():
+    redis = AsyncMock()
+    registry = AsyncMock()
+    registry.has_online_agent_type.return_value = (False, [])
+    redis.xread.return_value = []
+
+    client = GatewayClient(redis_client=redis, registry=registry)
+    result = await client.send_message(
+        target_agent_type="cold-agent",
+        session_id="s1",
+        content="hello",
+        route_policy=RoutePolicy.WAKE_AND_WAIT,
+        availability_timeout_ms=1,
+    )
+
+    assert result.success is False
+    assert result.status == "FAILED"
+    assert result.error_code == "AGENT_TYPE_UNAVAILABLE"
+    assert redis.xadd.await_count == 1
+    assert redis.xadd.await_args.args[0] == RedisKeys.control_plane_wakeup_stream()
+
+
+@pytest.mark.asyncio
+async def test_client_wake_and_queue_writes_pending_without_control_dispatch():
+    redis = AsyncMock()
+    registry = AsyncMock()
+    registry.has_online_agent_type.return_value = (False, [])
+
+    client = GatewayClient(redis_client=redis, registry=registry)
+    result = await client.send_message(
+        target_agent_type="cold-agent",
+        session_id="s1",
+        content="hello",
+        route_policy=RoutePolicy.WAKE_AND_QUEUE,
+        user_code="u-1",
+    )
+
+    assert result.success is True
+    assert result.status == "QUEUED"
+    assert redis.xadd.await_count == 2
+    streams = [call.args[0] for call in redis.xadd.await_args_list]
+    assert streams == [
+        RedisKeys.control_plane_wakeup_stream(),
+        RedisKeys.control_plane_delivery_pending_stream(),
+    ]
+
+    pending = json.loads(redis.xadd.await_args_list[1].args[1]["data"])
+    initialized = redis.xadd.await_args_list
+    del initialized
+    execution = registry.initialize_execution.await_args.args[0]
+    assert pending["execution_id"] == execution["execution_id"]
+    assert pending["target_agent_type"] == "cold-agent"
+    assert pending["user_code"] == "u-1"
+    assert pending["delivery_stream"] == RedisKeys.ctrl_stream("cold-agent")
+    assert pending["command_payload"]["header"]["target_agent_type"] == "cold-agent"
+
+
+@pytest.mark.asyncio
+async def test_client_send_anyway_route_policy_skips_online_check():
+    redis = AsyncMock()
+    registry = AsyncMock()
+
+    client = GatewayClient(redis_client=redis, registry=registry)
+    result = await client.send_message(
+        target_agent_type="offline-agent",
+        session_id="s1",
+        content="hello",
+        route_policy=RoutePolicy.SEND_ANYWAY,
+    )
+
+    assert result.success is True
+    registry.has_online_agent_type.assert_not_called()
+    assert redis.xadd.await_args.args[0] == RedisKeys.ctrl_stream("offline-agent")
+
+
+@pytest.mark.asyncio
+async def test_client_rejects_before_wakeup_when_tenant_quota_is_exhausted():
+    redis = AsyncMock()
+    redis.get.return_value = json.dumps(
+        {"available": False, "reason": "tenant quota exceeded"}
+    ).encode()
+    registry = AsyncMock()
+
+    client = GatewayClient(redis_client=redis, registry=registry)
+    result = await client.send_message(
+        target_agent_type="cold-agent",
+        session_id="s1",
+        content="hello",
+        route_policy=RoutePolicy.WAKE_AND_QUEUE,
+        user_code="u-1",
+    )
+
+    assert result.success is False
+    assert result.error_code == "TENANT_QUOTA_EXCEEDED"
+    assert result.error == "tenant quota exceeded"
+    registry.has_online_agent_type.assert_not_called()
+    redis.xadd.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_client_rejects_before_wakeup_when_agent_circuit_is_open():
+    redis = AsyncMock()
+
+    async def get_state(key):
+        if key == RedisKeys.control_plane_agent_circuit("cold-agent"):
+            return json.dumps({"state": "OPEN", "reason": "startup failures"}).encode()
+        return None
+
+    redis.get.side_effect = get_state
+    registry = AsyncMock()
+
+    client = GatewayClient(redis_client=redis, registry=registry)
+    result = await client.send_message(
+        target_agent_type="cold-agent",
+        session_id="s1",
+        content="hello",
+        route_policy=RoutePolicy.WAKE_AND_WAIT,
+    )
+
+    assert result.success is False
+    assert result.error_code == "AGENT_CIRCUIT_OPEN"
+    assert result.error == "startup failures"
+    registry.has_online_agent_type.assert_not_called()
+    redis.xadd.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_client_fallback_routes_to_selected_agent_type():
+    redis = AsyncMock()
+    redis.get.side_effect = [
+        None,
+        json.dumps({"selected_agent_type": "fallback-agent"}).encode(),
+    ]
+    registry = AsyncMock()
+    registry.has_online_agent_type.side_effect = [
+        (False, []),
+        (True, ["worker-fallback"]),
+    ]
+
+    client = GatewayClient(redis_client=redis, registry=registry)
+    result = await client.send_message(
+        target_agent_type="cold-agent",
+        session_id="s1",
+        content="hello",
+        route_policy=RoutePolicy.FAIL_FAST,
+    )
+
+    assert result.success is True
+    assert redis.xadd.await_args.args[0] == RedisKeys.ctrl_stream("fallback-agent")
+    command = command_from_dict(json.loads(redis.xadd.await_args.args[1]["data"]))
+    assert command.header.target_agent_type == "fallback-agent"
+
+
+@pytest.mark.asyncio
+async def test_context_call_agent_uses_wake_and_wait_before_dispatching():
+    redis = MagicMock()
+    redis.xadd = AsyncMock()
+    redis.smembers = AsyncMock(side_effect=[{b"worker-1"}, {b"worker-1"}])
+
+    async def get_state(key):
+        if key == RedisKeys.worker_online_lease("worker-1"):
+            if get_state.calls == 0:
+                get_state.calls += 1
+                return None
+            return b"1"
+        return None
+
+    get_state.calls = 0
+    redis.get = AsyncMock(side_effect=get_state)
+    redis.xread = AsyncMock(
+        return_value=[
+            [
+                RedisKeys.control_plane_wakeup_result_stream("unused"),
+                [
+                    (
+                        b"1-0",
+                        {
+                            b"data": json.dumps(
+                                {"status": WakeupDecisionStatus.READY}
+                            ).encode()
+                        },
+                    )
+                ],
+            ]
+        ]
+    )
+    mock_pipe = MagicMock()
+    mock_pipe.execute = AsyncMock(return_value=[])
+    redis.pipeline.return_value = mock_pipe
+
+    ctx = AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=redis,
+        current_agent_id="agent-a",
+        message_id="msg-parent",
+    )
+    result = await ctx.call_agent(
+        target_agent_type="cold-agent",
+        content="hello",
+        route_policy=RoutePolicy.WAKE_AND_WAIT,
+        availability_timeout_ms=100,
+    )
+
+    assert result["status"] == "QUEUED"
+    assert redis.xadd.await_count == 2
+    assert (
+        redis.xadd.await_args_list[0].args[0] == RedisKeys.control_plane_wakeup_stream()
+    )
+    assert redis.xadd.await_args_list[1].args[0] == RedisKeys.ctrl_stream("cold-agent")
+
+
+@pytest.mark.asyncio
+async def test_context_call_agent_wake_and_queue_writes_pending():
+    redis = MagicMock()
+    redis.xadd = AsyncMock()
+    redis.pipeline.return_value = MagicMock(execute=AsyncMock(return_value=[]))
+    redis.smembers = AsyncMock(return_value={b"worker-1"})
+    redis.get = AsyncMock(return_value=None)
+
+    ctx = AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=redis,
+        current_agent_id="agent-a",
+        message_id="msg-parent",
+    )
+    result = await ctx.call_agent(
+        target_agent_type="cold-agent",
+        content="hello",
+        route_policy=RoutePolicy.WAKE_AND_QUEUE,
+    )
+
+    assert result["status"] == "QUEUED"
+    assert redis.xadd.await_count == 2
+    assert (
+        redis.xadd.await_args_list[0].args[0] == RedisKeys.control_plane_wakeup_stream()
+    )
+    assert (
+        redis.xadd.await_args_list[1].args[0]
+        == RedisKeys.control_plane_delivery_pending_stream()
+    )
+    pending = json.loads(redis.xadd.await_args_list[1].args[1]["data"])
+    initialized = redis.pipeline.return_value.hset.call_args_list[0].args[2]
+    execution = json.loads(initialized)
+    assert pending["execution_id"] == execution["execution_id"]
+
+
+@pytest.mark.asyncio
+async def test_wakeup_controller_reads_request_and_writes_ready_decision():
+    class ReadyProvider:
+
+        async def wakeup(self, request):
+            return {"status": WakeupDecisionStatus.READY, "worker_ids": ["worker-1"]}
+
+    request = WakeupRequest(
+        execution_id="wake-1",
+        target_agent_type="cold-agent",
+        session_id="s1",
+        trace_id="t1",
+        message_id="msg-1",
+        source="client",
+        policy=RoutePolicy.WAKE_AND_WAIT,
+        timeout_ms=100,
+    )
+    redis = AsyncMock()
+    redis.xread.return_value = [
+        [
+            RedisKeys.control_plane_wakeup_stream(),
+            [(b"1-0", request.to_redis_payload())],
+        ]
+    ]
+
+    controller = WakeupController(redis=redis, provider=ReadyProvider())
+    next_id = await controller.run_once(last_id="0-0", block_ms=1)
+
+    assert next_id == "1-0"
+    redis.xadd.assert_awaited_once()
+    result_stream, result_payload = redis.xadd.await_args.args
+    assert result_stream == RedisKeys.control_plane_wakeup_result_stream("wake-1")
+    decision = json.loads(result_payload["data"])
+    assert decision["execution_id"] == "wake-1"
+    assert decision["target_agent_type"] == "cold-agent"
+    assert decision["status"] == WakeupDecisionStatus.READY
+
+
+@pytest.mark.asyncio
+async def test_wakeup_controller_dedupes_concurrent_requests():
+    class CountingProvider:
+
+        def __init__(self):
+            self.calls = 0
+
+        async def wakeup(self, request):
+            self.calls += 1
+            return {"status": WakeupDecisionStatus.READY}
+
+    request = WakeupRequest(
+        execution_id="wake-1",
+        target_agent_type="cold-agent",
+        session_id="s1",
+        trace_id="t1",
+        message_id="msg-1",
+        source="client",
+        policy=RoutePolicy.WAKE_AND_WAIT,
+        timeout_ms=100,
+        user_code="u-1",
+        region="us-east",
+    )
+    redis = AsyncMock()
+    redis.set.return_value = False
+    redis.xread.return_value = [
+        [
+            RedisKeys.control_plane_wakeup_stream(),
+            [(b"1-0", request.to_redis_payload())],
+        ]
+    ]
+    provider = CountingProvider()
+
+    controller = WakeupController(redis=redis, provider=provider)
+    await controller.run_once(last_id="0-0", block_ms=1)
+
+    assert provider.calls == 0
+    redis.set.assert_awaited_once_with(
+        RedisKeys.control_plane_wakeup_dedupe("cold-agent", "u-1", "us-east"),
+        "wake-1",
+        ex=30,
+        nx=True,
+    )
+    decision = json.loads(redis.xadd.await_args.args[1]["data"])
+    assert decision["status"] == WakeupDecisionStatus.QUEUED
+
+
+@pytest.mark.asyncio
+async def test_wakeup_controller_retries_provider_before_ready():
+    class FlakyProvider:
+
+        def __init__(self):
+            self.calls = 0
+
+        async def wakeup(self, request):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("transient startup failure")
+            return {"status": WakeupDecisionStatus.READY}
+
+    request = WakeupRequest(
+        execution_id="wake-retry",
+        target_agent_type="cold-agent",
+        session_id="s1",
+        trace_id="t1",
+        message_id="msg-1",
+        source="client",
+        policy=RoutePolicy.WAKE_AND_WAIT,
+        timeout_ms=100,
+    )
+    redis = AsyncMock()
+    redis.set.return_value = True
+    redis.xread.return_value = [
+        [
+            RedisKeys.control_plane_wakeup_stream(),
+            [(b"1-0", request.to_redis_payload())],
+        ]
+    ]
+    provider = FlakyProvider()
+
+    controller = WakeupController(redis=redis, provider=provider, max_attempts=2)
+    await controller.run_once(last_id="0-0", block_ms=1)
+
+    assert provider.calls == 2
+    decision = json.loads(redis.xadd.await_args.args[1]["data"])
+    assert decision["status"] == WakeupDecisionStatus.READY
+
+
+@pytest.mark.asyncio
+async def test_wakeup_controller_writes_deadletter_after_final_failure():
+    class FailingProvider:
+
+        async def wakeup(self, request):
+            raise RuntimeError("container failed")
+
+    request = WakeupRequest(
+        execution_id="wake-dead",
+        target_agent_type="cold-agent",
+        session_id="s1",
+        trace_id="t1",
+        message_id="msg-1",
+        source="client",
+        policy=RoutePolicy.WAKE_AND_WAIT,
+        timeout_ms=100,
+    )
+    redis = AsyncMock()
+    redis.set.return_value = True
+    redis.xread.return_value = [
+        [
+            RedisKeys.control_plane_wakeup_stream(),
+            [(b"1-0", request.to_redis_payload())],
+        ]
+    ]
+
+    controller = WakeupController(redis=redis, provider=FailingProvider())
+    await controller.run_once(last_id="0-0", block_ms=1)
+
+    streams = [call.args[0] for call in redis.xadd.await_args_list]
+    assert RedisKeys.control_plane_wakeup_result_stream("wake-dead") in streams
+    assert RedisKeys.control_plane_deadletter_stream() in streams
+
+
+@pytest.mark.asyncio
+async def test_delivery_gate_dispatches_matching_pending_delivery():
+    pending = PendingDelivery(
+        execution_id="wake-1",
+        message_id="msg-1",
+        session_id="s1",
+        trace_id="t1",
+        target_agent_type="cold-agent",
+        delivery_stream=RedisKeys.ctrl_stream("cold-agent"),
+        command_payload={
+            "action_type": "ASK_AGENT",
+            "header": {
+                "message_id": "msg-1",
+                "session_id": "s1",
+                "trace_id": "t1",
+                "target_agent_type": "cold-agent",
+            },
+            "body": {"content": "hello", "wait_for_reply": False},
+        },
+    )
+    redis = AsyncMock()
+    redis.xread.return_value = [
+        [
+            RedisKeys.control_plane_delivery_pending_stream(),
+            [(b"1-0", pending.to_redis_payload())],
+        ]
+    ]
+
+    gate = DeliveryGate(redis=redis)
+    dispatched = await gate.dispatch_ready(execution_id="wake-1")
+
+    assert dispatched == 1
+    redis.xadd.assert_awaited_once()
+    stream, payload = redis.xadd.await_args.args
+    assert stream == RedisKeys.ctrl_stream("cold-agent")
+    assert json.loads(payload["data"])["header"]["message_id"] == "msg-1"
+
+
+@pytest.mark.asyncio
+async def test_delivery_gate_dispatches_higher_priority_first():
+    low = PendingDelivery(
+        execution_id="wake-1",
+        message_id="msg-low",
+        session_id="s1",
+        trace_id="t1",
+        target_agent_type="cold-agent",
+        delivery_stream=RedisKeys.ctrl_stream("cold-agent"),
+        priority=1,
+        command_payload={
+            "action_type": "ASK_AGENT",
+            "header": {
+                "message_id": "msg-low",
+                "session_id": "s1",
+                "trace_id": "t1",
+                "target_agent_type": "cold-agent",
+            },
+            "body": {"content": "low", "wait_for_reply": False},
+        },
+    )
+    high = PendingDelivery(
+        execution_id="wake-1",
+        message_id="msg-high",
+        session_id="s1",
+        trace_id="t1",
+        target_agent_type="cold-agent",
+        delivery_stream=RedisKeys.ctrl_stream("cold-agent"),
+        priority=10,
+        command_payload={
+            "action_type": "ASK_AGENT",
+            "header": {
+                "message_id": "msg-high",
+                "session_id": "s1",
+                "trace_id": "t1",
+                "target_agent_type": "cold-agent",
+            },
+            "body": {"content": "high", "wait_for_reply": False},
+        },
+    )
+    redis = AsyncMock()
+    redis.xread.return_value = [
+        [
+            RedisKeys.control_plane_delivery_pending_stream(),
+            [
+                (b"1-0", low.to_redis_payload()),
+                (b"2-0", high.to_redis_payload()),
+            ],
+        ]
+    ]
+
+    gate = DeliveryGate(redis=redis)
+    dispatched = await gate.dispatch_ready(execution_id="wake-1")
+
+    assert dispatched == 2
+    first_payload = json.loads(redis.xadd.await_args_list[0].args[1]["data"])
+    assert first_payload["header"]["message_id"] == "msg-high"


### PR DESCRIPTION
## Summary

This PR adds an Agent Availability Control Plane to by-framework.

The core change is that `GatewayClient.send_message()` and `AgentContext.call_agent()` now share a unified `AvailabilityRouter`. When a target `agent_type` has no online worker, callers can choose a `route_policy` instead of always failing immediately.

Supported policies include:

- `FAIL_FAST`: preserve the default behavior and fail when no online worker is available.
- `SEND_ANYWAY`: skip online checks and write directly to `queue:ctrl:{agent_type}`.
- `WAKE_AND_WAIT`: emit a wakeup request, wait for a manager decision, then deliver if ready.
- `WAKE_AND_QUEUE`: emit a wakeup request and store the command in pending delivery.
- `QUEUE_ONLY`: store the command in pending delivery without triggering wakeup.

The control-plane Redis keys are namespaced under `byai_gateway:control_plane:*`.

## Key Changes

- Added `by_framework.core.availability`
  - `AvailabilityRouter`
  - `RoutePolicy`
  - `DeliveryIntent`
  - `WakeupRequest`
  - `PendingDelivery`
  - `WakeupDecision`
  - `AvailabilityResult`

- Added manager-side reference components
  - `WakeupController`
  - `WakeupProvider`
  - `DeliveryGate`

- Updated routing APIs
  - `GatewayClient.send_message(..., route_policy=..., availability_timeout_ms=..., region=..., priority=...)`
  - `AgentContext.call_agent(..., route_policy=..., availability_timeout_ms=..., region=..., priority=...)`
  - `ByaiGatewayClient` and `ByaiAgentContext` forward the same parameters.

- Unified `request_id` and `execution_id`
  - Wakeup requests, wakeup results, pending delivery, and execution tracking now use `execution_id` as the single correlation ID.

- Replaced the older online-check flags with a single `route_policy`
  - Removed `require_online_worker`
  - Removed `offline_route_policy`
  - Kept routing behavior explicit through `RoutePolicy`

- Added Redis key helpers under `RedisKeys`
  - `byai_gateway:control_plane:mgmt:wakeup`
  - `byai_gateway:control_plane:mgmt:wakeup:result:{execution_id}`
  - `byai_gateway:control_plane:mgmt:delivery:pending`
  - `byai_gateway:control_plane:mgmt:deadletter`
  - `byai_gateway:control_plane:availability:agent_type:{agent_type}`
  - `byai_gateway:control_plane:circuit:agent_type:{agent_type}`
  - `byai_gateway:control_plane:fallback:agent_type:{agent_type}`
  - `byai_gateway:control_plane:quota:tenant:{user_code}`
  - `byai_gateway:control_plane:wakeup:dedupe:{agent_type}:{user_code}:{region}`

## Architecture

The framework now separates delivery intent from wakeup ownership:

- Framework side:
  - checks online worker availability
  - applies circuit/quota/fallback policy
  - emits wakeup requests
  - waits or queues based on `route_policy`
  - performs final control-stream delivery

- Manager/client-owner side:
  - listens to Redis wakeup management events
  - deduplicates concurrent wakeup requests
  - starts containers or signals external systems through `WakeupProvider`
  - writes `WakeupDecision`
  - releases pending delivery through `DeliveryGate`

Agent developers do not need to implement wakeup hooks. As long as they use framework APIs, `call_agent()` automatically goes through the same availability control plane as `send_message()`.

## Tests

Added and updated tests covering:

- default `FAIL_FAST` behavior
- `SEND_ANYWAY`
- `WAKE_AND_WAIT`
- `WAKE_AND_QUEUE`
- `QUEUE_ONLY`
- manager `READY / FAILED / REJECTED` decisions
- timeout behavior
- pending delivery dispatch
- wakeup dedupe
- quota rejection
- circuit breaker rejection
- fallback routing
- `send_message()` and `call_agent()` sharing the same availability logic
- Redis key prefix coverage
- `execution_id` correlation across wakeup and delivery flow

## Verification

```bash
make lint
make test
