### PR TITLE
Redis cluster support Phase 3: split cross-entity pipelines (worker admin index + trace writes)

### DIFF
--- a/src/by_framework/core/registry.py
+++ b/src/by_framework/core/registry.py
@@ -1299,8 +1299,20 @@ class WorkerRegistry:
         pipe.hset(key, "lifecycle", lifecycle)
         pipe.hset(key, "reason", reason)
         pipe.hset(key, "updated_at", now)
-        pipe.sadd(RedisKeys.admin_workers(), worker_id)
         await pipe.execute()
+        # admin_workers() is a global index spanning every worker entity, so it
+        # can't share a Cluster hash tag with worker_admin(id) — write it as a
+        # separate, best-effort call. worker_admin(id) is the source of truth
+        # for reads; a transient index-write failure only affects the
+        # dashboard's "list all admin-controlled workers" view.
+        try:
+            await self.redis.sadd(RedisKeys.admin_workers(), worker_id)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.warning(
+                "set_worker_admin_state: admin_workers index update failed for %s",
+                worker_id,
+                exc_info=True,
+            )
 
     async def get_worker_admin_state(self, worker_id: str) -> dict[str, Any]:
         """Return the admin-controlled state for a worker.
@@ -1325,10 +1337,15 @@ class WorkerRegistry:
 
     async def clear_worker_admin_state(self, worker_id: str) -> None:
         """Remove the admin lifecycle key, restoring default-active behaviour."""
-        pipe = self.redis.pipeline()
-        pipe.delete(RedisKeys.worker_admin(worker_id))
-        pipe.srem(RedisKeys.admin_workers(), worker_id)
-        await pipe.execute()
+        await self.redis.delete(RedisKeys.worker_admin(worker_id))
+        try:
+            await self.redis.srem(RedisKeys.admin_workers(), worker_id)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.warning(
+                "clear_worker_admin_state: admin_workers index update failed for %s",
+                worker_id,
+                exc_info=True,
+            )
 
     async def remove_worker_from_type_members(self, worker_id: str) -> None:
         """SREM worker_id from every agent_type:members set it currently belongs to.

--- a/src/by_framework/trace/span_recorder.py
+++ b/src/by_framework/trace/span_recorder.py
@@ -426,6 +426,10 @@ class RedisSpanExporter:
             else 0
         )
         updated_at = max(existing_updated_at, end_ts)
+        # trace_meta/trace_spans share a Cluster hash tag (trace_id) since
+        # Phase 2a, so this group can stay atomic. The session/worker/agent
+        # indexes below are cross-entity relative to the trace group and are
+        # written as independent, best-effort calls instead.
         pipe = self.redis.pipeline()
         if isawaitable(pipe):
             pipe = await pipe
@@ -462,38 +466,49 @@ class RedisSpanExporter:
         await self._call_pipeline(
             pipe, "rpush", spans_key, json.dumps(payload, ensure_ascii=False)
         )
-        if payload.get("session_id"):
-            index_key = RedisKeys.trace_index_session(str(payload["session_id"]))
-            await self._call_pipeline(
-                pipe,
-                "zadd",
-                index_key,
-                {trace_id: start_ts},
-            )
-            await self._call_pipeline(pipe, "expire", index_key, self.ttl_seconds)
-        if payload.get("worker_id"):
-            index_key = RedisKeys.trace_index_worker(str(payload["worker_id"]))
-            await self._call_pipeline(
-                pipe,
-                "zadd",
-                index_key,
-                {trace_id: start_ts},
-            )
-            await self._call_pipeline(pipe, "expire", index_key, self.ttl_seconds)
-        if payload.get("target_agent_type"):
-            index_key = RedisKeys.trace_index_agent(str(payload["target_agent_type"]))
-            await self._call_pipeline(
-                pipe,
-                "zadd",
-                index_key,
-                {trace_id: start_ts},
-            )
-            await self._call_pipeline(pipe, "expire", index_key, self.ttl_seconds)
         await self._call_pipeline(pipe, "expire", meta_key, self.ttl_seconds)
         await self._call_pipeline(pipe, "expire", spans_key, self.ttl_seconds)
         result = pipe.execute()
         if isawaitable(result):
             await result
