### PR TITLE
Redis cluster support Phase 2a: hash-tag key matrix + trace namespace unification

### DIFF
--- a/src/by_framework/common/constants.py
+++ b/src/by_framework/common/constants.py
@@ -26,62 +26,119 @@ class RedisKeys:
     """Gateway SDK global Redis Key naming conventions and constants."""
 
     CONTROL_PLANE_PREFIX = "byai_gateway:control_plane"
+    CONTROL_PLANE_SUFFIX = "control_plane"
+    V2_PREFIX = "byai_gateway:v2:"
+
+    @classmethod
+    def _versioned(cls, v1_key: str, v2_suffix: str) -> str:
+        """Resolve a key according to REDIS_KEY_SCHEMA_VERSION.
+
+        v1 (default): returns v1_key unchanged, byte-for-byte.
+        v2: returns V2_PREFIX + v2_suffix, where v2_suffix already encodes
+        any Cluster hash tag needed for same-entity key groups.
+
+        Every RedisKeys factory method routes through this one function so
+        the v1/v2 decision lives in exactly one place.
+        """
+        if get_key_schema_version() == "v2":
+            return f"{cls.V2_PREFIX}{v2_suffix}"
+        return v1_key
 
     # --- Queues and Streams ---
-    @staticmethod
-    def ctrl_stream(agent_type: str) -> str:
-        """Control stream queue for dispatching tasks to Workers."""
-        return f"byai_gateway:ctrl:agent_type:{agent_type}"
+    @classmethod
+    def ctrl_stream(cls, agent_type: str) -> str:
+        """Control stream queue for dispatching tasks to Workers.
 
-    @staticmethod
-    def worker_ctrl_stream(worker_id: str) -> str:
+        Single-key: agent_type is the only variable dimension. Multiple
+        ctrl_stream calls are fanned out at the application layer (see
+        Phase 4's two-phase XREADGROUP split), not combined into one slot.
+        """
+        return cls._versioned(
+            v1_key=f"byai_gateway:ctrl:agent_type:{agent_type}",
+            v2_suffix=f"ctrl:agent_type:{agent_type}",
+        )
+
+    @classmethod
+    def worker_ctrl_stream(cls, worker_id: str) -> str:
         """Worker-specific control queue for directing control commands to worker."""
-        return f"byai_gateway:ctrl:worker:{worker_id}"
+        return cls._versioned(
+            v1_key=f"byai_gateway:ctrl:worker:{worker_id}",
+            v2_suffix=f"ctrl:worker:{{{worker_id}}}",
+        )
 
-    @staticmethod
-    def plugin_reload_ack_stream(reload_id: str) -> str:
+    @classmethod
+    def plugin_reload_ack_stream(cls, reload_id: str) -> str:
         """Stream for worker ACKs emitted after handling a plugin reload command."""
-        return f"byai_gateway:plugin_reload:{reload_id}:ack"
+        return cls._versioned(
+            v1_key=f"byai_gateway:plugin_reload:{reload_id}:ack",
+            v2_suffix=f"plugin_reload:{reload_id}:ack",
+        )
 
     @classmethod
     def control_plane_wakeup_stream(cls) -> str:
         """Management stream for agent availability wakeup requests."""
-        return f"{cls.CONTROL_PLANE_PREFIX}:mgmt:wakeup"
+        return cls._versioned(
+            v1_key=f"{cls.CONTROL_PLANE_PREFIX}:mgmt:wakeup",
+            v2_suffix=f"{cls.CONTROL_PLANE_SUFFIX}:mgmt:wakeup",
+        )
 
     @classmethod
     def control_plane_wakeup_result_stream(cls, execution_id: str) -> str:
         """Management stream for wakeup controller decisions."""
-        return f"{cls.CONTROL_PLANE_PREFIX}:mgmt:wakeup:result:{execution_id}"
+        return cls._versioned(
+            v1_key=f"{cls.CONTROL_PLANE_PREFIX}:mgmt:wakeup:result:{execution_id}",
+            v2_suffix=f"{cls.CONTROL_PLANE_SUFFIX}:mgmt:wakeup:result:{execution_id}",
+        )
 
     @classmethod
     def control_plane_delivery_pending_stream(cls) -> str:
         """Management stream for pending control-message delivery."""
-        return f"{cls.CONTROL_PLANE_PREFIX}:mgmt:delivery:pending"
+        return cls._versioned(
+            v1_key=f"{cls.CONTROL_PLANE_PREFIX}:mgmt:delivery:pending",
+            v2_suffix=f"{cls.CONTROL_PLANE_SUFFIX}:mgmt:delivery:pending",
+        )
 
     @classmethod
     def control_plane_deadletter_stream(cls) -> str:
         """Management stream for failed control-plane work."""
-        return f"{cls.CONTROL_PLANE_PREFIX}:mgmt:deadletter"
+        return cls._versioned(
+            v1_key=f"{cls.CONTROL_PLANE_PREFIX}:mgmt:deadletter",
+            v2_suffix=f"{cls.CONTROL_PLANE_SUFFIX}:mgmt:deadletter",
+        )
 
     @classmethod
     def control_plane_agent_availability(cls, agent_type: str) -> str:
         """Availability state key for an agent type."""
-        return f"{cls.CONTROL_PLANE_PREFIX}:availability:agent_type:{agent_type}"
+        return cls._versioned(
+            v1_key=f"{cls.CONTROL_PLANE_PREFIX}:availability:agent_type:{agent_type}",
+            v2_suffix=(
+                f"{cls.CONTROL_PLANE_SUFFIX}:availability:agent_type:{agent_type}"
+            ),
+        )
 
     @classmethod
     def control_plane_agent_circuit(cls, agent_type: str) -> str:
         """Circuit-breaker state key for an agent type."""
-        return f"{cls.CONTROL_PLANE_PREFIX}:circuit:agent_type:{agent_type}"
+        return cls._versioned(
+            v1_key=f"{cls.CONTROL_PLANE_PREFIX}:circuit:agent_type:{agent_type}",
+            v2_suffix=f"{cls.CONTROL_PLANE_SUFFIX}:circuit:agent_type:{agent_type}",
+        )
 
     @classmethod
     def control_plane_agent_fallback(cls, agent_type: str) -> str:
         """Fallback routing state key for an agent type."""
-        return f"{cls.CONTROL_PLANE_PREFIX}:fallback:agent_type:{agent_type}"
+        return cls._versioned(
+            v1_key=f"{cls.CONTROL_PLANE_PREFIX}:fallback:agent_type:{agent_type}",
+            v2_suffix=f"{cls.CONTROL_PLANE_SUFFIX}:fallback:agent_type:{agent_type}",
+        )
 
     @classmethod
     def control_plane_user_quota(cls, user_code: str) -> str:
         """User quota state key for control-plane scheduling."""
