### PR TITLE
Fix v2 scan-prefix mismatch and config/max_connections override bugs

### DIFF
--- a/src/by_framework/common/constants.py
+++ b/src/by_framework/common/constants.py
@@ -6,6 +6,7 @@ are centrally managed in this file. Do not hardcode literal strings in business 
 """
 
 import os
+from typing import Optional
 
 
 def get_key_schema_version() -> str:
@@ -43,6 +44,37 @@ class RedisKeys:
         if get_key_schema_version() == "v2":
             return f"{cls.V2_PREFIX}{v2_suffix}"
         return v1_key
+
+    @classmethod
+    def _worker_scan_pattern(cls, v1_prefix: str, v2_field: str) -> str:
+        """SCAN MATCH glob pattern matching every worker key in this family.
+
+        Under v1 the worker_id is the last path segment (prefix + id, no
+        suffix). Under v2 it's wrapped in a Cluster hash tag in the middle
+        of the key (prefix + "{" + id + "}" + suffix) — a bare "{prefix}*"
+        pattern (or a str.startswith("{prefix}") check) would never match a
+        real v2 key, since "{"/"}" are literal characters in Redis's glob
+        matching (only *, ?, [seq] are special), not wildcards.
+        """
+        if get_key_schema_version() == "v2":
+            return f"{cls.V2_PREFIX}registry:worker:{{*}}:{v2_field}"
+        return f"{v1_prefix}*"
+
+    @classmethod
+    def _worker_id_from_scanned_key(
+        cls, key: str, v1_prefix: str, v2_field: str
+    ) -> Optional[str]:
+        """Extract worker_id from a key returned by scanning with the
+        pattern from _worker_scan_pattern(v1_prefix, v2_field)."""
+        if get_key_schema_version() == "v2":
+            prefix = f"{cls.V2_PREFIX}registry:worker:{{"
+            suffix = f"}}:{v2_field}"
+            if key.startswith(prefix) and key.endswith(suffix):
+                return key[len(prefix) : -len(suffix)]
+            return None
+        if key.startswith(v1_prefix):
+            return key[len(v1_prefix) :]
+        return None
 
     # --- Queues and Streams ---
     @classmethod
@@ -319,6 +351,20 @@ class RedisKeys:
         )
 
     @classmethod
+    def worker_online_lease_scan_pattern(cls) -> str:
+        """SCAN MATCH glob pattern matching every worker_online_lease key."""
+        return cls._worker_scan_pattern(
+            "byai_gateway:registry:worker:online:", "online"
+        )
+
+    @classmethod
+    def worker_id_from_online_lease_key(cls, key: str) -> Optional[str]:
+        """Extract worker_id from a key found via worker_online_lease_scan_pattern()."""
+        return cls._worker_id_from_scanned_key(
+            key, "byai_gateway:registry:worker:online:", "online"
+        )
+
+    @classmethod
     def worker_status(cls, worker_id: str) -> str:
         """HASH storing aggregate execution counters for a Worker."""
         return cls._versioned(
@@ -377,6 +423,18 @@ class RedisKeys:
         return cls._versioned(
             v1_key=f"byai_gateway:registry:worker:admin:{worker_id}",
             v2_suffix=f"registry:worker:{{{worker_id}}}:admin",
+        )
+
+    @classmethod
+    def worker_admin_scan_pattern(cls) -> str:
+        """SCAN MATCH glob pattern matching every worker_admin key."""
+        return cls._worker_scan_pattern("byai_gateway:registry:worker:admin:", "admin")
+
+    @classmethod
+    def worker_id_from_admin_key(cls, key: str) -> Optional[str]:
+        """Extract worker_id from a key found via worker_admin_scan_pattern()."""
+        return cls._worker_id_from_scanned_key(
+            key, "byai_gateway:registry:worker:admin:", "admin"
         )
 
     @classmethod

--- a/src/by_framework/common/redis_client.py
+++ b/src/by_framework/common/redis_client.py
@@ -52,7 +52,11 @@ def init_redis(
             password = config.password or None
             username = config.username
             decode_responses = config.decode_responses
-            max_connections = config.max_connections
+            # config.max_connections of None means "not specified" - don't
+            # let it silently discard an explicitly-passed max_connections
+            # kwarg (e.g. worker/app.py's max_concurrency-derived value).
+            if config.max_connections is not None:
+                max_connections = config.max_connections
 
             if config.mode == "cluster" and get_key_schema_version() != "v2":
                 raise RedisConnectionError(

--- a/src/by_framework/metrics/snapshot.py
+++ b/src/by_framework/metrics/snapshot.py
@@ -8,7 +8,7 @@ import asyncio
 import json
 import time
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from by_framework.common.constants import RedisKeys
 from by_framework.common.logger import logger
@@ -1201,10 +1201,13 @@ async def _get_observable_workers(
     }
 
 
-async def _cluster_aware_scan_ids_by_prefix(
-    redis: Redis, prefix: str, scan_limit: int
+async def _cluster_aware_scan_ids(
+    redis: Redis,
+    pattern: str,
+    parse_id: Callable[[str], Optional[str]],
+    scan_limit: int,
 ) -> tuple[list[str], bool]:
-    """Enumerate key-name suffixes matching `{prefix}*` via SCAN.
+    """Enumerate IDs matching `pattern` via SCAN, extracted with `parse_id`.
 
     SCAN is a single-node command in standalone Redis, but
     `redis.asyncio.cluster.RedisCluster.scan_iter()` (verified against the
@@ -1214,10 +1217,15 @@ async def _cluster_aware_scan_ids_by_prefix(
     and every by-framework-supported client (standalone or cluster)
     provides it.
 
+    `pattern`/`parse_id` must come from a matching pair of RedisKeys
+    methods (e.g. `worker_online_lease_scan_pattern`/
+    `worker_id_from_online_lease_key`) — a bare prefix + str.startswith
+    doesn't work under v2, since the ID is wrapped in a Cluster hash tag
+    in the middle of the key, not appended at the end.
+
     Used by all metrics/snapshot.py code that needs to enumerate Redis
-    keys by prefix, instead of each call site reimplementing this.
+    keys by pattern, instead of each call site reimplementing this.
     """