+
+        if payload.get("session_id"):
+            await self._write_trace_index(
+                RedisKeys.trace_index_session(str(payload["session_id"])),
+                trace_id,
+                start_ts,
+            )
+        if payload.get("worker_id"):
+            await self._write_trace_index(
+                RedisKeys.trace_index_worker(str(payload["worker_id"])),
+                trace_id,
+                start_ts,
+            )
+        if payload.get("target_agent_type"):
+            await self._write_trace_index(
+                RedisKeys.trace_index_agent(str(payload["target_agent_type"])),
+                trace_id,
+                start_ts,
+            )
+
+    async def _write_trace_index(
+        self, index_key: str, trace_id: str, score: int
+    ) -> None:
+        """Best-effort write to a trace lookup index (session/worker/agent).
+
+        Cross-entity relative to the trace group, so it's written
+        independently and its failure must not affect the trace_meta/
+        trace_spans write that already landed above.
+        """
+        try:
+            await self.redis.zadd(index_key, {trace_id: int(score or 0)})
+            await self.redis.expire(index_key, self.ttl_seconds)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.warning(
+                "RedisSpanExporter: trace index write failed for %s",
+                index_key,
+                exc_info=True,
+            )
 
     @staticmethod
     async def _call_pipeline(pipe: Any, method_name: str, *args: Any) -> None:

--- a/src/by_framework/trace/trace_writer.py
+++ b/src/by_framework/trace/trace_writer.py
@@ -43,7 +43,13 @@ class TraceWriteClient:
         )
 
     async def record_trace(self, record: TraceRecord) -> None:
-        """Persist trace-level metadata and lookup indexes."""
+        """Persist trace-level metadata and lookup indexes.
+
+        trace_meta is written in its own atomic pipeline. The session/agent
+        lookup indexes are cross-entity relative to trace_meta, so they're
+        written as independent, best-effort calls afterward — a failure
+        there must not affect the trace_meta write that already landed.
+        """
         try:
             payload = record.to_dict()
             if not payload.get("trace_id"):
@@ -67,25 +73,25 @@ class TraceWriteClient:
                     int(payload.get("end_ts", start_ts) or start_ts),
                 )
             await self._call_pipeline(pipe, "expire", meta_key, self.ttl_seconds)
-            if payload.get("session_id"):
-                await self._index_trace(
-                    pipe,
-                    RedisKeys.trace_index_session(str(payload["session_id"])),
-                    trace_id,
-                    start_ts,
-                )
-            if payload.get("root_agent_type"):
-                await self._index_trace(
-                    pipe,
-                    RedisKeys.trace_index_agent(str(payload["root_agent_type"])),
-                    trace_id,
-                    start_ts,
-                )
             result = pipe.execute()
             if isawaitable(result):
                 await result
         except Exception as err:  # pylint: disable=broad-exception-caught
             logger.warning("TraceWriteClient.record_trace skipped: %s", err)
+            return
+
+        if payload.get("session_id"):
+            await self._index_trace(
+                RedisKeys.trace_index_session(str(payload["session_id"])),
+                trace_id,
+                start_ts,
+            )
+        if payload.get("root_agent_type"):
+            await self._index_trace(
+                RedisKeys.trace_index_agent(str(payload["root_agent_type"])),
+                trace_id,
+                start_ts,
+            )
 
     async def record_span(self, record: SpanRecord) -> None:
         """Persist a trace-tree span."""
@@ -144,11 +150,19 @@ class TraceWriteClient:
         except Exception as err:  # pylint: disable=broad-exception-caught
             logger.warning("TraceWriteClient.record_event skipped: %s", err)
 
-    async def _index_trace(
-        self, pipe: Any, index_key: str, trace_id: str, score: int
-    ) -> None:
-        await self._call_pipeline(pipe, "zadd", index_key, {trace_id: int(score or 0)})
-        await self._call_pipeline(pipe, "expire", index_key, self.ttl_seconds)
+    async def _index_trace(self, index_key: str, trace_id: str, score: int) -> None:
+        """Best-effort write to a trace lookup index (session/agent).
+
+        Cross-entity relative to trace_meta, so it's written independently;
+        failure here is logged and never propagated to the caller.
+        """
+        try:
+            await self.redis.zadd(index_key, {trace_id: int(score or 0)})
+            await self.redis.expire(index_key, self.ttl_seconds)
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            logger.warning(
+                "TraceWriteClient: trace index write failed for %s: %s", index_key, err
+            )
 
     @staticmethod
     async def _call_pipeline(pipe: Any, method_name: str, *args: Any) -> None:

--- a/tests/core/test_registry.py
+++ b/tests/core/test_registry.py
@@ -1137,3 +1137,50 @@ async def test_is_worker_online():
     # Unknown worker should not be online
     is_online = await registry.is_worker_online("unknown_worker")
     assert is_online is False
