### PR TITLE
Redis cluster support Phase 4: two-phase XREADGROUP split for multi agent_type workers

### DIFF
--- a/src/by_framework/worker/runner.py
+++ b/src/by_framework/worker/runner.py
@@ -108,6 +108,9 @@ class WorkerRunner:
         # Refreshed by the heartbeat thread every heartbeat interval.
         # Avoids per-iteration Redis SISMEMBER calls in the consume loop.
         self._denied_agent_types: frozenset[str] = frozenset()
+        # Round-robin cursor for fetch_messages' phase-two blocking read, so
+        # no agent_type is permanently starved of the blocking slot.
+        self._primary_cursor: int = 0
         self._consumer_last_tick_monotonic = 0.0
         stream_block_seconds = float(WorkerConfig.stream_block_ms) / 1000.0
         self._consumer_health_timeout_seconds = max(
@@ -200,6 +203,17 @@ class WorkerRunner:
         """
         Fetch messages from streams without processing them.
 
+        Two-phase read to stay Cluster-safe: different agent_type ctrl
+        streams are different entities/slots, so they can never be combined
+        into one XREADGROUP call.
+
+        Phase one: concurrent non-blocking XREADGROUP, one call per active
+        stream. If any stream returned messages, return immediately.
+        Phase two: only if every stream came back empty, one blocking
+        XREADGROUP against a single "primary" stream, chosen by round-robin
+        across the declared agent_types so no agent_type is starved of the
+        blocking slot.
+
         Returns:
             List of (stream_name, message_id, data_dict) tuples.
         """
@@ -210,16 +224,41 @@ class WorkerRunner:
             await asyncio.sleep(float(block) / 1000.0)
             return []
 
-        messages = await self.redis.xreadgroup(
+        stream_names = list(streams.keys())
+
+        async def read_nonblocking(stream_name: str):
+            return await self.redis.xreadgroup(
+                groupname=self.group_name,
+                consumername=self.consumer_name,
+                streams={stream_name: STREAM_READ_LAST_ID},
+                count=count,
+            )
+
+        first_pass = await asyncio.gather(
+            *[read_nonblocking(stream_name) for stream_name in stream_names]
+        )
+        results = await self._parse_xreadgroup_results(first_pass)
+        if results:
+            return results
+
+        primary = stream_names[self._primary_cursor % len(stream_names)]
+        self._primary_cursor += 1
+        blocked = await self.redis.xreadgroup(
             groupname=self.group_name,
             consumername=self.consumer_name,
-            streams=streams,
+            streams={primary: STREAM_READ_LAST_ID},
             count=count,
             block=block,
         )
+        return await self._parse_xreadgroup_results([blocked])
 
+    @staticmethod
+    async def _parse_xreadgroup_results(batches: list) -> list[tuple[str, str, dict]]:
+        """Flatten and parse one or more XREADGROUP responses."""
         results = []
-        if messages:
+        for messages in batches:
+            if not messages:
+                continue
             for stream_bytes, msg_list in messages:
                 stream_name = decode_message_id(stream_bytes)
                 for msg_id_bytes, msg_data in msg_list:

--- a/tests/worker/test_fetch_messages.py
+++ b/tests/worker/test_fetch_messages.py
@@ -1,0 +1,133 @@
+"""Tests for WorkerRunner.fetch_messages's two-phase XREADGROUP split.
+
+Phase one: concurrent non-blocking XREADGROUP per active agent_type stream.
+Phase two: only if every stream came back empty, one blocking XREADGROUP
+against a single round-robin "primary" stream.
+
+Every call in both phases targets exactly one stream — this is the
+code-level property that eliminates CROSSSLOT under Cluster (verified at
+the unit level here; a live 3-master Cluster integration test is a
+separate, slow/optional CI job per the issue, not covered in this file).
+"""
+
+from typing import Any
+
+import pytest
+
+from by_framework import GatewayWorker, RedisKeys, WorkerRunner
+
+
+class _FixedAgentTypesWorker(GatewayWorker):
+    """Minimal worker declaring a fixed, ordered list of agent_types."""
+
+    def __init__(self, agent_types: list[str]):
+        super().__init__("worker-1", None, None, None)
+        self._agent_types = agent_types
+
+    def get_agent_types(self) -> list[str]:
+        return self._agent_types
+
+    async def process_command(self, command: Any, context: Any) -> None:
+        pass
+
+
+class ScriptedXreadgroupRedis:
+    """Redis fake that scripts per-stream XREADGROUP responses and records
+    every call's stream set/block value, regardless of concurrent ordering.
+    """
+
+    def __init__(self, responses_by_stream: dict[str, list[Any]] | None = None):
+        self._responses = {k: list(v) for k, v in (responses_by_stream or {}).items()}
+        self.calls: list[dict[str, Any]] = []
+
+    async def xgroup_create(self, name, groupname, id="0", mkstream=False):
+        pass
+
+    async def xreadgroup(self, groupname, consumername, streams, count=1, block=None):
+        self.calls.append({"streams": dict(streams), "count": count, "block": block})
+        queue = None
+        for stream_name in streams:
+            queue = self._responses.get(stream_name)
+            if queue:
+                return queue.pop(0)
+        return []
+
+    async def xack(self, name, groupname, *ids):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_fetch_messages_phase_one_returns_immediately_without_blocking():
+    """If any active stream has a message, fetch_messages returns it via the
+    non-blocking phase-one scan — every call is single-stream, no `block`."""
+    redis_mock = ScriptedXreadgroupRedis(
+        {
+            RedisKeys.ctrl_stream("agent-b"): [
+                [
+                    [
+                        RedisKeys.ctrl_stream("agent-b").encode(),
+                        [(b"1-0", {b"data": b'{"foo": "bar"}'})],
+                    ]
+                ]
+            ]
+        }
+    )
+    worker = _FixedAgentTypesWorker(["agent-a", "agent-b"])
+    runner = WorkerRunner(
+        redis_client=redis_mock, worker=worker, group_name="test_group"
+    )
+
+    messages = await runner.fetch_messages()
+
+    assert len(messages) == 1
+    assert messages[0][0] == RedisKeys.ctrl_stream("agent-b")
+    assert len(redis_mock.calls) == 2  # one non-blocking call per active stream
+    for call in redis_mock.calls:
+        assert len(call["streams"]) == 1
+        assert call["block"] is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_messages_falls_back_to_single_blocking_primary_when_all_empty():
+    """When every stream comes back empty in phase one, exactly one more
+    call happens: a single-stream blocking read against the primary."""
+    redis_mock = ScriptedXreadgroupRedis()
+    worker = _FixedAgentTypesWorker(["agent-a", "agent-b"])
+    runner = WorkerRunner(
+        redis_client=redis_mock, worker=worker, group_name="test_group"
+    )
+
+    messages = await runner.fetch_messages(block=5000)
+
+    assert messages == []
+    assert len(redis_mock.calls) == 3  # 2 non-blocking + 1 blocking
+    non_blocking_calls = [c for c in redis_mock.calls if c["block"] is None]
+    blocking_calls = [c for c in redis_mock.calls if c["block"] is not None]
+    assert len(non_blocking_calls) == 2
+    assert len(blocking_calls) == 1
+    assert blocking_calls[0]["block"] == 5000
+    assert len(blocking_calls[0]["streams"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_messages_round_robins_the_blocking_primary():
+    """Across successive empty rounds, the primary used for the phase-two
+    blocking read rotates through every declared agent_type before any one
+    repeats, so no agent_type is starved of the blocking slot."""
+    redis_mock = ScriptedXreadgroupRedis()
+    worker = _FixedAgentTypesWorker(["agent-a", "agent-b", "agent-c"])
+    runner = WorkerRunner(
+        redis_client=redis_mock, worker=worker, group_name="test_group"
+    )
+
+    primaries = []
+    for _ in range(3):
+        await runner.fetch_messages()
+        blocking_calls = [c for c in redis_mock.calls if c["block"] is not None]
+        primaries.append(next(iter(blocking_calls[-1]["streams"])))
+
+    assert set(primaries) == {
+        RedisKeys.ctrl_stream("agent-a"),
+        RedisKeys.ctrl_stream("agent-b"),
+        RedisKeys.ctrl_stream("agent-c"),
+    }


### PR DESCRIPTION
## Summary
- `WorkerRunner.fetch_messages` replaced its single multi-stream blocking `XREADGROUP` (mixing every active `agent_type` ctrl stream + one shared `BLOCK` — CROSSSLOT-prone under Cluster, since each `agent_type` is a different entity/slot) with a two-phase read:
  1. **Phase one**: concurrent non-blocking `XREADGROUP`, one call per active stream (no `BLOCK` at all — not the same as `BLOCK 0`). Returns immediately if any stream had messages.
  2. **Phase two**: only if every stream came back empty, one blocking `XREADGROUP` against a single "primary" stream, chosen by round-robin across the declared `agent_type`s so no `agent_type` is starved of the blocking slot.
- Every `XREADGROUP` call in both phases now targets exactly one stream — the property that actually eliminates CROSSSLOT.
- `COUNT` semantics unchanged (still per-stream, same `N × count` ceiling as before the split).

## Test plan
- [x] Phase-one non-blocking scan: returns immediately when any stream has a message; every call is single-stream with no `block`
- [x] Phase-two fallback: exactly one further call when all streams are empty — single-stream, blocking, against the primary
- [x] Round-robin: primary rotates through every declared `agent_type` across successive empty rounds before repeating
- [x] `uv run pytest` — 538 passed, 1 skipped, 0 failures (pre-existing unrelated flaky `tests/metrics/test_catalog.py` test, confirmed present on `main` before this branch)
- [x] `make format-changed` / `make lint-changed` clean (pylint 10.00/10)

**Not covered here** (per the issue's own scope): the live 3-master Redis Cluster integration test verifying no real CROSSSLOT errors is a separate, slow/optional CI job — no Cluster environment was available to stand up for this PR. Coverage above is at the unit level (single-stream/no-block guarantee), which is the actual code property CROSSSLOT depends on.

Closes #46