-    pattern = f"{prefix}*"
     limit = max(scan_limit, 0)
     ids: list[str] = []
     scan_iter = getattr(redis, "scan_iter", None)
@@ -1226,8 +1234,9 @@ async def _cluster_aware_scan_ids_by_prefix(
 
     async for key in scan_iter(match=pattern, count=max(limit or 100, 100)):
         key_text = key.decode("utf-8") if isinstance(key, bytes) else str(key)
-        if key_text.startswith(prefix):
-            ids.append(key_text.removeprefix(prefix))
+        parsed_id = parse_id(key_text)
+        if parsed_id is not None:
+            ids.append(parsed_id)
         if limit and len(ids) >= limit:
             break
     return sorted(set(ids)), True
@@ -1236,8 +1245,11 @@ async def _cluster_aware_scan_ids_by_prefix(
 async def _scan_online_worker_ids(
     redis: Redis, scan_limit: int
 ) -> tuple[list[str], bool]:
-    return await _cluster_aware_scan_ids_by_prefix(
-        redis, RedisKeys.worker_online_lease(""), scan_limit
+    return await _cluster_aware_scan_ids(
+        redis,
+        RedisKeys.worker_online_lease_scan_pattern(),
+        RedisKeys.worker_id_from_online_lease_key,
+        scan_limit,
     )
 
 
@@ -1251,8 +1263,11 @@ async def _get_admin_managed_worker_ids(
         item.decode("utf-8") if isinstance(item, bytes) else str(item)
         for item in indexed_raw
     }
-    scanned_ids, scan_supported = await _cluster_aware_scan_ids_by_prefix(
-        redis, RedisKeys.worker_admin(""), scan_limit
+    scanned_ids, scan_supported = await _cluster_aware_scan_ids(
+        redis,
+        RedisKeys.worker_admin_scan_pattern(),
+        RedisKeys.worker_id_from_admin_key,
+        scan_limit,
     )
     worker_ids = sorted(indexed_ids | set(scanned_ids))
     limited_ids = worker_ids[: max(scan_limit, 0)] if scan_limit else worker_ids

--- a/tests/common/test_constants.py
+++ b/tests/common/test_constants.py
@@ -2,6 +2,7 @@
 Tests for by_framework.common.constants module.
 """
 
+import fnmatch
 import os
 import unittest
 
@@ -24,6 +25,48 @@ class _KeySchemaVersionTestCase(unittest.TestCase):
 
     def set_schema_version(self, version: str) -> None:
         os.environ["REDIS_KEY_SCHEMA_VERSION"] = version
+
+
+class TestRedisKeysWorkerScanPatterns(_KeySchemaVersionTestCase):
+    """Tests for the SCAN-based worker discovery helpers under v1/v2.
+
+    Redis's SCAN/KEYS MATCH glob only treats `*`, `?`, `[seq]` as special —
+    `{`/`}` are literal characters, same as Python's fnmatch semantics used
+    here as a faithful proxy for "would Redis actually match this pattern"
+    without needing a real server.
+    """
+
+    def test_online_lease_scan_pattern_matches_a_real_v1_key(self):
+        self.set_schema_version("v1")
+        real_key = RedisKeys.worker_online_lease("worker-online")
+        pattern = RedisKeys.worker_online_lease_scan_pattern()
+        self.assertTrue(fnmatch.fnmatchcase(real_key, pattern))
+        self.assertEqual(
+            RedisKeys.worker_id_from_online_lease_key(real_key), "worker-online"
+        )
+
+    def test_online_lease_scan_pattern_matches_a_real_v2_key(self):
+        self.set_schema_version("v2")
+        real_key = RedisKeys.worker_online_lease("worker-online")
+        pattern = RedisKeys.worker_online_lease_scan_pattern()
+        self.assertTrue(fnmatch.fnmatchcase(real_key, pattern))
+        self.assertEqual(
+            RedisKeys.worker_id_from_online_lease_key(real_key), "worker-online"
+        )
+
+    def test_admin_scan_pattern_matches_a_real_v1_key(self):
+        self.set_schema_version("v1")
+        real_key = RedisKeys.worker_admin("worker-scanned")
+        pattern = RedisKeys.worker_admin_scan_pattern()
+        self.assertTrue(fnmatch.fnmatchcase(real_key, pattern))
+        self.assertEqual(RedisKeys.worker_id_from_admin_key(real_key), "worker-scanned")
+
+    def test_admin_scan_pattern_matches_a_real_v2_key(self):
+        self.set_schema_version("v2")
+        real_key = RedisKeys.worker_admin("worker-scanned")
+        pattern = RedisKeys.worker_admin_scan_pattern()
+        self.assertTrue(fnmatch.fnmatchcase(real_key, pattern))
+        self.assertEqual(RedisKeys.worker_id_from_admin_key(real_key), "worker-scanned")
 
 
 class TestRedisKeysSameEntityWorkerGroupVersioning(_KeySchemaVersionTestCase):

--- a/tests/common/test_redis_client.py
+++ b/tests/common/test_redis_client.py
@@ -83,6 +83,31 @@ class TestRedisClient(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(kwargs["host"], "redis.example.com")
             self.assertEqual(kwargs["port"], 6380)
 
+    async def test_init_redis_config_none_max_conns_keeps_explicit_kwarg(
+        self,
+    ):
+        """An explicitly-passed max_connections kwarg must win when
+        config.max_connections is None ("not specified"), not be silently
+        discarded — this is what worker/app.py's cluster branch relies on
+        to scale the connection pool with max_concurrency."""
+        with patch("by_framework.common.redis_client.Redis") as mock_redis_cls:
+            init_redis(config=RedisConfig(max_connections=None), max_connections=60)
+
+            _, kwargs = mock_redis_cls.call_args
+            self.assertEqual(kwargs["max_connections"], 60)
+
+    async def test_init_redis_config_max_connections_set_still_wins_over_explicit_kwarg(
+        self,
+    ):
+        """When config.max_connections IS explicitly set, it still takes
+        precedence over a separately-passed max_connections kwarg (config
+        represents the caller's fuller intent when both are given)."""
+        with patch("by_framework.common.redis_client.Redis") as mock_redis_cls:
+            init_redis(config=RedisConfig(max_connections=100), max_connections=60)
+
+            _, kwargs = mock_redis_cls.call_args
+            self.assertEqual(kwargs["max_connections"], 100)
+
     async def test_init_redis_singleton(self):
         """Verify that init_redis returns a singleton."""
         with patch("by_framework.common.redis_client.Redis") as mock_redis_cls:

--- a/tests/metrics/test_snapshot.py
+++ b/tests/metrics/test_snapshot.py
@@ -1,6 +1,8 @@
 """Tests for observability dashboard snapshots."""
 
 import asyncio
+import fnmatch
+from unittest.mock import patch
 
 import pytest
 
@@ -550,6 +552,57 @@ async def test_worker_snapshot_discovers_admin_worker_via_scan():
     assert snapshot["worker_scan"]["admin"]["source"] == "admin_index_and_scan"
     summaries = {worker["worker_id"]: worker for worker in snapshot["workers"]}
     assert summaries["worker-scanned"]["lifecycle"] == "suspended"
+
+
+class _FnmatchScanRedis(StreamAwareRedis):
+    """StreamAwareRedis variant whose scan_iter actually respects the MATCH
+    glob pattern (like real Redis SCAN), instead of ignoring it and always
+    yielding a hardcoded key. Needed to catch bugs in the scan pattern
+    itself, not just in client-side key parsing."""
+
+    async def scan_iter(self, match=None, count=None):
+        del count
+        for key in set(self.kv.keys()) | set(self.data.keys()):
+            if match is None or fnmatch.fnmatchcase(key, match):
+                yield key
+
+
+@pytest.mark.asyncio
+async def test_worker_snapshot_discovers_online_worker_via_scan_under_v2():
+    """Regression: the online-lease scan pattern must actually match real
+    v2-format keys (worker_id wrapped in a Cluster hash tag), both as a
+    SCAN MATCH glob and for client-side worker_id extraction — not just
+    happen to work under the default v1 schema."""
+    with patch.dict("os.environ", {"REDIS_KEY_SCHEMA_VERSION": "v2"}, clear=False):
+        redis = _FnmatchScanRedis()
+        registry = WorkerRegistry(redis)
+        await registry.register_worker_membership("worker-online", ["planner"])
+        await registry.heartbeat_worker("worker-online")
+
+        snapshot = await build_worker_observability_snapshot(redis)
+
+    assert snapshot["worker_scan"]["source"] == "online_lease_scan"
+    assert snapshot["workers"][0]["worker_id"] == "worker-online"
+
+
+@pytest.mark.asyncio
+async def test_worker_snapshot_discovers_admin_worker_via_scan_under_v2():
+    """Same regression, for the admin-worker scan path. Writes the
+    worker_admin hash directly (bypassing the admin_workers() index) so
+    this test only passes if scan discovery itself actually works."""
+    with patch.dict("os.environ", {"REDIS_KEY_SCHEMA_VERSION": "v2"}, clear=False):
+        redis = _FnmatchScanRedis()
+        await redis.hset(
+            RedisKeys.worker_admin("worker-scanned-v2"),
+            mapping={"lifecycle": "suspended", "reason": "scanned"},
+        )
+
+        snapshot = await build_worker_observability_snapshot(redis)
+
+    assert snapshot["worker_scan"]["admin"]["source"] == "admin_index_and_scan"
+    assert snapshot["worker_scan"]["admin"]["scanned_workers"] >= 1
+    summaries = {worker["worker_id"]: worker for worker in snapshot["workers"]}
+    assert summaries["worker-scanned-v2"]["lifecycle"] == "suspended"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Two confirmed correctness bugs, both regressions in already-merged Redis cluster support work, found via independent audit and re-verified against the running code before fixing.

- **Bug 1**: `metrics/snapshot.py`'s worker/admin SCAN discovery built prefixes via `RedisKeys.worker_online_lease("")`/`worker_admin("")`. Under `REDIS_KEY_SCHEMA_VERSION=v2`, an empty worker_id still gets wrapped in a Cluster hash tag, producing e.g. `...:{}:online` — not a valid prefix of the real key `...:{worker-id}:online`, and not a matching `SCAN MATCH` glob on the Redis server either (`{`/`}` are literal in Redis's glob matching, not wildcards). Under Cluster + `v2` this silently made `build_worker_observability_snapshot` report 0 online workers via the scan path even with live lease keys in Redis. My existing tests never caught this because none of them set `REDIS_KEY_SCHEMA_VERSION=v2` — v1 has no hash-tag braces, so the empty-arg trick happened to work there by coincidence.
- **Bug 2**: `init_redis(config=..., max_connections=...)` unconditionally did `max_connections = config.max_connections` whenever a config was passed, silently discarding an explicitly-passed `max_connections` kwarg whenever `config.max_connections` was `None`. `worker/app.py`'s cluster branch hit this in practice — the worker's `max_concurrency`-derived connection pool size was silently dropped whenever `REDIS_MAX_CONNECTIONS` wasn't set via env.

## Fixes
- Added `RedisKeys.worker_online_lease_scan_pattern()`/`worker_id_from_online_lease_key()` and the `worker_admin` equivalents — build a real `SCAN MATCH` glob and correctly parse the worker_id back out for both `v1` and `v2`.
- `_cluster_aware_scan_ids_by_prefix` became `_cluster_aware_scan_ids(pattern, parse_id, ...)`, taking a matching pattern/parser pair from `RedisKeys` instead of a bare prefix computed ad hoc at the call site.
- `init_redis()` only lets `config.max_connections` override an explicit kwarg when it's actually set (not `None`).

## Test plan
- [x] New tests: `worker_online_lease_scan_pattern()`/`worker_admin_scan_pattern()` actually match a real key generated by the corresponding factory method, under both `v1` and `v2` (verified via `fnmatch`, a faithful proxy for Redis's glob-matching semantics — only `*`/`?`/`[seq]` are special in both)
- [x] New tests: `build_worker_observability_snapshot` discovers a real worker via scan under `REDIS_KEY_SCHEMA_VERSION=v2`, using a `scan_iter` fake that actually respects the `MATCH` pattern (unlike the existing fakes, which ignored it and always yielded a hardcoded key) — confirmed these fail against the pre-fix code
- [x] New tests: `init_redis(config=RedisConfig(max_connections=None), max_connections=60)` results in `max_connections=60` being passed through; `config.max_connections` still wins when it's explicitly set
- [x] `uv run pytest` — 550 passed, 1 skipped, 0 failures (pre-existing unrelated flaky `tests/metrics/test_catalog.py` test, confirmed present on `main` before this branch)
- [x] `make format-changed` / `make lint-changed` clean (pylint 10.00/10)

Closes #58