-        return f"{cls.CONTROL_PLANE_PREFIX}:quota:user:{user_code}"
+        return cls._versioned(
+            v1_key=f"{cls.CONTROL_PLANE_PREFIX}:quota:user:{user_code}",
+            v2_suffix=f"{cls.CONTROL_PLANE_SUFFIX}:quota:user:{user_code}",
+        )
 
     @classmethod
     def control_plane_tenant_quota(cls, tenant_id: str) -> str:
@@ -93,67 +150,131 @@ class RedisKeys:
         cls, agent_type: str, user_code: str, region: str
     ) -> str:
         """Dedupe key for concurrent wakeup requests."""
-        return (
-            f"{cls.CONTROL_PLANE_PREFIX}:wakeup:dedupe:"
-            f"{agent_type}:{user_code}:{region}"
+        return cls._versioned(
+            v1_key=(
+                f"{cls.CONTROL_PLANE_PREFIX}:wakeup:dedupe:"
+                f"{agent_type}:{user_code}:{region}"
+            ),
+            v2_suffix=(
+                f"{cls.CONTROL_PLANE_SUFFIX}:wakeup:dedupe:"
+                f"{agent_type}:{user_code}:{region}"
+            ),
         )
 
-    @staticmethod
-    def agent_configs_snapshot(snapshot_key: str) -> str:
+    @classmethod
+    def agent_configs_snapshot(cls, snapshot_key: str) -> str:
         """Blob key for a persisted AgentConfigsSnapshot payload."""
-        return f"byai_gateway:agent_configs_snapshot:{snapshot_key}"
+        return cls._versioned(
+            v1_key=f"byai_gateway:agent_configs_snapshot:{snapshot_key}",
+            v2_suffix=f"agent_configs_snapshot:{snapshot_key}",
+        )
 
-    @staticmethod
-    def session_data_stream(session_id: str) -> str:
+    @classmethod
+    def session_data_stream(cls, session_id: str) -> str:
         """Session-level data stream. Workers push streaming content here."""
-        return f"byai_gateway:session:{session_id}:data_stream"
+        return cls._versioned(
+            v1_key=f"byai_gateway:session:{session_id}:data_stream",
+            v2_suffix=f"session:{{{session_id}}}:data_stream",
+        )
 
-    @staticmethod
-    def session_data_checkpoint(session_id: str, consumer_name: str) -> str:
+    @classmethod
+    def session_data_checkpoint(cls, session_id: str, consumer_name: str) -> str:
         """Checkpoint key storing a consumer's last processed data stream ID."""
-        return f"byai_gateway:session:{session_id}:consumer:{consumer_name}:checkpoint"
+        return cls._versioned(
+            v1_key=(
+                f"byai_gateway:session:{session_id}:consumer:"
+                f"{consumer_name}:checkpoint"
+            ),
+            v2_suffix=(f"session:{{{session_id}}}:consumer:{consumer_name}:checkpoint"),
+        )
 
-    @staticmethod
-    def trace_meta(trace_id: str) -> str:
-        """Hash storing trace-level metadata for observability."""
-        return f"by_framework:trace:{trace_id}"
+    @classmethod
+    def trace_meta(cls, trace_id: str) -> str:
+        """Hash storing trace-level metadata for observability.
 
-    @staticmethod
-    def trace_spans(trace_id: str) -> str:
+        v1 keeps Python's historical by_framework:trace:* namespace. v2
+        unifies onto the shared byai_gateway:v2:trace:{id} format used by
+        all three language SDKs (Python/Java previously shared
+        by_framework:trace:*, TS used a different byai_gateway:trace:*
+        layout — v2 replaces both with one namespace).
+        """
+        return cls._versioned(
+            v1_key=f"by_framework:trace:{trace_id}",
+            v2_suffix=f"trace:{{{trace_id}}}",
+        )
+
+    @classmethod
+    def trace_spans(cls, trace_id: str) -> str:
         """List storing trace span JSON payloads ordered by write time."""
-        return f"by_framework:trace:spans:{trace_id}"
+        return cls._versioned(
+            v1_key=f"by_framework:trace:spans:{trace_id}",
+            v2_suffix=f"trace:spans:{{{trace_id}}}",
+        )
 
-    @staticmethod
-    def trace_index_session(session_id: str) -> str:
-        """Sorted Set index from session_id to trace IDs."""
-        return f"by_framework:trace:idx:session:{session_id}"
+    @classmethod
+    def trace_index_session(cls, session_id: str) -> str:
+        """Sorted Set index from session_id to trace IDs.
 
-    @staticmethod
-    def trace_index_worker(worker_id: str) -> str:
-        """Sorted Set index from worker_id to trace IDs."""
-        return f"by_framework:trace:idx:worker:{worker_id}"
+        Cross-entity relative to the trace group (meta/spans) — deliberately
+        untagged, see _versioned/module docs on cross-entity splitting.
+        """
+        return cls._versioned(
+            v1_key=f"by_framework:trace:idx:session:{session_id}",
+            v2_suffix=f"trace:idx:session:{session_id}",
+        )
 
-    @staticmethod
-    def trace_index_agent(agent_type: str) -> str:
-        """Sorted Set index from agent type to trace IDs."""
-        return f"by_framework:trace:idx:agent:{agent_type}"
+    @classmethod
+    def trace_index_worker(cls, worker_id: str) -> str:
+        """Sorted Set index from worker_id to trace IDs. Cross-entity, untagged."""
+        return cls._versioned(
+            v1_key=f"by_framework:trace:idx:worker:{worker_id}",
+            v2_suffix=f"trace:idx:worker:{worker_id}",
+        )
 
-    @staticmethod
-    def task_group(group_id: str) -> str:
+    @classmethod
+    def trace_index_agent(cls, agent_type: str) -> str:
+        """Sorted Set index from agent type to trace IDs. Cross-entity, untagged."""
+        return cls._versioned(
+            v1_key=f"by_framework:trace:idx:agent:{agent_type}",
+            v2_suffix=f"trace:idx:agent:{agent_type}",
+        )
+
+    @classmethod
+    def task_group(cls, group_id: str) -> str:
         """Task group progress tracking Hash Key."""
-        return f"byai_gateway:task_group:{group_id}"
+        return cls._versioned(
+            v1_key=f"byai_gateway:task_group:{group_id}",
+            v2_suffix=f"task_group:{{{group_id}}}",
+        )
 
-    @staticmethod
-    def task_group_results(group_id: str) -> str:
+    @classmethod
+    def task_group_results(cls, group_id: str) -> str:
         """All subtask results Hash Key for a task group."""
-        return f"byai_gateway:task_group:{group_id}:results"
+        return cls._versioned(
+            v1_key=f"byai_gateway:task_group:{group_id}:results",
+            v2_suffix=f"task_group:{{{group_id}}}:results",
+        )
 
     # --- Registry ---
-    # Set of known workers used for registry enumeration.
-    KNOWN_WORKERS = "byai_gateway:registry:workers"
-    # Set of workers with explicit admin lifecycle state. Used by dashboard
-    # management views to include offline suspended/evicted workers.
-    ADMIN_WORKERS = "byai_gateway:registry:worker:admin_workers"
+    @classmethod
+    def known_workers(cls) -> str:
+        """Set of known workers used for registry enumeration. Global index,
+        untagged (spans every worker entity), still version-prefixed."""
+        return cls._versioned(
+            v1_key="byai_gateway:registry:workers",
+            v2_suffix="registry:workers",
+        )
+
+    @classmethod
+    def admin_workers(cls) -> str:
+        """Set of workers with explicit admin lifecycle state. Used by
+        dashboard management views to include offline suspended/evicted
+        workers. Global index, untagged, still version-prefixed."""
+        return cls._versioned(
+            v1_key="byai_gateway:registry:worker:admin_workers",
+            v2_suffix="registry:worker:admin_workers",
+        )
+
     WORKER_DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 5
     # 6× the heartbeat interval gives enough margin even when the main event
     # loop is briefly occupied by an LLM call.  The dedicated heartbeat thread
@@ -165,99 +286,150 @@ class RedisKeys:
     DEFAULT_SESSION_TTL = 7 * 24 * 3600
     AGENT_CONFIGS_SNAPSHOT_TTL_SECONDS = DEFAULT_SESSION_TTL
 
-    @staticmethod
-    def worker_declared_agent_types(worker_id: str) -> str:
+    @classmethod
+    def worker_declared_agent_types(cls, worker_id: str) -> str:
         """Set Key storing all agent type identifiers supported by a Worker."""
-        return f"byai_gateway:registry:worker:agent_types:{worker_id}"
+        return cls._versioned(
+            v1_key=f"byai_gateway:registry:worker:agent_types:{worker_id}",
+            v2_suffix=f"registry:worker:{{{worker_id}}}:agent_types",
+        )
 
-    @staticmethod
-    def agent_type_members(agent_type: str) -> str:
+    @classmethod
+    def agent_type_members(cls, agent_type: str) -> str:
         """Set Key storing all Worker IDs with a specific agent type."""
-        return f"byai_gateway:registry:agent_type:workers:{agent_type}"
+        return cls._versioned(
+            v1_key=f"byai_gateway:registry:agent_type:workers:{agent_type}",
+            v2_suffix=f"registry:agent_type:{{{agent_type}}}:workers",
+        )
 
-    @staticmethod
-    def worker_lock(worker_id: str) -> str:
+    @classmethod
+    def worker_lock(cls, worker_id: str) -> str:
         """Worker startup mutex lock to prevent duplicate worker_id startup."""
-        return f"byai_gateway:registry:worker:lock:{worker_id}"
+        return cls._versioned(
+            v1_key=f"byai_gateway:registry:worker:lock:{worker_id}",
+            v2_suffix=f"registry:worker:{{{worker_id}}}:lock",
+        )
 
-    @staticmethod
-    def worker_online_lease(worker_id: str) -> str:
+    @classmethod
+    def worker_online_lease(cls, worker_id: str) -> str:
         """Worker online lease Key. Presence means the worker is considered online."""
-        return f"byai_gateway:registry:worker:online:{worker_id}"
+        return cls._versioned(
+            v1_key=f"byai_gateway:registry:worker:online:{worker_id}",
+            v2_suffix=f"registry:worker:{{{worker_id}}}:online",
+        )
 
-    @staticmethod
-    def worker_status(worker_id: str) -> str:
+    @classmethod
+    def worker_status(cls, worker_id: str) -> str:
         """HASH storing aggregate execution counters for a Worker."""
-        return f"byai_gateway:registry:worker:status:{worker_id}"
+        return cls._versioned(
+            v1_key=f"byai_gateway:registry:worker:status:{worker_id}",
+            v2_suffix=f"registry:worker:{{{worker_id}}}:status",
+        )
 
-    @staticmethod
-    def worker_executions(worker_id: str) -> str:
+    @classmethod
+    def worker_executions(cls, worker_id: str) -> str:
         """ZSET of execution IDs handled by a Worker, scored by update time."""
-        return f"byai_gateway:registry:worker:executions:{worker_id}"
+        return cls._versioned(
+            v1_key=f"byai_gateway:registry:worker:executions:{worker_id}",
+            v2_suffix=f"registry:worker:{{{worker_id}}}:executions",
+        )
 
-    @staticmethod
-    def worker_active_executions(worker_id: str) -> str:
+    @classmethod
+    def worker_active_executions(cls, worker_id: str) -> str:
         """Legacy SET of non-terminal execution IDs assigned to a Worker."""
-        return f"byai_gateway:registry:worker:active_executions:{worker_id}"
+        return cls._versioned(
+            v1_key=f"byai_gateway:registry:worker:active_executions:{worker_id}",
+            v2_suffix=f"registry:worker:{{{worker_id}}}:active_executions",
+        )
 
-    @staticmethod
-    def worker_active_execution_index(worker_id: str) -> str:
+    @classmethod
+    def worker_active_execution_index(cls, worker_id: str) -> str:
         """ZSET of active execution IDs assigned to a Worker, scored by update time."""
-        return f"byai_gateway:registry:worker:active_execution_index:{worker_id}"
+        return cls._versioned(
+            v1_key=f"byai_gateway:registry:worker:active_execution_index:{worker_id}",
+            v2_suffix=f"registry:worker:{{{worker_id}}}:active_execution_index",
+        )
 
-    @staticmethod
-    def worker_active_snapshots(worker_id: str) -> str:
+    @classmethod
+    def worker_active_snapshots(cls, worker_id: str) -> str:
         """HASH mapping active execution IDs to lightweight snapshots."""
-        return f"byai_gateway:registry:worker:active_snapshots:{worker_id}"
+        return cls._versioned(
+            v1_key=f"byai_gateway:registry:worker:active_snapshots:{worker_id}",
+            v2_suffix=f"registry:worker:{{{worker_id}}}:active_snapshots",
+        )
 
-    @staticmethod
-    def worker_history_snapshots(worker_id: str) -> str:
+    @classmethod
+    def worker_history_snapshots(cls, worker_id: str) -> str:
         """HASH mapping worker execution IDs to lightweight history snapshots."""
-        return f"byai_gateway:registry:worker:history_snapshots:{worker_id}"
+        return cls._versioned(
+            v1_key=f"byai_gateway:registry:worker:history_snapshots:{worker_id}",
+            v2_suffix=f"registry:worker:{{{worker_id}}}:history_snapshots",
+        )
 
-    @staticmethod
-    def worker_admin(worker_id: str) -> str:
+    @classmethod
+    def worker_admin(cls, worker_id: str) -> str:
         """HASH storing admin-controlled state for a Worker.
 
         Fields: lifecycle (active|suspended|evicted), reason, updated_at.
         Written by WorkerManager; read by the worker on heartbeat and startup.
         No TTL — persists until explicitly cleared by an admin action.
         """
-        return f"byai_gateway:registry:worker:admin:{worker_id}"
+        return cls._versioned(
+            v1_key=f"byai_gateway:registry:worker:admin:{worker_id}",
+            v2_suffix=f"registry:worker:{{{worker_id}}}:admin",
+        )
 
-    @staticmethod
-    def agent_type_denied(agent_type: str) -> str:
+    @classmethod
+    def agent_type_denied(cls, agent_type: str) -> str:
         """SET of worker_ids explicitly denied from consuming an agent_type stream.
 
         Key absent or empty SET means the agent_type is open to all workers.
         Written by WorkerManager; checked by workers before XREADGROUP and
         inside register_worker_membership().
         """
-        return f"byai_gateway:registry:agent_type:denied:{agent_type}"
+        return cls._versioned(
+            v1_key=f"byai_gateway:registry:agent_type:denied:{agent_type}",
+            v2_suffix=f"registry:agent_type:{{{agent_type}}}:denied",
+        )
 
-    @staticmethod
-    def session_registry(session_id: str) -> str:
+    @classmethod
+    def session_registry(cls, session_id: str) -> str:
         """Session-level aggregate registry (Hash).
 
         Internally divided into the following Field categories:
         - exec:{execution_id} -> Stores specific execution details JSON
         - msg_map:{message_id} -> Stores message ID to execution ID mapping
         """
-        return f"byai_gateway:session:{session_id}:registry"
+        return cls._versioned(
+            v1_key=f"byai_gateway:session:{session_id}:registry",
+            v2_suffix=f"session:{{{session_id}}}:registry",
+        )
 
     # --- Service Discovery ---
-    @staticmethod
-    def sd_active_instances(service_name: str) -> str:
+    @classmethod
+    def sd_active_instances(cls, service_name: str) -> str:
         """ZSET Key for active service instances (sorted by heartbeat timestamp)."""
-        return f"byai_gateway:sd:active:{service_name}"
+        return cls._versioned(
+            v1_key=f"byai_gateway:sd:active:{service_name}",
+            v2_suffix=f"sd:{{{service_name}}}:active",
+        )
 
-    @staticmethod
-    def sd_instance_details(service_name: str) -> str:
+    @classmethod
+    def sd_instance_details(cls, service_name: str) -> str:
         """HASH Key for service instance metadata."""
-        return f"byai_gateway:sd:instances:{service_name}"
+        return cls._versioned(
+            v1_key=f"byai_gateway:sd:instances:{service_name}",
+            v2_suffix=f"sd:{{{service_name}}}:instances",
+        )
 
-    # Set of all known service names (SET)
-    SD_SERVICES = "byai_gateway:sd:services"
+    @classmethod
+    def sd_services(cls) -> str:
+        """Set of all known service names. Global index, untagged, still
+        version-prefixed."""
+        return cls._versioned(
+            v1_key="byai_gateway:sd:services", v2_suffix="sd:services"
+        )
+
     # Default heartbeat send interval (10 seconds)
     SD_DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 10
     # Default service heartbeat threshold (30 seconds)

--- a/src/by_framework/core/discovery.py
+++ b/src/by_framework/core/discovery.py
@@ -145,7 +145,7 @@ class ServiceRegistry:
         )
         self._current_instance.last_heartbeat = now_ms
         # 3. Add service name to global index
