### PR TITLE
fix: refactor discovery HTTP client upload logic to correctly handle file streams and implement retry seek support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
               echo "package_name=by-framework-adk" >> "$GITHUB_OUTPUT"
               echo "package_dir=libs/by-framework-adk" >> "$GITHUB_OUTPUT"
               echo "version=${REF_NAME#by-framework-adk-v}" >> "$GITHUB_OUTPUT"
-              ;;              
+              ;;
             *)
               echo "Unsupported tag: $REF_NAME" >&2
               exit 1

--- a/src/by_framework/util/discovery_http_client.py
+++ b/src/by_framework/util/discovery_http_client.py
@@ -379,14 +379,17 @@ class DiscoveryHttpClient:
         Returns:
             HttpResponse from the server
         """
+        p = Path(file_path)
         parts: list[tuple[str, Any]] = []
         if form_fields:
             for key, value in form_fields.items():
                 parts.append((key, value))
-        parts.append((file_field, str(file_path)))
-        return await self._upload_with_discovery(
-            service_name, path, parts, headers=headers
-        )
+
+        with open(p, "rb") as f:
+            parts.append((file_field, (p.name, f)))
+            return await self._upload_with_discovery(
+                service_name, path, parts, headers=headers
+            )
 
     async def upload_multiple(
         self,
@@ -412,15 +415,21 @@ class DiscoveryHttpClient:
         Returns:
             HttpResponse from the server
         """
+        from contextlib import ExitStack
+
         parts: list[tuple[str, Any]] = []
         if form_fields:
             for key, value in form_fields.items():
                 parts.append((key, value))
