### PR TITLE
feat(emitter): add object_type and status fields to stream chunk events

### DIFF
--- a/src/by_framework/common/emitter.py
+++ b/src/by_framework/common/emitter.py
@@ -36,6 +36,8 @@ class DataLayoutBuilder(Protocol):
         tool_responses: Optional[List[Dict[str, Any]]] = None,
         order_id: Optional[str] = None,
         parent_order_id: Optional[str] = None,
+        object_type: Optional[str] = None,
+        status: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Build the event data payload."""
         raise NotImplementedError
@@ -66,6 +68,8 @@ class DefaultSseLayoutBuilder(DataLayoutBuilder):
         tool_responses: Optional[List[Dict[str, Any]]] = None,
         order_id: Optional[str] = None,
         parent_order_id: Optional[str] = None,
+        object_type: Optional[str] = None,
+        status: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Build deep structure compatible with native BaiYingChatCompletion."""
         return {
@@ -77,6 +81,8 @@ class DefaultSseLayoutBuilder(DataLayoutBuilder):
             "agentId": source_agent_type if source_agent_type else None,
             "orderId": order_id,
             "parentOrderId": parent_order_id,
+            "objectType": object_type,
+            "status": status,
             "choices": [
                 {
                     "index": 0,
@@ -192,6 +198,8 @@ class GatewayDataEmitter:
         parent_message_id: str = "",
         event_type: Optional[str] = None,
         content_type: Optional[str] = None,
+        object_type: Optional[str] = None,
+        status: Optional[str] = None,
     ) -> None:
         """Emit a stream chunk event."""
         if isinstance(event, str):
@@ -214,6 +222,8 @@ class GatewayDataEmitter:
                 tool_responses=event.tool_responses,
                 order_id=message_id,
                 parent_order_id=parent_message_id,
+                object_type=object_type,
+                status=status,
             ),
             metadata=event.metadata,
         )

--- a/src/by_framework/core/protocol/content_type.py
+++ b/src/by_framework/core/protocol/content_type.py
@@ -23,6 +23,7 @@ class SseMessageType(str, Enum):
 class SseReasonMessageType(str, Enum):
     """SSE reasoning message type enum."""
 
+    json_block = "2020" # tool json arguments
     think_title = "3003"  # thinking process title
     think_sub_title = "3005"  # thinking process subtitle
     think_resource = "3004"  # thinking process reference

--- a/src/by_framework/worker/context.py
+++ b/src/by_framework/worker/context.py
@@ -321,6 +321,8 @@ class AgentContext:
         content_type: Optional[str] = None,
         message_id: Optional[str] = None,
         parent_message_id: Optional[str] = None,
+        object_type: Optional[str] = None,
+        status: Optional[str] = None,
     ) -> None:
         """Emit a streaming chunk event.
 
@@ -378,6 +380,8 @@ class AgentContext:
             parent_message_id=emitted_parent_message_id,
             event_type=event_type,
             content_type=content_type,
+            object_type=object_type,
+            status=status,
         )
 
         # 3. If it's a stream end marker, trigger persistence to history


### PR DESCRIPTION
- Thread object_type and status through AgentContext.emit_chunk, GatewayDataEmitter.emit and DataLayoutBuilder chain
- Add json_block (2020) SseReasonMessageType for tool json arguments

**Main Changes**
Please provide a brief description of the changes introduced by this PR.

**Related Issue**
Fixes # (issue number)

**Type of Change**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor

**Checklist**
- [ ] I have ensured that `make lint` and `make format` pass.
- [ ] I have added necessary unit tests.
- [ ] Local `make test` has passed.
- [ ] I have updated relevant documentation.

**Screenshots/Data**
If it involves UI or performance optimization, please post comparisons.