-        await self.redis.sadd(RedisKeys.SD_SERVICES, service_name)
+        await self.redis.sadd(RedisKeys.sd_services(), service_name)
 
         # 4. Start recurring heartbeats only when requested.
         if heartbeat_interval > RedisKeys.SD_NO_HEARTBEAT:

--- a/src/by_framework/core/registry.py
+++ b/src/by_framework/core/registry.py
@@ -292,7 +292,7 @@ class WorkerRegistry:
             for item in old_agent_types_raw
         }
 
-        await self.redis.sadd(RedisKeys.KNOWN_WORKERS, worker_id)
+        await self.redis.sadd(RedisKeys.known_workers(), worker_id)
         for stale_agent_type in old_agent_types - new_agent_types:
             await self.redis.srem(
                 RedisKeys.agent_type_members(stale_agent_type), worker_id
@@ -341,7 +341,7 @@ class WorkerRegistry:
         if not result:
             return False
 
-        await self.redis.sadd(RedisKeys.KNOWN_WORKERS, worker_id)
+        await self.redis.sadd(RedisKeys.known_workers(), worker_id)
         return True
 
     async def register_worker(self, worker_id: str, agent_types: List[str]):
@@ -361,7 +361,7 @@ class WorkerRegistry:
             RedisKeys.worker_declared_agent_types(worker_id)
         )
         await self.redis.delete(RedisKeys.worker_declared_agent_types(worker_id))