-        for fp in file_paths:
-            parts.append((file_field, str(fp)))
-        return await self._upload_with_discovery(
-            service_name, path, parts, headers=headers
-        )
+
+        with ExitStack() as stack:
+            for fp in file_paths:
+                p = Path(fp)
+                f = stack.enter_context(open(p, "rb"))
+                parts.append((file_field, (p.name, f)))
+            return await self._upload_with_discovery(
+                service_name, path, parts, headers=headers
+            )
 
     async def upload_with_stream(
         self,
@@ -537,6 +546,22 @@ class DiscoveryHttpClient:
             logger.warning(
                 "Node-switching retry in %.1fs for service %s", delay, service_name
             )
+
+            # Reset seek position for any file-like objects in parts before retrying
+            for _, val in parts:
+                if isinstance(val, tuple):
+                    for item in val:
+                        if hasattr(item, "seek") and callable(item.seek):
+                            try:
+                                item.seek(0)
+                            except Exception:
+                                pass
+                elif hasattr(val, "seek") and callable(val.seek):
+                    try:
+                        val.seek(0)
+                    except Exception:
+                        pass
+
             await asyncio.sleep(delay)
             return await self._upload_with_discovery(
                 service_name,

--- a/src/by_framework/util/http_client.py
+++ b/src/by_framework/util/http_client.py
@@ -543,12 +543,15 @@ class ByHttpClient:
         Returns:
             HttpResponse from the server
         """
+        path = Path(file_path)
         parts: list[tuple[str, Any]] = []
         if form_fields:
             for key, value in form_fields.items():
                 parts.append((key, value))
-        parts.append((file_field, str(file_path)))
-        return await self._upload(url, parts, headers=headers)
+
+        with open(path, "rb") as f:
+            parts.append((file_field, (path.name, f)))
+            return await self._upload(url, parts, headers=headers)
 
     async def upload_multiple(
         self,
@@ -572,13 +575,19 @@ class ByHttpClient:
         Returns:
             HttpResponse from the server
         """
+        from contextlib import ExitStack
+
         parts: list[tuple[str, Any]] = []
         if form_fields:
             for key, value in form_fields.items():
                 parts.append((key, value))
-        for path in file_paths:
-            parts.append((file_field, str(path)))
-        return await self._upload(url, parts, headers=headers)
+
+        with ExitStack() as stack:
+            for fp in file_paths:
+                path = Path(fp)
+                f = stack.enter_context(open(path, "rb"))
+                parts.append((file_field, (path.name, f)))
+            return await self._upload(url, parts, headers=headers)
 
     async def upload_with_stream(
         self,
@@ -643,12 +652,24 @@ class ByHttpClient:
 
         logger.debug("[POST] %s (multipart upload, %d parts)", url, len(parts))
 
+        # Convert non-file parts (e.g. standard form fields) to (None, value)
+        # to ensure httpx renders them without filename attribute,
+        # and avoid AsyncClient sync/async conflicts.
+        formatted_parts: list[tuple[str, Any]] = []
+        for key, val in parts:
+            if isinstance(val, tuple):
+                formatted_parts.append((key, val))
+            elif hasattr(val, "read") and callable(val.read):
+                formatted_parts.append((key, val))
+            else:
+                formatted_parts.append((key, (None, str(val))))
+
         try:
             response = await self._client.request(
                 method="POST",
                 url=url,
                 headers=request_headers,
-                files=parts,
+                files=formatted_parts,
             )
 
             logger.debug(

--- a/tests/util/test_discovery_http_client_upload.py
+++ b/tests/util/test_discovery_http_client_upload.py
@@ -1,0 +1,181 @@
+import io
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from by_framework.core.discovery import DiscoveryClient, ServiceInstance
+from by_framework.util.discovery_http_client import DiscoveryHttpClient
+from by_framework.util.http_client import (ByHttpClient, HttpResponse, RetryConfig)
+
+
+@pytest.fixture
+def mock_discovery_client():
+    client = MagicMock(spec=DiscoveryClient)
+    client.discover = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def mock_http_client():
+    client = MagicMock(spec=ByHttpClient)
+    client._upload = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def fake_instance():
+    return ServiceInstance(id="inst1", host="192.168.1.100", port=8080)
+
+
+@pytest.mark.asyncio
+async def test_discovery_upload_single_file(
+    mock_discovery_client, mock_http_client, fake_instance, tmp_path
+):
+    mock_discovery_client.discover.return_value = fake_instance
+    success_response = HttpResponse(
+        status_code=200, headers={}, data={"status": "ok"}, is_success=True
+    )
+    mock_http_client._upload.return_value = success_response
+
+    client = DiscoveryHttpClient(
+        discovery_client=mock_discovery_client,
+        http_client=mock_http_client,
+    )
+
+    file_path = tmp_path / "test.txt"
+    file_path.write_bytes(b"hello")
+
+    response = await client.upload(
+        service_name="my-service",
+        path="/upload",
+        file_path=file_path,
+        form_fields={"field1": "value1"},
+    )
+
+    assert response.is_success is True
+    mock_http_client._upload.assert_called_once()
+    called_args, _ = mock_http_client._upload.call_args
+    assert called_args[0] == "http://192.168.1.100:8080/upload"
+    parts = called_args[1]
+
+    assert ("field1", "value1") in parts
+    file_part = [p for p in parts if p[0] == "file"][0]
+    assert file_part[1][0] == "test.txt"
+    assert not isinstance(file_part[1][1], str)
+    assert hasattr(file_part[1][1], "read")
+
+
+@pytest.mark.asyncio
+async def test_discovery_upload_multiple_files(
+    mock_discovery_client, mock_http_client, fake_instance, tmp_path
+):
+    mock_discovery_client.discover.return_value = fake_instance
+    success_response = HttpResponse(
+        status_code=200, headers={}, data={"status": "ok"}, is_success=True
+    )
+    mock_http_client._upload.return_value = success_response
+
+    client = DiscoveryHttpClient(
+        discovery_client=mock_discovery_client,
+        http_client=mock_http_client,
+    )
+
+    f1 = tmp_path / "f1.txt"
+    f2 = tmp_path / "f2.txt"
+    f1.write_bytes(b"1")
+    f2.write_bytes(b"2")
+
+    response = await client.upload_multiple(
+        service_name="my-service",
+        path="/upload",
+        file_paths=[f1, f2],
+    )
+
+    assert response.is_success is True
+    mock_http_client._upload.assert_called_once()
+    called_args, _ = mock_http_client._upload.call_args
+    parts = called_args[1]
+
+    file_parts = [p for p in parts if p[0] == "file"]
+    assert len(file_parts) == 2
+    assert file_parts[0][1][0] == "f1.txt"
+    assert file_parts[1][1][0] == "f2.txt"
+
+
+@pytest.mark.asyncio
+async def test_discovery_upload_with_stream(
+    mock_discovery_client, mock_http_client, fake_instance
+):
+    mock_discovery_client.discover.return_value = fake_instance
+    success_response = HttpResponse(
+        status_code=200, headers={}, data={"status": "ok"}, is_success=True
+    )
+    mock_http_client._upload.return_value = success_response
+
+    client = DiscoveryHttpClient(
+        discovery_client=mock_discovery_client,
+        http_client=mock_http_client,
+    )
+
+    response = await client.upload_with_stream(
+        service_name="my-service",
+        path="/upload",
+        file_name="stream.bin",
+        content=b"stream content",
+    )
+
+    assert response.is_success is True
+    mock_http_client._upload.assert_called_once()
+    called_args, _ = mock_http_client._upload.call_args
+    parts = called_args[1]
+    file_part = [p for p in parts if p[0] == "file"][0]
+    assert file_part[1][0] == "stream.bin"
+    assert file_part[1][2] == "application/octet-stream"
+    assert isinstance(file_part[1][1], io.BytesIO)
+
+
+@pytest.mark.asyncio
+async def test_discovery_upload_retry_resets_stream_seeks(
+    mock_discovery_client, mock_http_client, fake_instance
+):
+    mock_discovery_client.discover.return_value = fake_instance
+
+    fail_response = HttpResponse(
+        status_code=502, headers={}, data="Error", is_success=False
+    )
+    success_response = HttpResponse(
+        status_code=200, headers={}, data="Success", is_success=True
+    )
+
+    async def mock_upload_handler(url, parts, headers=None):
+        file_part = [p for p in parts if p[0] == "file"][0]
+        file_stream = file_part[1][1]
+
+        data = file_stream.read()
+        assert data == b"test bytes"
+
+        if mock_upload_handler.call_count == 0:
+            mock_upload_handler.call_count += 1
+            return fail_response
+        return success_response
+
+    mock_upload_handler.call_count = 0
+    mock_http_client._upload.side_effect = mock_upload_handler
+
+    client = DiscoveryHttpClient(
+        discovery_client=mock_discovery_client,
+        http_client=mock_http_client,
+        retry_config=RetryConfig(
+            max_attempts=2, retry_on_status_codes=frozenset({502})
+        ),
+    )
+
+    response = await client.upload_with_stream(
+        service_name="my-service",
+        path="/upload",
+        file_name="stream.bin",
+        content=b"test bytes",
+    )
+
+    assert response.is_success is True
+    assert mock_http_client._upload.call_count == 2

--- a/tests/util/test_http_client.py
+++ b/tests/util/test_http_client.py
@@ -39,3 +39,134 @@ async def test_download_streams_response_to_file(tmp_path: Path):
     assert response.status_code == 200
     assert response.data == str(target_path)
     assert target_path.read_bytes() == payload
+
+
+@pytest.mark.asyncio
+async def test_upload_single_file(tmp_path: Path):
+    file_content = b"my unique file content"
+    file_path = tmp_path / "test_upload.txt"
+    file_path.write_bytes(file_content)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.path == "/upload"
+        req_body = await request.aread()
+
+        # 验证是否上传了真正的文件内容
+        assert file_content in req_body
+        assert b'filename="test_upload.txt"' in req_body
+        assert b'name="file"' in req_body
+        assert b'name="field1"' in req_body
+        assert b"value1" in req_body
+
+        return httpx.Response(
+            status_code=200,
+            json={"status": "uploaded"},
+            request=request,
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    async with ByHttpClient(
+        base_url="https://example.com",
+        http_client=httpx.AsyncClient(
+            transport=transport,
+            base_url="https://example.com",
+        ),
+        retry_config=RetryConfig.no_retry(),
+    ) as client:
+        response = await client.upload(
+            "/upload",
+            file_path,
+            file_field="file",
+            form_fields={"field1": "value1"},
+        )
+
+    assert response.is_success is True
+    assert response.data == {"status": "uploaded"}
+
+
+@pytest.mark.asyncio
+async def test_upload_multiple_files(tmp_path: Path):
+    file1_content = b"content of file 1"
+    file2_content = b"content of file 2"
+    file1_path = tmp_path / "file1.txt"
+    file2_path = tmp_path / "file2.txt"
+    file1_path.write_bytes(file1_content)
+    file2_path.write_bytes(file2_content)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        req_body = await request.aread()
+
+        # 验证两个文件的内容和文件名都被正确发送
+        assert file1_content in req_body
+        assert file2_content in req_body
+        assert b'filename="file1.txt"' in req_body
+        assert b'filename="file2.txt"' in req_body
+        assert b'name="file"' in req_body
+
+        return httpx.Response(
+            status_code=200,
+            json={"status": "uploaded_multiple"},
+            request=request,
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    async with ByHttpClient(
+        base_url="https://example.com",
+        http_client=httpx.AsyncClient(
+            transport=transport,
+            base_url="https://example.com",
+        ),
+        retry_config=RetryConfig.no_retry(),
+    ) as client:
+        response = await client.upload_multiple(
+            "/upload",
+            [file1_path, file2_path],
+            file_field="file",
+        )
+
+    assert response.is_success is True
+    assert response.data == {"status": "uploaded_multiple"}
+
+
+@pytest.mark.asyncio
+async def test_upload_with_stream():
+    stream_content = b"stream upload data"
+    file_name = "stream_file.bin"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        req_body = await request.aread()
+
+        assert stream_content in req_body
+        assert f'filename="{file_name}"'.encode() in req_body
+        assert b'name="file"' in req_body
+
+        return httpx.Response(
+            status_code=200,
+            json={"status": "uploaded_stream"},
+            request=request,
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    async with ByHttpClient(
+        base_url="https://example.com",
+        http_client=httpx.AsyncClient(
+            transport=transport,
+            base_url="https://example.com",
+        ),
+        retry_config=RetryConfig.no_retry(),
+    ) as client:
+        response = await client.upload_with_stream(
+            "/upload",
+            file_name,
+            stream_content,
+            content_type="application/octet-stream",
+        )
+
+    assert response.is_success is True
+    assert response.data == {"status": "uploaded_stream"}

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "by-framework"
-version = "0.2.1"
+version = "0.2.2.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "dill" },
@@ -350,7 +350,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "by-framework-adk"
-version = "0.0.2"
+version = "0.0.3.dev0"
 source = { editable = "libs/by-framework-adk" }
 dependencies = [
     { name = "by-framework" },
@@ -384,7 +384,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "by-framework-history-byclaw"
-version = "0.0.2"
+version = "0.0.3.dev0"
 source = { editable = "libs/by-framework-history-byclaw" }
 dependencies = [
     { name = "by-framework" },
@@ -414,7 +414,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "by-framework-history-postgres"
-version = "0.0.2"
+version = "0.0.3.dev0"
 source = { editable = "libs/by-framework-history-postgres" }
 dependencies = [
     { name = "asyncpg" },
@@ -446,7 +446,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "by-framework-langgraph"
-version = "0.0.2"
+version = "0.0.3.dev0"
 source = { editable = "libs/by-framework-langgraph" }
 dependencies = [
     { name = "by-framework" },
@@ -492,7 +492,7 @@ provides-extras = ["dev", "langfuse", "phoenix"]
 
 [[package]]
 name = "by-framework-trace-langfuse"
-version = "0.0.2"
+version = "0.0.3.dev0"
 source = { editable = "libs/by-framework-trace-langfuse" }
 dependencies = [
     { name = "by-framework" },
@@ -526,7 +526,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "by-framework-trace-phoenix"
-version = "0.0.2"
+version = "0.0.3.dev0"
 source = { editable = "libs/by-framework-trace-phoenix" }
 dependencies = [
     { name = "arize-phoenix-otel" },


### PR DESCRIPTION
**Main Changes**

## Fix File Upload Issues and Retry Stream Cursor Reset in HTTP Clients

### Background & Issues
1. **Upload Failures**: `DiscoveryHttpClient.upload` incorrectly passed the path string instead of opening the file content.
2. **0-Byte Uploads on Retry**: During service discovery node-switching retries, the file/stream object was consumed in the first attempt. Without resetting the cursor (`seek(0)`), subsequent retries uploaded 0 bytes.
3. **httpx Sync/Async Conflict & API Validation Errors**: 
   - Combining `data` (form fields) and `files` (streams) in `httpx.AsyncClient` raised a sync/async stream `RuntimeError`.
   - Passing plain strings directly into `files` appended `filename="upload"` to headers, causing FastAPI backend form validations to fail.

### Key Changes
1. **Safe File Handling**: Used `with open` (binary mode) to upload file contents, and `contextlib.ExitStack` in `upload_multiple` to safely manage multiple file descriptors.
2. **Cursor Reset on Retry**: Added automatic `item.seek(0)` for seekable streams in `DiscoveryHttpClient._upload_with_discovery` before retrying a request on a new node.
3. **Parameter Formatting**: Formatted non-file form fields into `(None, str(val))` inside `ByHttpClient._upload`. This avoids `httpx.AsyncClient` sync/async conflict and prevents backend servers from misinterpreting plain fields as `UploadFile`.
4. **Testing**: Added comprehensive test cases in [test_http_client.py](file:///Users/xiaozhongcheng/data/company/beyonai/by-framework-python/.worktree/fix-discovery-http-client-upload-logic/tests/util/test_http_client.py) and [test_discovery_http_client_upload.py](file:///Users/xiaozhongcheng/data/company/beyonai/by-framework-python/.worktree/fix-discovery-http-client-upload-logic/tests/util/test_discovery_http_client_upload.py). All 367 tests passed.
