### PR TITLE
Redis cluster support Phase 1: connection config + client factory + key-schema-version fail-fast

### DIFF
--- a/src/by_framework/common/config.py
+++ b/src/by_framework/common/config.py
@@ -6,7 +6,7 @@ Provides typed configuration loaded from environment variables.
 
 import os
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Literal, Optional
 
 from by_framework.common.constants import RedisKeys
 
@@ -22,6 +22,10 @@ class RedisConfig:
     username: Optional[str] = None
     decode_responses: bool = True
     max_connections: Optional[int] = None
+    mode: Literal["standalone", "cluster"] = "standalone"
+    cluster_nodes: Optional[list[tuple[str, int]]] = None
+    socket_connect_timeout: int = 5
+    socket_timeout: int = 10
 
     @classmethod
     def from_env(cls) -> "RedisConfig":
@@ -29,6 +33,14 @@ class RedisConfig:
         password = os.environ.get("REDIS_PASSWORD", "")
         username = os.environ.get("REDIS_USERNAME") or None
         max_connections = os.environ.get("REDIS_MAX_CONNECTIONS")
+        mode = os.environ.get("REDIS_MODE", "standalone")
+        cluster_nodes_str = os.environ.get("REDIS_CLUSTER_NODES")
+        cluster_nodes = None
+        if cluster_nodes_str:
+            cluster_nodes = []
+            for node in cluster_nodes_str.split(","):
+                node_host, node_port = node.rsplit(":", 1)
+                cluster_nodes.append((node_host, int(node_port)))
         return cls(
             host=os.environ.get("REDIS_HOST", "localhost"),
             port=int(os.environ.get("REDIS_PORT", "6379")),
@@ -36,6 +48,8 @@ class RedisConfig:
             password=password,
             username=username,
             max_connections=int(max_connections) if max_connections else None,
+            mode=mode,
+            cluster_nodes=cluster_nodes,
         )
 
 

--- a/src/by_framework/common/constants.py
+++ b/src/by_framework/common/constants.py
@@ -5,6 +5,22 @@ All Redis Stream names, Hash Keys, Set Keys and other configuration items
 are centrally managed in this file. Do not hardcode literal strings in business code.
 """
 
+import os
+
+
+def get_key_schema_version() -> str:
+    """Return the configured Redis key schema version ("v1" or "v2").
+
+    Controlled by REDIS_KEY_SCHEMA_VERSION, defaulting to "v1" (the current
+    unprefixed key format). Cluster mode requires "v2" (see redis_client.init_redis).
+    """
+    version = os.environ.get("REDIS_KEY_SCHEMA_VERSION", "v1")
+    if version not in ("v1", "v2"):
+        raise ValueError(
+            f"Invalid REDIS_KEY_SCHEMA_VERSION: {version!r} (must be 'v1' or 'v2')"
+        )
+    return version
+
 
 class RedisKeys:
     """Gateway SDK global Redis Key naming conventions and constants."""

--- a/src/by_framework/common/redis_client.py
+++ b/src/by_framework/common/redis_client.py
@@ -6,7 +6,10 @@ Provides singleton Redis client initialization and management.
 from typing import Optional
 
 from redis.asyncio import Redis
+from redis.asyncio.cluster import ClusterNode, RedisCluster
 
+from .config import RedisConfig
+from .constants import get_key_schema_version
 from .exceptions import RedisConnectionError, StreamGroupExistsError
 
 _redis_client: Optional[Redis] = None
@@ -22,6 +25,7 @@ def _handle_redis_error(e: Exception, operation: str = "Redis operation") -> Exc
 
 
 def init_redis(
+    config: Optional[RedisConfig] = None,
     host: str = "localhost",
     port: int = 6379,
     db: int = 0,
@@ -35,22 +39,54 @@ def init_redis(
 
     If already initialized and you don't want to recreate, it will be
     reused directly (can re-init after close_redis()).
+
+    A RedisConfig can be passed via `config` instead of individual kwargs;
+    when provided, its fields take precedence over the individual params.
     """
     global _redis_client
     if _redis_client is None:
+        if config is not None:
+            host = config.host
+            port = config.port
+            db = config.db
+            password = config.password or None
+            username = config.username
+            decode_responses = config.decode_responses
+            max_connections = config.max_connections
+
+            if config.mode == "cluster" and get_key_schema_version() != "v2":
+                raise RedisConnectionError(
+                    "REDIS_MODE=cluster requires REDIS_KEY_SCHEMA_VERSION=v2 "
+                    "(v1 key format has no hash tags and will hit CROSSSLOT "
+                    "errors under Cluster). Set REDIS_KEY_SCHEMA_VERSION=v2 "
+                    "and complete the key migration first."
+                )
+
         if max_connections is not None:
             kwargs["max_connections"] = max_connections
 
         try:
-            _redis_client = Redis(
-                host=host,
-                port=port,
-                db=db,
-                password=password,
-                username=username,
-                decode_responses=decode_responses,
-                **kwargs,
-            )
+            if config is not None and config.mode == "cluster":
+                _redis_client = RedisCluster(
+                    startup_nodes=[
+                        ClusterNode(node_host, node_port)
+                        for node_host, node_port in (config.cluster_nodes or [])
+                    ],
+                    password=password,
+                    username=username,
+                    decode_responses=decode_responses,
+                    **kwargs,
+                )
+            else:
+                _redis_client = Redis(
+                    host=host,
+                    port=port,
+                    db=db,
+                    password=password,
+                    username=username,
+                    decode_responses=decode_responses,
+                    **kwargs,
+                )
         except Exception as e:
             raise RedisConnectionError(f"Failed to initialize Redis client: {e}") from e
     return _redis_client

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -29,6 +29,14 @@ class TestRedisConfig(unittest.TestCase):
         self.assertTrue(config.decode_responses)
         self.assertIsNone(config.max_connections)
 
+    def test_cluster_fields_defaults(self):
+        """Test that cluster-mode fields default to standalone-safe values."""
+        config = RedisConfig()
+        self.assertEqual(config.mode, "standalone")
+        self.assertIsNone(config.cluster_nodes)
+        self.assertEqual(config.socket_connect_timeout, 5)
+        self.assertEqual(config.socket_timeout, 10)
+
     def test_frozen_immutability(self):
         """Test that frozen dataclass is immutable."""
         config = RedisConfig()
@@ -59,6 +67,39 @@ class TestRedisConfig(unittest.TestCase):
             for k, v in old_values.items():
                 if v is not None:
                     os.environ[k] = v
+
+    def test_from_env_parses_mode(self):
+        """Test that from_env reads REDIS_MODE, defaulting to standalone."""
+        old_value = os.environ.get("REDIS_MODE")
+        try:
+            os.environ.pop("REDIS_MODE", None)
+            self.assertEqual(RedisConfig.from_env().mode, "standalone")
+
+            os.environ["REDIS_MODE"] = "cluster"
+            self.assertEqual(RedisConfig.from_env().mode, "cluster")
+        finally:
+            if old_value is not None:
+                os.environ["REDIS_MODE"] = old_value
+            else:
+                os.environ.pop("REDIS_MODE", None)
+
+    def test_from_env_parses_cluster_nodes(self):
+        """Test that from_env parses REDIS_CLUSTER_NODES into (host, port) tuples."""
+        old_value = os.environ.get("REDIS_CLUSTER_NODES")
+        try:
+            os.environ.pop("REDIS_CLUSTER_NODES", None)
+            self.assertIsNone(RedisConfig.from_env().cluster_nodes)
+
+            os.environ["REDIS_CLUSTER_NODES"] = "h1:6379,h2:6380"
+            self.assertEqual(
+                RedisConfig.from_env().cluster_nodes,
+                [("h1", 6379), ("h2", 6380)],
+            )
+        finally:
+            if old_value is not None:
+                os.environ["REDIS_CLUSTER_NODES"] = old_value
+            else:
+                os.environ.pop("REDIS_CLUSTER_NODES", None)
 
     def test_from_env_with_custom_values(self):
         """Test from_env with custom environment variables."""

--- a/tests/common/test_constants.py
+++ b/tests/common/test_constants.py
@@ -1,0 +1,41 @@
+"""
+Tests for by_framework.common.constants module.
+"""
+
+import os
+import unittest
+
+from by_framework.common.constants import get_key_schema_version
+
+
+class TestGetKeySchemaVersion(unittest.TestCase):
+    """Tests for get_key_schema_version."""
+
+    def setUp(self):
+        self._old_value = os.environ.get("REDIS_KEY_SCHEMA_VERSION")
+
+    def tearDown(self):
+        if self._old_value is not None:
+            os.environ["REDIS_KEY_SCHEMA_VERSION"] = self._old_value
+        else:
+            os.environ.pop("REDIS_KEY_SCHEMA_VERSION", None)
+
+    def test_defaults_to_v1(self):
+        """Test that the schema version defaults to v1 when unset."""
+        os.environ.pop("REDIS_KEY_SCHEMA_VERSION", None)
+        self.assertEqual(get_key_schema_version(), "v1")
+
+    def test_explicit_v2(self):
+        """Test that an explicit v2 value is returned as-is."""
+        os.environ["REDIS_KEY_SCHEMA_VERSION"] = "v2"
+        self.assertEqual(get_key_schema_version(), "v2")
+
+    def test_invalid_value_raises(self):
+        """Test that an invalid schema version raises ValueError."""
+        os.environ["REDIS_KEY_SCHEMA_VERSION"] = "v3"
+        with self.assertRaises(ValueError):
+            get_key_schema_version()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/common/test_redis_client.py
+++ b/tests/common/test_redis_client.py
@@ -1,6 +1,9 @@
+import os
 import unittest
 from unittest.mock import patch
 