-        await self.redis.srem(RedisKeys.KNOWN_WORKERS, worker_id)
+        await self.redis.srem(RedisKeys.known_workers(), worker_id)
         for agent_type_raw in agent_types_raw:
             agent_type = (
                 agent_type_raw.decode()
@@ -454,7 +454,7 @@ class WorkerRegistry:
             and last active time.
         """
         redis_inst = self.redis
-        worker_ids_raw = await redis_inst.smembers(RedisKeys.KNOWN_WORKERS)
+        worker_ids_raw = await redis_inst.smembers(RedisKeys.known_workers())
         worker_ids = [w.decode() if isinstance(w, bytes) else w for w in worker_ids_raw]
 
         result = {}
@@ -513,7 +513,7 @@ class WorkerRegistry:
         if not ok:
             raise ValueError(f"worker_id already in use: {worker_id}")
         self._lock_tokens[worker_id] = token
-        await self.redis.sadd(RedisKeys.KNOWN_WORKERS, worker_id)
+        await self.redis.sadd(RedisKeys.known_workers(), worker_id)
         return token
 
     async def refresh_worker_id_lock(
@@ -1299,7 +1299,7 @@ class WorkerRegistry:
         pipe.hset(key, "lifecycle", lifecycle)
         pipe.hset(key, "reason", reason)
         pipe.hset(key, "updated_at", now)
-        pipe.sadd(RedisKeys.ADMIN_WORKERS, worker_id)
+        pipe.sadd(RedisKeys.admin_workers(), worker_id)
         await pipe.execute()
 
     async def get_worker_admin_state(self, worker_id: str) -> dict[str, Any]:
@@ -1327,7 +1327,7 @@ class WorkerRegistry:
         """Remove the admin lifecycle key, restoring default-active behaviour."""
         pipe = self.redis.pipeline()
         pipe.delete(RedisKeys.worker_admin(worker_id))
-        pipe.srem(RedisKeys.ADMIN_WORKERS, worker_id)
+        pipe.srem(RedisKeys.admin_workers(), worker_id)
         await pipe.execute()
 
     async def remove_worker_from_type_members(self, worker_id: str) -> None:

--- a/src/by_framework/metrics/snapshot.py
+++ b/src/by_framework/metrics/snapshot.py
@@ -1152,7 +1152,7 @@ async def _get_observable_workers(
         total_known = len(worker_ids)
         source = "online_lease_scan"
     else:
-        worker_ids_raw = await redis.smembers(RedisKeys.KNOWN_WORKERS)
+        worker_ids_raw = await redis.smembers(RedisKeys.known_workers())
         worker_ids = sorted(
             worker_id.decode("utf-8")
             if isinstance(worker_id, bytes)
@@ -1242,7 +1242,7 @@ async def _get_admin_managed_worker_ids(
     scan_limit: int,
 ) -> tuple[list[str], dict[str, Any]]:
     """Return workers with explicit admin lifecycle state, including offline ones."""
-    indexed_raw = await redis.smembers(RedisKeys.ADMIN_WORKERS)
+    indexed_raw = await redis.smembers(RedisKeys.admin_workers())
     indexed_ids = {
         item.decode("utf-8") if isinstance(item, bytes) else str(item)
         for item in indexed_raw

--- a/tests/common/test_constants.py
+++ b/tests/common/test_constants.py
@@ -5,7 +5,429 @@ Tests for by_framework.common.constants module.
 import os
 import unittest
 
-from by_framework.common.constants import get_key_schema_version
+from redis.crc import key_slot
+
+from by_framework.common.constants import RedisKeys, get_key_schema_version
+
+
+class _KeySchemaVersionTestCase(unittest.TestCase):
+    """Base class that saves/restores REDIS_KEY_SCHEMA_VERSION around each test."""
+
+    def setUp(self):
+        self._old_value = os.environ.get("REDIS_KEY_SCHEMA_VERSION")
+
+    def tearDown(self):
+        if self._old_value is not None:
+            os.environ["REDIS_KEY_SCHEMA_VERSION"] = self._old_value
+        else:
+            os.environ.pop("REDIS_KEY_SCHEMA_VERSION", None)
+
+    def set_schema_version(self, version: str) -> None:
+        os.environ["REDIS_KEY_SCHEMA_VERSION"] = version
+
+
+class TestRedisKeysSameEntityWorkerGroupVersioning(_KeySchemaVersionTestCase):
+    """Tests for a same-entity (worker group) factory method under v1/v2."""
+
+    def test_worker_admin_v1_unchanged(self):
+        """v1 output is byte-for-byte identical to the pre-versioning format."""
+        self.set_schema_version("v1")
+        self.assertEqual(
+            RedisKeys.worker_admin("worker-01"),
+            "byai_gateway:registry:worker:admin:worker-01",
+        )
+
+    def test_worker_admin_v2_wraps_worker_id_in_hash_tag(self):
+        """v2 mode wraps the worker_id in Cluster hash-tag braces."""
+        self.set_schema_version("v2")
+        self.assertEqual(
+            RedisKeys.worker_admin("worker-01"),
+            "byai_gateway:v2:registry:worker:{worker-01}:admin",
+        )
+
+
+class TestRedisKeysAgentTypeGroupVersioning(_KeySchemaVersionTestCase):
+    """Tests for the mandatory agent_type hash-tag group under v2."""
+
+    def test_agent_type_members_and_denied_share_the_same_cluster_slot(self):
+        """agent_type_members/agent_type_denied must be co-located: the
+        deny-worker-for-type path writes both together and must keep working
+        atomically, so this shared tag is mandatory, not optional."""
+        self.set_schema_version("v2")
+        members_key = RedisKeys.agent_type_members("chat")
+        denied_key = RedisKeys.agent_type_denied("chat")
+        self.assertEqual(key_slot(members_key.encode()), key_slot(denied_key.encode()))
+
+
+class TestRedisKeysTraceNamespaceVersioning(_KeySchemaVersionTestCase):
+    """Tests for the trace group's namespace unification under v2."""
+
+    def test_trace_meta_v1_stays_on_historical_by_framework_namespace(self):
+        """v1 keeps Python's historical by_framework:trace:* namespace,
+        unchanged (this is the pre-existing format, not touched by v2)."""
+        self.set_schema_version("v1")
+        self.assertEqual(
+            RedisKeys.trace_meta("trace-xyz"), "by_framework:trace:trace-xyz"
+        )
+
+    def test_trace_meta_v2_moves_to_unified_byai_gateway_namespace(self):
+        """v2 unifies onto the shared byai_gateway:v2:trace:{id} format used
+        by all three language SDKs, replacing the historical namespace."""
+        self.set_schema_version("v2")
+        self.assertEqual(
+            RedisKeys.trace_meta("trace-xyz"), "byai_gateway:v2:trace:{trace-xyz}"
+        )
+
+    def test_trace_spans_v2_shares_trace_meta_slot(self):
+        """trace_meta/trace_spans are written together in one pipeline, so
+        they must share the same Cluster slot under v2."""
+        self.set_schema_version("v2")
+        self.assertEqual(
+            RedisKeys.trace_spans("trace-xyz"),
+            "byai_gateway:v2:trace:spans:{trace-xyz}",
+        )
+        self.assertEqual(
+            key_slot(RedisKeys.trace_meta("trace-xyz").encode()),
+            key_slot(RedisKeys.trace_spans("trace-xyz").encode()),
+        )
+
+    def test_trace_index_session_v2_gets_new_prefix_without_tag(self):
+        """trace_index_* is cross-entity (written alongside the trace group
+        today, split apart in a later issue) so it must NOT share the trace
+        group's tag — only the prefix moves from by_framework: to v2."""
+        self.set_schema_version("v2")
+        self.assertEqual(
+            RedisKeys.trace_index_session("sess-abc123"),
+            "byai_gateway:v2:trace:idx:session:sess-abc123",
+        )
+
+
+class TestRedisKeysGlobalIndexVersioning(_KeySchemaVersionTestCase):
+    """Tests for global-index keys (untagged, but still version-prefixed)."""
+
+    def test_known_workers_v1_unchanged(self):
+        """v1 output matches the pre-versioning KNOWN_WORKERS literal."""
+        self.set_schema_version("v1")
+        self.assertEqual(RedisKeys.known_workers(), "byai_gateway:registry:workers")
+
+    def test_known_workers_v2_gets_prefix_no_tag(self):
+        """v2 still gets the version prefix even though it's a global index
+        with no single owning entity to tag."""
+        self.set_schema_version("v2")
+        self.assertEqual(RedisKeys.known_workers(), "byai_gateway:v2:registry:workers")
+
+    def test_admin_workers_v1_unchanged(self):
+        """v1 output matches the pre-versioning ADMIN_WORKERS literal."""
+        self.set_schema_version("v1")
+        self.assertEqual(
+            RedisKeys.admin_workers(), "byai_gateway:registry:worker:admin_workers"
+        )
+
+    def test_admin_workers_v2_gets_prefix_no_tag(self):
+        """v2 still gets the version prefix even though it's a global index."""
+        self.set_schema_version("v2")
+        self.assertEqual(
+            RedisKeys.admin_workers(), "byai_gateway:v2:registry:worker:admin_workers"
+        )
+
+    def test_sd_services_v1_unchanged(self):
+        """v1 output matches the pre-versioning SD_SERVICES literal."""
+        self.set_schema_version("v1")
+        self.assertEqual(RedisKeys.sd_services(), "byai_gateway:sd:services")
+
+    def test_sd_services_v2_gets_prefix_no_tag(self):
+        """v2 still gets the version prefix even though it's a global index."""
+        self.set_schema_version("v2")
+        self.assertEqual(RedisKeys.sd_services(), "byai_gateway:v2:sd:services")
+
+
+class TestRedisKeysSingleKeyVersioning(_KeySchemaVersionTestCase):
+    """Tests for a single-key (no hash tag) factory method under v1/v2."""
+
+    def test_plugin_reload_ack_stream_v1_unchanged(self):
+        """v1 output is byte-for-byte identical to the pre-versioning format."""
+        self.set_schema_version("v1")
+        self.assertEqual(
+            RedisKeys.plugin_reload_ack_stream("reload-1"),
+            "byai_gateway:plugin_reload:reload-1:ack",
+        )
+
+    def test_plugin_reload_ack_stream_v2_gets_v2_prefix_no_tag(self):
+        """v2 mode prefixes single-key methods without adding a hash tag."""
+        self.set_schema_version("v2")
+        self.assertEqual(
+            RedisKeys.plugin_reload_ack_stream("reload-1"),
+            "byai_gateway:v2:plugin_reload:reload-1:ack",
+        )
+
+
+class TestRedisKeysGoldenV2Keys(_KeySchemaVersionTestCase):
+    """Golden-key test: fixed IDs -> exact v2 key strings for every factory
+    method (issue #43 acceptance criteria #6). Expected values are
+    transcribed from the design doc's key matrix, independent of the
+    implementation, so this test can actually disagree with the code."""
+
+    IDS = {
+        "session_id": "sess-abc123",
+        "worker_id": "worker-01",
+        "trace_id": "trace-xyz",
+        "agent_type": "chat",
+        "group_id": "tg-1",
+        "service_name": "svc-a",
+        "reload_id": "reload-1",
+        "execution_id": "exec-1",
+        "user_code": "user-1",
+        "region": "us-east",
+        "snapshot_key": "snap-1",
+        "consumer_name": "consumer-1",
+    }
+
+    def setUp(self):
+        super().setUp()
+        self.set_schema_version("v2")
+
+    def test_golden_v2_keys(self):
+        ids = self.IDS
+        cases = {
+            "ctrl_stream": (
+                RedisKeys.ctrl_stream(ids["agent_type"]),
+                "byai_gateway:v2:ctrl:agent_type:chat",
+            ),
+            "worker_ctrl_stream": (
+                RedisKeys.worker_ctrl_stream(ids["worker_id"]),
+                "byai_gateway:v2:ctrl:worker:{worker-01}",
+            ),
+            "plugin_reload_ack_stream": (
+                RedisKeys.plugin_reload_ack_stream(ids["reload_id"]),
+                "byai_gateway:v2:plugin_reload:reload-1:ack",
+            ),
+            "control_plane_wakeup_stream": (
+                RedisKeys.control_plane_wakeup_stream(),
+                "byai_gateway:v2:control_plane:mgmt:wakeup",
+            ),
+            "control_plane_wakeup_result_stream": (
+                RedisKeys.control_plane_wakeup_result_stream(ids["execution_id"]),
+                "byai_gateway:v2:control_plane:mgmt:wakeup:result:exec-1",
+            ),
+            "control_plane_delivery_pending_stream": (
+                RedisKeys.control_plane_delivery_pending_stream(),
+                "byai_gateway:v2:control_plane:mgmt:delivery:pending",
+            ),
+            "control_plane_deadletter_stream": (
+                RedisKeys.control_plane_deadletter_stream(),
+                "byai_gateway:v2:control_plane:mgmt:deadletter",
+            ),
+            "control_plane_agent_availability": (
+                RedisKeys.control_plane_agent_availability(ids["agent_type"]),
+                "byai_gateway:v2:control_plane:availability:agent_type:chat",
+            ),
+            "control_plane_agent_circuit": (
+                RedisKeys.control_plane_agent_circuit(ids["agent_type"]),
+                "byai_gateway:v2:control_plane:circuit:agent_type:chat",
+            ),
+            "control_plane_agent_fallback": (
+                RedisKeys.control_plane_agent_fallback(ids["agent_type"]),
+                "byai_gateway:v2:control_plane:fallback:agent_type:chat",
+            ),
+            "control_plane_user_quota": (
+                RedisKeys.control_plane_user_quota(ids["user_code"]),
+                "byai_gateway:v2:control_plane:quota:user:user-1",
+            ),
+            "control_plane_tenant_quota": (
+                RedisKeys.control_plane_tenant_quota(ids["user_code"]),
+                "byai_gateway:v2:control_plane:quota:user:user-1",
+            ),
+            "control_plane_wakeup_dedupe": (
+                RedisKeys.control_plane_wakeup_dedupe(
+                    ids["agent_type"], ids["user_code"], ids["region"]
+                ),
+                "byai_gateway:v2:control_plane:wakeup:dedupe:chat:user-1:us-east",
+            ),
+            "agent_configs_snapshot": (
+                RedisKeys.agent_configs_snapshot(ids["snapshot_key"]),
+                "byai_gateway:v2:agent_configs_snapshot:snap-1",
+            ),
+            "session_data_stream": (
+                RedisKeys.session_data_stream(ids["session_id"]),
+                "byai_gateway:v2:session:{sess-abc123}:data_stream",
+            ),
+            "session_data_checkpoint": (
+                RedisKeys.session_data_checkpoint(
+                    ids["session_id"], ids["consumer_name"]
+                ),
+                "byai_gateway:v2:session:{sess-abc123}:consumer:consumer-1:checkpoint",
+            ),
+            "trace_meta": (
+                RedisKeys.trace_meta(ids["trace_id"]),
+                "byai_gateway:v2:trace:{trace-xyz}",
+            ),
+            "trace_spans": (
+                RedisKeys.trace_spans(ids["trace_id"]),
+                "byai_gateway:v2:trace:spans:{trace-xyz}",
+            ),
+            "trace_index_session": (
+                RedisKeys.trace_index_session(ids["session_id"]),
+                "byai_gateway:v2:trace:idx:session:sess-abc123",
+            ),
+            "trace_index_worker": (
+                RedisKeys.trace_index_worker(ids["worker_id"]),
+                "byai_gateway:v2:trace:idx:worker:worker-01",
+            ),
+            "trace_index_agent": (
+                RedisKeys.trace_index_agent(ids["agent_type"]),
+                "byai_gateway:v2:trace:idx:agent:chat",
+            ),
+            "task_group": (
+                RedisKeys.task_group(ids["group_id"]),
+                "byai_gateway:v2:task_group:{tg-1}",
+            ),
+            "task_group_results": (
+                RedisKeys.task_group_results(ids["group_id"]),
+                "byai_gateway:v2:task_group:{tg-1}:results",
+            ),
+            "known_workers": (
+                RedisKeys.known_workers(),
+                "byai_gateway:v2:registry:workers",
+            ),
+            "admin_workers": (
+                RedisKeys.admin_workers(),
+                "byai_gateway:v2:registry:worker:admin_workers",
+            ),
+            "worker_declared_agent_types": (
+                RedisKeys.worker_declared_agent_types(ids["worker_id"]),
+                "byai_gateway:v2:registry:worker:{worker-01}:agent_types",
+            ),
+            "agent_type_members": (
+                RedisKeys.agent_type_members(ids["agent_type"]),
+                "byai_gateway:v2:registry:agent_type:{chat}:workers",
+            ),
+            "worker_lock": (
+                RedisKeys.worker_lock(ids["worker_id"]),
+                "byai_gateway:v2:registry:worker:{worker-01}:lock",
+            ),
+            "worker_online_lease": (
+                RedisKeys.worker_online_lease(ids["worker_id"]),
+                "byai_gateway:v2:registry:worker:{worker-01}:online",
+            ),
+            "worker_status": (
+                RedisKeys.worker_status(ids["worker_id"]),
+                "byai_gateway:v2:registry:worker:{worker-01}:status",
+            ),
+            "worker_executions": (
+                RedisKeys.worker_executions(ids["worker_id"]),
+                "byai_gateway:v2:registry:worker:{worker-01}:executions",
+            ),
+            "worker_active_executions": (
+                RedisKeys.worker_active_executions(ids["worker_id"]),
+                "byai_gateway:v2:registry:worker:{worker-01}:active_executions",
+            ),
+            "worker_active_execution_index": (
+                RedisKeys.worker_active_execution_index(ids["worker_id"]),
+                "byai_gateway:v2:registry:worker:{worker-01}:active_execution_index",
+            ),
+            "worker_active_snapshots": (
+                RedisKeys.worker_active_snapshots(ids["worker_id"]),
+                "byai_gateway:v2:registry:worker:{worker-01}:active_snapshots",
+            ),
+            "worker_history_snapshots": (
+                RedisKeys.worker_history_snapshots(ids["worker_id"]),
+                "byai_gateway:v2:registry:worker:{worker-01}:history_snapshots",
+            ),
+            "worker_admin": (
+                RedisKeys.worker_admin(ids["worker_id"]),
+                "byai_gateway:v2:registry:worker:{worker-01}:admin",
+            ),
+            "agent_type_denied": (
+                RedisKeys.agent_type_denied(ids["agent_type"]),
+                "byai_gateway:v2:registry:agent_type:{chat}:denied",
+            ),
+            "session_registry": (
+                RedisKeys.session_registry(ids["session_id"]),
+                "byai_gateway:v2:session:{sess-abc123}:registry",
+            ),
+            "sd_active_instances": (
+                RedisKeys.sd_active_instances(ids["service_name"]),
+                "byai_gateway:v2:sd:{svc-a}:active",
+            ),
+            "sd_instance_details": (
+                RedisKeys.sd_instance_details(ids["service_name"]),
+                "byai_gateway:v2:sd:{svc-a}:instances",
+            ),
+            "sd_services": (
+                RedisKeys.sd_services(),
+                "byai_gateway:v2:sd:services",
+            ),
+        }
+        for label, (actual, expected) in cases.items():
+            with self.subTest(label=label):
+                self.assertEqual(actual, expected)
+
+
+class TestRedisKeysSameEntitySlotVerification(_KeySchemaVersionTestCase):
+    """Slot-verification test (issue #43 acceptance criteria #5): every
+    same-entity group's member keys must hash to the same Cluster slot
+    under v2, verified via redis-py's actual CLUSTER-KEYSLOT implementation
+    (the same one a real RedisCluster client uses), not a reimplementation."""
+
+    def setUp(self):
+        super().setUp()
+        self.set_schema_version("v2")
+
+    def assert_same_slot(self, *keys: str) -> None:
+        slots = {key_slot(k.encode()) for k in keys}
+        self.assertEqual(len(slots), 1, f"keys landed on different slots: {keys}")
+
+    def test_session_group_shares_a_slot(self):
+        session_id = "sess-abc123"
+        self.assert_same_slot(
+            RedisKeys.session_data_stream(session_id),
+            RedisKeys.session_data_checkpoint(session_id, "consumer-1"),
+            RedisKeys.session_registry(session_id),
+        )
+
+    def test_worker_group_shares_a_slot(self):
+        worker_id = "worker-01"
+        self.assert_same_slot(
+            RedisKeys.worker_ctrl_stream(worker_id),
+            RedisKeys.worker_declared_agent_types(worker_id),
+            RedisKeys.worker_lock(worker_id),
+            RedisKeys.worker_online_lease(worker_id),
+            RedisKeys.worker_status(worker_id),
+            RedisKeys.worker_executions(worker_id),
+            RedisKeys.worker_active_executions(worker_id),
+            RedisKeys.worker_active_execution_index(worker_id),
+            RedisKeys.worker_active_snapshots(worker_id),
+            RedisKeys.worker_history_snapshots(worker_id),
+            RedisKeys.worker_admin(worker_id),
+        )
+
+    def test_task_group_shares_a_slot(self):
+        group_id = "tg-1"
+        self.assert_same_slot(
+            RedisKeys.task_group(group_id),
+            RedisKeys.task_group_results(group_id),
+        )
+
+    def test_agent_type_group_shares_a_slot(self):
+        agent_type = "chat"
+        self.assert_same_slot(
+            RedisKeys.agent_type_members(agent_type),
+            RedisKeys.agent_type_denied(agent_type),
+        )
+
+    def test_service_discovery_group_shares_a_slot(self):
+        service_name = "svc-a"
+        self.assert_same_slot(
+            RedisKeys.sd_active_instances(service_name),
+            RedisKeys.sd_instance_details(service_name),
+        )
+
+    def test_trace_group_shares_a_slot(self):
+        trace_id = "trace-xyz"
+        self.assert_same_slot(
+            RedisKeys.trace_meta(trace_id),
+            RedisKeys.trace_spans(trace_id),
+        )
 
 
 class TestGetKeySchemaVersion(unittest.TestCase):

--- a/tests/core/test_registry.py
+++ b/tests/core/test_registry.py
@@ -360,7 +360,7 @@ async def test_register_worker_compatibility_wrapper():
     with pytest.warns(DeprecationWarning, match="register_worker"):
         await registry.register_worker("worker-1", ["super_assistant"])
     assert OLD_ACTIVE_WORKERS not in redis_mock.data
-    assert "worker-1" in redis_mock.data[RedisKeys.KNOWN_WORKERS]
+    assert "worker-1" in redis_mock.data[RedisKeys.known_workers()]
     assert redis_mock.data[RedisKeys.worker_declared_agent_types("worker-1")] == {
         "super_assistant"
     }
@@ -378,7 +378,7 @@ async def test_unregister_worker_compatibility_wrapper_warns():
         await registry.unregister_worker("worker-1")
 
     assert OLD_ACTIVE_WORKERS not in redis_mock.data
-    assert "worker-1" not in redis_mock.data[RedisKeys.KNOWN_WORKERS]
+    assert "worker-1" not in redis_mock.data[RedisKeys.known_workers()]
     assert RedisKeys.worker_declared_agent_types("worker-1") not in redis_mock.data
 
 
@@ -393,7 +393,7 @@ async def test_register_worker_membership_only_updates_membership_sets():
     )
 
     assert OLD_ACTIVE_WORKERS not in redis_mock.data