+
+
+class _AdminIndexFailingRedis(MockRedis):
+    """MockRedis variant whose sadd/srem fail only for the admin_workers()
+    index, to verify the worker_admin(id) key is independent of it."""
+
+    async def sadd(self, name, value):
+        if name == RedisKeys.admin_workers():
+            raise ConnectionError("simulated admin_workers index write failure")
+        return await super().sadd(name, value)
+
+    async def srem(self, name, value):
+        if name == RedisKeys.admin_workers():
+            raise ConnectionError("simulated admin_workers index write failure")
+        return await super().srem(name, value)
+
+
+@pytest.mark.asyncio
+async def test_set_worker_admin_state_survives_admin_workers_index_failure():
+    """The admin_workers() index write is best-effort: if it fails, the
+    per-worker worker_admin(id) hash (source of truth for reads) must still
+    have been written and be readable."""
+    redis_mock = _AdminIndexFailingRedis()
+    registry = WorkerRegistry(redis_mock)
+
+    await registry.set_worker_admin_state("worker-1", "suspended", reason="abuse")
+
+    state = await registry.get_worker_admin_state("worker-1")
+    assert state["lifecycle"] == "suspended"
+    assert state["reason"] == "abuse"
+
+
+@pytest.mark.asyncio
+async def test_clear_worker_admin_state_survives_admin_workers_index_failure():
+    """clear_worker_admin_state must delete the worker_admin(id) key even if
+    the best-effort admin_workers() index removal fails."""
+    redis_mock = _AdminIndexFailingRedis()
+    registry = WorkerRegistry(redis_mock)
+    redis_mock.data[RedisKeys.worker_admin("worker-1")] = {
+        "lifecycle": "suspended",
+        "reason": "abuse",
+    }
+
+    await registry.clear_worker_admin_state("worker-1")
+
+    state = await registry.get_worker_admin_state("worker-1")
+    assert state == {}

--- a/tests/trace/test_span_recorder.py
+++ b/tests/trace/test_span_recorder.py
@@ -80,6 +80,50 @@ class SpanRedis:
         return MockPipeline(self)
 
 
+class _WorkerIndexFailingSpanRedis(SpanRedis):
+    """SpanRedis variant whose zadd fails only for the trace_index_worker
+    key, to verify the trace group (meta+spans) and the other cross-entity
+    indexes are independent best-effort writes."""
+
+    async def zadd(self, name, mapping):
+        if name == RedisKeys.trace_index_worker("worker-safe"):
+            raise ConnectionError("simulated trace_index_worker write failure")
+        return await super().zadd(name, mapping)
+
+
+@pytest.mark.asyncio
+async def test_export_span_survives_trace_index_worker_failure():
+    """trace_index_worker is a cross-entity index write, split apart from
+    the trace group's atomic meta+spans write. If it fails, trace_meta/
+    trace_spans must still be correctly readable by trace_id, and the
+    other (unrelated) indexes must still have been written."""
+    redis = _WorkerIndexFailingSpanRedis()
+    exporter = RedisSpanExporter(redis, ttl_seconds=321)
+
+    await exporter.export_span(
+        TraceSpan(
+            trace_id="trace-safe",
+            span_id="span-1",
+            parent_span_id="",
+            operation="client.dispatch",
+            component="client",
+            start_ts=100,
+            end_ts=150,
+            status="OK",
+            session_id="sess-safe",
+            worker_id="worker-safe",
+            target_agent_type="planner",
+        )
+    )
+
+    assert redis.data[RedisKeys.trace_meta("trace-safe")]["trace_id"] == "trace-safe"
+    assert redis.data[RedisKeys.trace_meta("trace-safe")]["status"] == "OK"
+    assert len(redis.data[RedisKeys.trace_spans("trace-safe")]) == 1
+    assert "trace-safe" in redis.data[RedisKeys.trace_index_session("sess-safe")]
+    assert "trace-safe" in redis.data[RedisKeys.trace_index_agent("planner")]
+    assert RedisKeys.trace_index_worker("worker-safe") not in redis.data
+
+
 @pytest.mark.asyncio
 async def test_redis_span_exporter_redacts_sensitive_metadata_and_expires_indexes():
     """Redis trace storage redacts secrets and applies TTL to lookup indexes."""

