### PR TITLE
Redis cluster support Phase 5: cluster-aware SCAN + gather-based batch admin state reads

### DIFF
--- a/src/by_framework/metrics/snapshot.py
+++ b/src/by_framework/metrics/snapshot.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 from by_framework.common.constants import RedisKeys
+from by_framework.common.logger import logger
 from by_framework.common.redis_client import Redis, get_redis
 from by_framework.core.registry import WorkerRegistry
 
@@ -1200,41 +1201,44 @@ async def _get_observable_workers(
     }
 
 
+async def _cluster_aware_scan_ids_by_prefix(
+    redis: Redis, prefix: str, scan_limit: int
+) -> tuple[list[str], bool]:
+    """Enumerate key-name suffixes matching `{prefix}*` via SCAN.
+
+    SCAN is a single-node command in standalone Redis, but
+    `redis.asyncio.cluster.RedisCluster.scan_iter()` (verified against the
+    pinned redis-py version's source) already targets every primary node
+    and merges each node's cursor internally, so no manual per-node
+    iteration is needed here — this helper just needs to call `scan_iter`
+    and every by-framework-supported client (standalone or cluster)
+    provides it.
+
+    Used by all metrics/snapshot.py code that needs to enumerate Redis
+    keys by prefix, instead of each call site reimplementing this.
+    """
+    pattern = f"{prefix}*"
+    limit = max(scan_limit, 0)
+    ids: list[str] = []
+    scan_iter = getattr(redis, "scan_iter", None)
+    if not callable(scan_iter):
+        return [], False
+
+    async for key in scan_iter(match=pattern, count=max(limit or 100, 100)):
+        key_text = key.decode("utf-8") if isinstance(key, bytes) else str(key)
+        if key_text.startswith(prefix):
+            ids.append(key_text.removeprefix(prefix))
+        if limit and len(ids) >= limit:
+            break
+    return sorted(set(ids)), True
+
+
 async def _scan_online_worker_ids(
     redis: Redis, scan_limit: int
 ) -> tuple[list[str], bool]:
-    prefix = RedisKeys.worker_online_lease("")
-    pattern = f"{prefix}*"
-    limit = max(scan_limit, 0)
-    worker_ids: list[str] = []
-    scan_iter = getattr(redis, "scan_iter", None)
-    if callable(scan_iter):
-        async for key in scan_iter(match=pattern, count=max(limit or 100, 100)):
-            key_text = key.decode("utf-8") if isinstance(key, bytes) else str(key)
-            if key_text.startswith(prefix):
-                worker_ids.append(key_text.removeprefix(prefix))
-            if limit and len(worker_ids) >= limit:
-                break
-        return sorted(set(worker_ids)), True
-
-    scan = getattr(redis, "scan", None)
-    if not callable(scan):
-        return [], False
-
-    cursor: int | str = 0
-    while True:
-        cursor, keys = await scan(
-            cursor=cursor, match=pattern, count=max(limit or 100, 100)
-        )
-        for key in keys:
-            key_text = key.decode("utf-8") if isinstance(key, bytes) else str(key)
-            if key_text.startswith(prefix):
-                worker_ids.append(key_text.removeprefix(prefix))
-            if limit and len(worker_ids) >= limit:
-                return sorted(set(worker_ids)), True
-        if str(cursor) == "0":
-            break
-    return sorted(set(worker_ids)), True
+    return await _cluster_aware_scan_ids_by_prefix(
+        redis, RedisKeys.worker_online_lease(""), scan_limit
+    )
 
 
 async def _get_admin_managed_worker_ids(
@@ -1247,7 +1251,9 @@ async def _get_admin_managed_worker_ids(
         item.decode("utf-8") if isinstance(item, bytes) else str(item)
         for item in indexed_raw
     }
-    scanned_ids, scan_supported = await _scan_worker_admin_ids(redis, scan_limit)
+    scanned_ids, scan_supported = await _cluster_aware_scan_ids_by_prefix(
+        redis, RedisKeys.worker_admin(""), scan_limit
+    )
     worker_ids = sorted(indexed_ids | set(scanned_ids))
     limited_ids = worker_ids[: max(scan_limit, 0)] if scan_limit else worker_ids
     return limited_ids, {
@@ -1258,44 +1264,6 @@ async def _get_admin_managed_worker_ids(
         "returned_workers": len(limited_ids),
         "truncated": len(worker_ids) > len(limited_ids),
     }
-
-
-async def _scan_worker_admin_ids(
-    redis: Redis,
-    scan_limit: int,
-) -> tuple[list[str], bool]:
-    prefix = RedisKeys.worker_admin("")
-    pattern = f"{prefix}*"
-    limit = max(scan_limit, 0)
-    worker_ids: list[str] = []
-    scan_iter = getattr(redis, "scan_iter", None)
-    if callable(scan_iter):
-        async for key in scan_iter(match=pattern, count=max(limit or 100, 100)):
-            key_text = key.decode("utf-8") if isinstance(key, bytes) else str(key)
-            if key_text.startswith(prefix):
-                worker_ids.append(key_text.removeprefix(prefix))
-            if limit and len(worker_ids) >= limit:
-                break
-        return sorted(set(worker_ids)), True
-
-    scan = getattr(redis, "scan", None)
-    if not callable(scan):
-        return [], False
-
-    cursor: int | str = 0
-    while True:
-        cursor, keys = await scan(
-            cursor=cursor, match=pattern, count=max(limit or 100, 100)
-        )
-        for key in keys:
-            key_text = key.decode("utf-8") if isinstance(key, bytes) else str(key)
-            if key_text.startswith(prefix):
-                worker_ids.append(key_text.removeprefix(prefix))
-            if limit and len(worker_ids) >= limit:
-                return sorted(set(worker_ids)), True
-        if str(cursor) == "0":
-            break
-    return sorted(set(worker_ids)), True
 
 
 def _decode_worker_presence_for_snapshot(raw: Any) -> tuple[int, bool]:
@@ -1317,17 +1285,30 @@ def _decode_worker_presence_for_snapshot(raw: Any) -> tuple[int, bool]:
 async def _batch_fetch_admin_states(
     redis: Redis, worker_ids: list[str]
 ) -> dict[str, dict[str, Any]]:
-    """Pipeline-fetch admin state HASHes for all workers in one round-trip."""
+    """Concurrently fetch admin state HASHes for all workers.
+
+    worker_admin(id) keys belong to different worker entities, so bundling
+    them into one pipeline is a cross-entity, CROSSSLOT-prone operation
+    under Cluster. Each worker's read is issued independently instead, so
+    a single worker's read failure can't take down the whole batch.
+    """
     if not worker_ids:
         return {}
-    pipe = redis.pipeline()
-    for wid in worker_ids:
-        pipe.hgetall(RedisKeys.worker_admin(wid))
-    results = await pipe.execute()
-    return {
-        worker_id: _decode_hash_mapping(raw)
-        for worker_id, raw in zip(worker_ids, results)
-    }
+
+    async def _fetch_one(worker_id: str) -> dict[str, Any]:
+        try:
+            raw = await redis.hgetall(RedisKeys.worker_admin(worker_id))
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.warning(
+                "_batch_fetch_admin_states: read failed for %s",
+                worker_id,
+                exc_info=True,
+            )
+            return {}
+        return _decode_hash_mapping(raw)
+
+    results = await asyncio.gather(*[_fetch_one(wid) for wid in worker_ids])
+    return dict(zip(worker_ids, results))
 
 
 def _decode_hash_mapping(raw: Any) -> dict[str, Any]:

--- a/tests/metrics/test_snapshot.py
+++ b/tests/metrics/test_snapshot.py
@@ -529,6 +529,30 @@ async def test_split_worker_snapshot_prefers_online_lease_scan():
 
 
 @pytest.mark.asyncio
+async def test_worker_snapshot_discovers_admin_worker_via_scan():
+    """Admin-managed workers are discoverable via the cluster-aware scan
+    helper too, not only via the admin_workers() index set — exercising
+    the same scan_iter path _scan_online_worker_ids already uses."""
+    redis = StreamAwareRedis()
+
+    async def scan_iter(match=None, count=None):
+        del match, count
+        yield RedisKeys.worker_admin("worker-scanned")
+
+    redis.scan_iter = scan_iter
+    await redis.hset(
+        RedisKeys.worker_admin("worker-scanned"),
+        mapping={"lifecycle": "suspended", "reason": "scanned"},
+    )
+
+    snapshot = await build_worker_observability_snapshot(redis)
+
+    assert snapshot["worker_scan"]["admin"]["source"] == "admin_index_and_scan"
+    summaries = {worker["worker_id"]: worker for worker in snapshot["workers"]}
+    assert summaries["worker-scanned"]["lifecycle"] == "suspended"
+
+
+@pytest.mark.asyncio
 async def test_worker_snapshot_includes_offline_evicted_admin_worker():
     """Worker endpoint includes evicted workers even after online lease is gone."""
     redis = StreamAwareRedis()
@@ -546,6 +570,36 @@ async def test_worker_snapshot_includes_offline_evicted_admin_worker():
     assert worker["lifecycle_reason"] == "decommission"
     assert worker["last_seen"] == 0
     assert worker["agent_types"] == []
+
+
+@pytest.mark.asyncio
+async def test_worker_snapshot_survives_one_worker_admin_state_read_failure():
+    """A read failure for one worker's worker_admin(id) hash must not
+    prevent the other workers' admin states (or the whole snapshot) from
+    being returned. worker_admin(id) keys belong to different worker
+    entities, so batch-fetching them must not be one all-or-nothing
+    pipeline (a cross-entity CROSSSLOT hazard under Cluster) — each
+    worker's read is independent."""
+
+    class FailingAdminStateRedis(StreamAwareRedis):
+
+        async def hgetall(self, name):
+            if name == RedisKeys.worker_admin("worker-bad"):
+                raise ConnectionError("simulated worker_admin read failure")
+            return await super().hgetall(name)
+
+    redis = FailingAdminStateRedis()
+    registry = WorkerRegistry(redis)
+    await registry.set_worker_admin_state("worker-ok", "suspended", reason="test")
+    await registry.set_worker_admin_state("worker-bad", "suspended", reason="test")
+
+    snapshot = await build_worker_observability_snapshot(redis)
+
+    summaries = {worker["worker_id"]: worker for worker in snapshot["workers"]}
+    assert summaries["worker-ok"]["lifecycle"] == "suspended"
+    # worker-bad's read failed: falls back to the default "active" lifecycle
+    # rather than taking down the whole snapshot.
+    assert summaries["worker-bad"]["lifecycle"] == "active"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Verified against the actually-pinned `redis==7.4.0` source (not assumed): `RedisCluster.scan_iter()` already targets every primary node — `SCAN`'s default cluster command-routing policy is `PRIMARIES` (see `redis/cluster.py`'s command mapping), and `scan_iter()` loops each node's cursor until it hits 0, merging results as it yields. No manual per-node iteration/merge is needed.
- Consolidated the two duplicated `scan_iter`-or-manual-cursor-loop implementations (`_scan_online_worker_ids`, `_scan_worker_admin_ids`) into one shared `_cluster_aware_scan_ids_by_prefix` helper, and dropped the untested manual `.scan()` fallback branch — it mishandled `RedisCluster.scan()`'s per-node cursor-dict return shape (expects a scalar cursor) and was unreachable in practice, since every by-framework-supported client (standalone or cluster) exposes `scan_iter`.
- `_batch_fetch_admin_states` bundled every worker's `worker_admin(id)` read into one pipeline — a cross-entity, CROSSSLOT-prone operation under Cluster, and all-or-nothing: today a single worker's read failure took down the whole batch. Converted to `asyncio.gather` of independent per-worker reads, each individually caught and logged, falling back to `{}` (default "active" lifecycle) on failure instead of failing the whole snapshot.

## Test plan
- [x] New test: a worker's `worker_admin(id)` read failure no longer takes down the whole `build_worker_observability_snapshot` call — the other worker's admin state is still returned correctly
- [x] New test: admin-managed workers are discoverable via the scan path too (`_scan_worker_admin_ids`'s `scan_iter` branch), not just via the `admin_workers()` index — this path had zero test coverage before
- [x] `uv run pytest` — 540 passed, 1 skipped, 0 failures (pre-existing unrelated flaky `tests/metrics/test_catalog.py` test, confirmed present on `main` before this branch)
- [x] `make format-changed` / `make lint-changed` clean (pylint 10.00/10)

Closes #47