-    assert redis_mock.data[RedisKeys.KNOWN_WORKERS] == {"worker-1"}
+    assert redis_mock.data[RedisKeys.known_workers()] == {"worker-1"}
     assert redis_mock.data[RedisKeys.worker_declared_agent_types("worker-1")] == {
         "super_assistant",
         "code_agent",
@@ -436,7 +436,7 @@ async def test_heartbeat_worker_only_updates_presence():
     assert presence["last_seen"] > 0
     assert presence["ip_address"] == "10.0.0.7"
     assert OLD_ACTIVE_WORKERS not in redis_mock.data
-    assert redis_mock.data[RedisKeys.KNOWN_WORKERS] == {"worker-1"}
+    assert redis_mock.data[RedisKeys.known_workers()] == {"worker-1"}
     assert redis_mock.expires[RedisKeys.worker_online_lease("worker-1")] == (
         RedisKeys.WORKER_DEFAULT_LEASE_TTL_SECONDS
     )
@@ -502,7 +502,7 @@ async def test_unregister_worker_membership_only_removes_membership_sets():
     assert redis_mock.kv[RedisKeys.worker_online_lease("worker-1")] == online_snapshot
     assert RedisKeys.worker_declared_agent_types("worker-1") not in redis_mock.data
     assert redis_mock.data[RedisKeys.agent_type_members("super_assistant")] == set()
-    assert "worker-1" not in redis_mock.data[RedisKeys.KNOWN_WORKERS]
+    assert "worker-1" not in redis_mock.data[RedisKeys.known_workers()]
 
 
 @pytest.mark.asyncio
@@ -520,7 +520,7 @@ async def test_mark_worker_inactive_only_removes_online_state():
     assert redis_mock.data[RedisKeys.worker_declared_agent_types("worker-1")] == {
         "super_assistant"
     }
-    assert "worker-1" in redis_mock.data[RedisKeys.KNOWN_WORKERS]
+    assert "worker-1" in redis_mock.data[RedisKeys.known_workers()]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Every `RedisKeys` factory method now routes through one centralized `_versioned(v1_key, v2_suffix)` helper — no method independently decides whether to add the `v2` prefix.
- Under `REDIS_KEY_SCHEMA_VERSION=v2`: keys get a `byai_gateway:v2:` prefix, and same-entity groups (session / worker / task_group / agent_type / service-discovery / trace) share a Cluster hash tag so multi-key ops land on one slot.
- `agent_type_members`/`agent_type_denied` share a **mandatory** tag (verified via a slot test) since `deny_worker_for_type` writes both together.
- Trace keys (`trace_meta`/`trace_spans`) additionally unify onto one cross-language v2 namespace (`byai_gateway:v2:trace:{trace_id}` / `byai_gateway:v2:trace:spans:{trace_id}`), replacing Python's historical `by_framework:trace:*` format. `trace_index_session/worker/agent` stay untagged (cross-entity, split apart in a later issue) — only their prefix moves.
- `v1` output is unchanged everywhere (regression-locked by tests).
- `KNOWN_WORKERS`/`ADMIN_WORKERS`/`SD_SERVICES` become `known_workers()`/`admin_workers()`/`sd_services()` classmethods, since these global-index keys still need the `v2` prefix and can no longer be static strings. Updated the ~15 internal call sites in `registry.py`, `discovery.py`, and `metrics/snapshot.py` accordingly (confirmed no external consumers reference these three by attribute — `by-framework-trace-query` only uses the already-method-style `trace_*`/`session_*` factories).

## Test plan
- [x] Golden-key test: fixed ID fixture (`session_id="sess-abc123"`, `worker_id="worker-01"`, `trace_id="trace-xyz"`, etc.) asserted against exact v2 key strings for all 30 factory methods, transcribed independently from the design doc's matrix
- [x] Slot-verification test: every same-entity group (session, worker, task_group, agent_type, service-discovery, trace) asserted to hash to the same Cluster slot under v2, via `redis.crc.key_slot` (the same implementation a real `RedisCluster` client uses)
- [x] v1-regression tests confirm byte-identical output to the pre-change format for representative methods across every category
- [x] `uv run pytest` — 530 passed, 3 skipped, 0 failures, 0 regressions
- [x] `make format-changed` / `make lint-changed` clean (pylint 10.00/10)

Closes #43