--- a/tests/trace/test_trace_writer.py
+++ b/tests/trace/test_trace_writer.py
@@ -1,0 +1,87 @@
+"""Tests for TraceWriteClient's best-effort Redis writes."""
+
+import pytest
+
+from by_framework.common.constants import RedisKeys
+from by_framework.trace.trace_schema import TraceRecord
+from by_framework.trace.trace_writer import TraceWriteClient
+
+
+class _MockPipeline:
+    """Small Redis pipeline fake matching TraceWriteClient's call shapes."""
+
+    def __init__(self, redis):
+        self.redis = redis
+        self.commands = []
+
+    def hset(self, name, key, value):
+        self.commands.append(("hset", name, key, value))
+        return self
+
+    def expire(self, name, ttl):
+        self.commands.append(("expire", name, ttl))
+        return self
+
+    async def execute(self):
+        for command in self.commands:
+            if command[0] == "hset":
+                await self.redis.hset(command[1], command[2], command[3])
+            elif command[0] == "expire":
+                await self.redis.expire(command[1], command[2])
+        return []
+
+
+class _TraceWriterRedis:
+    """Minimal Redis fake for TraceWriteClient.record_trace."""
+
+    def __init__(self):
+        self.data = {}
+        self.expires = {}
+
+    async def hset(self, name, key, value):
+        self.data.setdefault(name, {})[key] = value
+
+    async def zadd(self, name, mapping):
+        self.data.setdefault(name, {}).update(mapping)
+
+    async def expire(self, name, ttl):
+        self.expires[name] = ttl
+        return 1
+
+    def pipeline(self):
+        return _MockPipeline(self)
+
+
+class _AgentIndexFailingRedis(_TraceWriterRedis):
+    """Fails only the trace_index_agent write, to verify trace_meta is
+    independent of it."""
+
+    async def zadd(self, name, mapping):
+        if name == RedisKeys.trace_index_agent("planner"):
+            raise ConnectionError("simulated trace_index_agent write failure")
+        return await super().zadd(name, mapping)
+
+
+@pytest.mark.asyncio
+async def test_record_trace_survives_trace_index_agent_failure():
+    """trace_index_agent is a cross-entity index write, split apart from the
+    trace_meta write. If it fails, trace_meta must still be correctly
+    readable by trace_id, and the unrelated session index must still land."""
+    redis = _AgentIndexFailingRedis()
+    client = TraceWriteClient(redis, ttl_seconds=321)
+
+    await client.record_trace(
+        TraceRecord(
+            trace_id="trace-safe",
+            session_id="sess-safe",
+            root_agent_type="planner",
+            status="OK",
+            start_ts=100,
+            end_ts=150,
+        )
+    )
+
+    assert redis.data[RedisKeys.trace_meta("trace-safe")]["trace_id"] == "trace-safe"
+    assert redis.data[RedisKeys.trace_meta("trace-safe")]["status"] == "OK"
+    assert "trace-safe" in redis.data[RedisKeys.trace_index_session("sess-safe")]
+    assert RedisKeys.trace_index_agent("planner") not in redis.data


### PR DESCRIPTION
## Summary
- **Mode A** (`registry.py`): `set_worker_admin_state`/`clear_worker_admin_state` split into the primary `worker_admin(id)` write plus an independent, best-effort `admin_workers()` index update. A transient index-write failure is logged, not propagated — `worker_admin(id)` remains the source of truth for reads.
- **Mode B** (`span_recorder.py` / `trace_writer.py`): `RedisSpanExporter.export_span` and `TraceWriteClient.record_trace` split the trace group (`trace_meta`+`trace_spans`, same entity, tagged since Phase 2a — stays atomic) from the session/worker/agent lookup indexes (cross-entity, up to 5 different entities in one pipeline today). Indexes are now written independently, each individually caught and logged, so an index write failure can no longer wipe out the trace record that already landed.
- `deny_worker_for_type` is explicitly untouched — `agent_type_members`/`agent_type_denied` already share a Cluster hash tag from Phase 2a and keep their atomic write.

## Test plan
- [x] New test: `set_worker_admin_state`/`clear_worker_admin_state` survive a simulated `admin_workers()` index write failure — the `worker_admin(id)` write/delete still lands and is readable
- [x] New test: `RedisSpanExporter.export_span` survives a simulated `trace_index_worker` failure — `trace_meta`/`trace_spans` still readable by `trace_id`, and the unrelated session/agent indexes still land
- [x] New test: `TraceWriteClient.record_trace` survives a simulated `trace_index_agent` failure — `trace_meta` still readable, unrelated session index still lands
- [x] `uv run pytest` — 535 passed, 1 skipped, 0 failures (pre-existing unrelated flaky `tests/metrics/test_catalog.py` test, confirmed present on `main` before this branch)
- [x] `make format-changed` / `make lint-changed` clean (pylint 10.00/10)

Closes #45