### PR TITLE
Redis cluster support: wire cluster mode into worker startup + heartbeat's isolated connection

### DIFF
--- a/src/by_framework/worker/app.py
+++ b/src/by_framework/worker/app.py
@@ -122,14 +122,27 @@ async def _run_worker_async(
             actual_redis_max_conns = max_concurrency + 10
 
     # 2. Establish Redis connection (must be inside event loop)
-    redis_client = init_redis(
-        host=redis_host,
-        port=redis_port,
-        db=redis_db,
-        password=redis_password,
-        username=redis_username,
-        max_connections=actual_redis_max_conns,
-    )
+    from by_framework.common.config import RedisConfig as SDKRedisConfig
+
+    env_config = SDKRedisConfig.from_env()
+    if env_config.mode == "cluster":
+        redis_client = init_redis(
+            config=env_config,
+            max_connections=actual_redis_max_conns,
+        )
+        logger.info(
+            "Worker Redis initialized in Cluster mode (nodes=%s)",
+            env_config.cluster_nodes,
+        )
+    else:
+        redis_client = init_redis(
+            host=redis_host,
+            port=redis_port,
+            db=redis_db,
+            password=redis_password,
+            username=redis_username,
+            max_connections=actual_redis_max_conns,
+        )
 
     # 2.1 Configure history message storage backend
     # The storage backend itself decides which operations are supported

--- a/src/by_framework/worker/heartbeat.py
+++ b/src/by_framework/worker/heartbeat.py
@@ -272,6 +272,32 @@ class WorkerHeartbeat:
     async def _create_isolated_redis(self) -> Optional[Redis]:
         """Create a fresh Redis connection for the heartbeat thread."""
         try:
+            from redis.asyncio.cluster import RedisCluster
+
+            if isinstance(self.redis, RedisCluster):
+                import inspect
+
+                conn_kwargs = dict(self.redis.connection_kwargs)
+                # RedisCluster.connection_kwargs carries extra keys (e.g.
+                # connection_class, response_callbacks) that aren't valid
+                # RedisCluster.__init__ params and would raise "unexpected
+                # keyword argument" if passed through unfiltered.
+                sig = inspect.signature(RedisCluster.__init__)
+                valid_params = set(sig.parameters.keys())
+                conn_kwargs = {
+                    k: v for k, v in conn_kwargs.items() if k in valid_params
+                }
+
+                for key in (
+                    "retry",
+                    "retry_on_timeout",
+                    "retry_on_error",
+                    "response_callbacks",
+                ):
+                    conn_kwargs.pop(key, None)
+                startup_nodes = list(self.redis.nodes_manager.startup_nodes.values())
+                return RedisCluster(startup_nodes=startup_nodes, **conn_kwargs)
+
             if not hasattr(self.redis, "connection_pool"):
                 return None
             pool = self.redis.connection_pool

--- a/tests/worker/test_app.py
+++ b/tests/worker/test_app.py
@@ -108,6 +108,46 @@ async def test_run_worker_async_flow():
 
 
 @pytest.mark.asyncio
+async def test_run_worker_async_initializes_cluster_client_when_mode_is_cluster():
+    """REDIS_MODE=cluster must route init_redis through config=, not the
+    individual host/port args, so REDIS_CLUSTER_NODES is actually honored."""
+    with (
+        patch.dict(
+            "os.environ",
+            {"REDIS_MODE": "cluster", "REDIS_CLUSTER_NODES": "h1:6379,h2:6380"},
+            clear=False,
+        ),
+        patch("by_framework.worker.app.init_redis") as mock_init_redis,
+        patch("by_framework.worker.app.close_redis", new_callable=AsyncMock),
+        patch("by_framework.worker.app.WorkerRegistry"),
+        patch("by_framework.worker.app.WorkspaceManager"),
+        patch("by_framework.worker.app.WorkerRunner") as mock_runner,
+    ):
+        mock_init_redis.return_value = MagicMock()
+        mock_runner.return_value.start = AsyncMock()
+
+        await _run_worker_async(
+            worker_class=MyTestWorker,
+            worker_id="test-w1",
+            redis_host="localhost",
+            redis_port=6379,
+            redis_db=0,
+            redis_password=None,
+            redis_username=None,
+            workspace_dir="/tmp/test-ws",
+            consumer_group="test-group",
+            max_concurrency=10,
+            fetch_count=5,
+        )
+
+        mock_init_redis.assert_called_once()
+        _, kwargs = mock_init_redis.call_args
+        assert "config" in kwargs
+        assert kwargs["config"].mode == "cluster"
+        assert kwargs["config"].cluster_nodes == [("h1", 6379), ("h2", 6380)]
+
+
+@pytest.mark.asyncio
 async def test_run_worker_async_attaches_layout_builder():
     """Verify _run_worker_async wires layout_builder onto the worker."""
     layout_builder = CustomLayoutBuilder()

--- a/tests/worker/test_heartbeat.py
+++ b/tests/worker/test_heartbeat.py
@@ -6,6 +6,8 @@ import asyncio
 import unittest
 from unittest.mock import AsyncMock, Mock
 
+from redis.asyncio.cluster import ClusterNode, RedisCluster
+
 from by_framework.worker.heartbeat import WorkerHeartbeat
 
 
@@ -57,6 +59,33 @@ class TestWorkerHeartbeat(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(heartbeat.interval, 15)
         self.assertEqual(heartbeat.lease_ttl_seconds, 30)
         self.assertIsNone(heartbeat._task)
+
+    async def test_create_isolated_redis_clones_a_cluster_client(self):
+        """The heartbeat thread needs its own Redis connection, cloned from
+        the main client's connection parameters. Under Cluster mode, this
+        must return a fresh RedisCluster (not None, and not crash on
+        constructor-invalid kwargs like connection_class/response_callbacks
+        that RedisCluster.connection_kwargs carries but __init__ doesn't
+        accept)."""
+        cluster_redis = RedisCluster(
+            startup_nodes=[ClusterNode("h1", 6379), ClusterNode("h2", 6380)],
+            password="secret",
+            decode_responses=True,
+        )
+        mock_registry = MockRegistry()
+        heartbeat = WorkerHeartbeat(
+            worker_id="worker-1",
+            agent_types=["agent-a"],
+            redis_client=cluster_redis,
+            registry=mock_registry,
+        )
+
+        isolated = await heartbeat._create_isolated_redis()
+
+        self.assertIsInstance(isolated, RedisCluster)
+        self.assertIsNot(isolated, cluster_redis)
+        self.assertEqual(isolated.connection_kwargs.get("password"), "secret")
+        self.assertTrue(isolated.connection_kwargs.get("decode_responses"))
 
     async def test_start_initial_registration(self):
         """Test that start() performs initial registration."""


### PR DESCRIPTION
## Summary
- `worker/app.py`'s `_run_worker_async()` now reads `RedisConfig.from_env()` at startup: when `REDIS_MODE=cluster`, it initializes via `init_redis(config=env_config, ...)` (respecting `REDIS_CLUSTER_NODES`) instead of the individual `redis_host`/`redis_port`/etc. args, which are hardcoded literal defaults and were never env-aware. Before this, setting `REDIS_MODE=cluster` had zero effect on the actual worker process.
- `worker/heartbeat.py`'s `WorkerHeartbeat._create_isolated_redis()` — the heartbeat thread needs its own Redis connection cloned from the main client (can't share a connection across event loops/threads). It only handled standalone `Redis` before; for a `RedisCluster` client (no `.connection_pool`) it silently returned `None`, meaning the heartbeat thread failed to start under cluster mode. Now clones via `connection_kwargs` + `nodes_manager.startup_nodes`, filtered to `RedisCluster.__init__`'s actual valid parameter names — `connection_kwargs` carries extra keys (`connection_class`, `response_callbacks`) that aren't valid constructor params and would otherwise raise "unexpected keyword argument".

Verified both against the pinned `redis==7.4.0` source (not assumed): `RedisCluster.connection_kwargs` and `nodes_manager.startup_nodes` are real attributes with the expected shapes, commands lazily call `self.initialize()` on first use (no separate init step needed), and standalone `Redis`'s `connection_pool.connection_kwargs` never contains the constructor-invalid keys in the first place (confirming why the pre-existing standalone branch didn't need the same filtering).

## Test plan
- [x] New test: `REDIS_MODE=cluster` + `REDIS_CLUSTER_NODES` routes `init_redis` through `config=` with the right `mode`/`cluster_nodes`, not the individual host/port args
- [x] New test: `_create_isolated_redis()` returns a working cloned `RedisCluster` (not `None`) when `self.redis` is a `RedisCluster` instance, preserving credentials/`decode_responses` — confirmed this test genuinely fails against the pre-fix code (`assertIsInstance` fails with `None`) and passes with the fix
- [x] `uv run pytest` — 542 passed, 1 skipped, 0 failures (pre-existing unrelated flaky `tests/metrics/test_catalog.py` test, confirmed present on `main` before this branch)
- [x] `make format-changed` / `make lint-changed` clean (pylint 10.00/10)

## Known follow-up (not blocking, tracked in the issue)
`app.py`'s cluster branch reads Redis config purely from `RedisConfig.from_env()`, ignoring any explicitly-passed `redis_host`/`redis_password`/etc. function arguments. Acceptable for now since `run_worker()` has no `cluster_nodes` parameter to pass explicitly anyway.

Closes #56