+from by_framework.common.config import RedisConfig
+from by_framework.common.exceptions import RedisConnectionError
 from by_framework.common.redis_client import close_redis, get_redis, init_redis
 
 
@@ -12,6 +15,73 @@ class TestRedisClient(unittest.IsolatedAsyncioTestCase):
 
         if rc._redis_client is not None:
             rc._redis_client = None
+
+    async def test_init_redis_cluster_mode_requires_v2_schema(self):
+        """Cluster mode with the default (v1) key schema must fail fast,
+        synchronously, without constructing any client."""
+        old_value = os.environ.get("REDIS_KEY_SCHEMA_VERSION")
+        os.environ.pop("REDIS_KEY_SCHEMA_VERSION", None)
+        try:
+            with (
+                patch("by_framework.common.redis_client.Redis") as mock_redis_cls,
+                patch(
+                    "by_framework.common.redis_client.RedisCluster"
+                ) as mock_cluster_cls,
+            ):
+                with self.assertRaises(RedisConnectionError):
+                    init_redis(
+                        config=RedisConfig(
+                            mode="cluster",
+                            cluster_nodes=[("unreachable-host", 6379)],
+                        )
+                    )
+                mock_redis_cls.assert_not_called()
+                mock_cluster_cls.assert_not_called()
+        finally:
+            if old_value is not None:
+                os.environ["REDIS_KEY_SCHEMA_VERSION"] = old_value
+            else:
+                os.environ.pop("REDIS_KEY_SCHEMA_VERSION", None)
+
+    async def test_init_redis_cluster_mode_with_v2_schema_builds_cluster_client(self):
+        """Cluster mode + v2 schema constructs RedisCluster, not standalone Redis."""
+        old_value = os.environ.get("REDIS_KEY_SCHEMA_VERSION")
+        os.environ["REDIS_KEY_SCHEMA_VERSION"] = "v2"
+        try:
+            with (
+                patch("by_framework.common.redis_client.Redis") as mock_redis_cls,
+                patch(
+                    "by_framework.common.redis_client.RedisCluster"
+                ) as mock_cluster_cls,
+            ):
+                init_redis(
+                    config=RedisConfig(
+                        mode="cluster",
+                        cluster_nodes=[("h1", 6379), ("h2", 6380)],
+                    )
+                )
+
+                mock_redis_cls.assert_not_called()
+                mock_cluster_cls.assert_called_once()
+                _, kwargs = mock_cluster_cls.call_args
+                self.assertEqual(
+                    [(n.host, n.port) for n in kwargs["startup_nodes"]],
+                    [("h1", 6379), ("h2", 6380)],
+                )
+        finally:
+            if old_value is not None:
+                os.environ["REDIS_KEY_SCHEMA_VERSION"] = old_value
+            else:
+                os.environ.pop("REDIS_KEY_SCHEMA_VERSION", None)
+
+    async def test_init_redis_from_config_standalone(self):
+        """Verify that a standalone RedisConfig builds the standalone client."""
+        with patch("by_framework.common.redis_client.Redis") as mock_redis_cls:
+            init_redis(config=RedisConfig(host="redis.example.com", port=6380))
+
+            args, kwargs = mock_redis_cls.call_args
+            self.assertEqual(kwargs["host"], "redis.example.com")
+            self.assertEqual(kwargs["port"], 6380)
 
     async def test_init_redis_singleton(self):
         """Verify that init_redis returns a singleton."""


### PR DESCRIPTION
## Summary
- Extends `RedisConfig` (`common/config.py`) with `mode` (`standalone`/`cluster`), `cluster_nodes`, and socket timeout fields; `standalone` remains the default with no behavior change.
- `init_redis()` now accepts an optional `config: RedisConfig`, builds a `redis.asyncio.cluster.RedisCluster` when `mode=cluster`, and otherwise builds the existing standalone `Redis` client unchanged.
- Adds `REDIS_KEY_SCHEMA_VERSION` (`common/constants.get_key_schema_version()`, default `v1`, validates `v1`/`v2`) and a fail-fast check in `init_redis()`: `mode=cluster` with schema version not `v2` raises `RedisConnectionError` synchronously, before any client is constructed — no real Cluster connectivity is exercised in this phase.

## Test plan
- [x] `uv run pytest` — 508 passed, 3 skipped, 0 failures (pre-existing unrelated flaky `tests/metrics/test_catalog.py` test confirmed present on `main` before this branch, not a regression)
- [x] New unit tests (mocked `Redis`/`RedisCluster`, no real Cluster) cover: cluster-field defaults, `REDIS_MODE`/`REDIS_CLUSTER_NODES` env parsing, `get_key_schema_version()` default/valid/invalid, fail-fast raises without constructing any client, `cluster`+`v2` builds `RedisCluster` with the configured nodes
- [x] `make format-changed` / `make lint-changed` clean (pylint 10.00/10)

Closes #42