### PR TITLE
Unify run_worker()'s Redis config resolution across standalone and cluster mode

### DIFF
--- a/src/by_framework/worker/app.py
+++ b/src/by_framework/worker/app.py
@@ -3,10 +3,12 @@
 import asyncio
 import inspect
 import pkgutil
+from dataclasses import replace
 from importlib import import_module
 from types import ModuleType
-from typing import Awaitable, Callable, List, Optional, Type, Union
+from typing import (Awaitable, Callable, List, Literal, Optional, Tuple, Type, Union)
 
+from by_framework.common.config import RedisConfig
 from by_framework.common.emitter import DataLayoutBuilder
 from by_framework.common.logger import logger
 from by_framework.common.redis_client import close_redis, init_redis
@@ -84,9 +86,9 @@ def _build_auto_trace_plugin() -> Plugin | None:
 async def _run_worker_async(
     worker_class: Type[GatewayWorker],
     worker_id: str,
-    redis_host: str,
-    redis_port: int,
-    redis_db: int,
+    redis_host: Optional[str],
+    redis_port: Optional[int],
+    redis_db: Optional[int],
     redis_password: Optional[str],
     redis_username: Optional[str],
     workspace_dir: str,
@@ -104,6 +106,8 @@ async def _run_worker_async(
     plugin_dir: Optional[str] = None,
     storage: Optional[FileStorage] = None,
     layout_builder: Optional[DataLayoutBuilder] = None,
+    redis_mode: Optional[Literal["standalone", "cluster"]] = None,
+    redis_cluster_nodes: Optional[List[Tuple[str, int]]] = None,
     **worker_kwargs,
 ):
     """Async worker runner initialization."""
@@ -121,27 +125,37 @@ async def _run_worker_async(
             # Default auto-link: concurrency + 10 management connections
             actual_redis_max_conns = max_concurrency + 10
 
-    # 2. Establish Redis connection (must be inside event loop)
-    from by_framework.common.config import RedisConfig as SDKRedisConfig
-
-    env_config = SDKRedisConfig.from_env()
-    if env_config.mode == "cluster":
-        redis_client = init_redis(
-            config=env_config,
-            max_connections=actual_redis_max_conns,
-        )
+    # 2. Establish Redis connection (must be inside event loop). Explicit
+    # args always take precedence over env vars, for every field, in both
+    # standalone and cluster mode - one unified resolution path so third
+    # parties can configure either mode purely programmatically or purely
+    # via env vars, without the two modes behaving inconsistently.
+    env_config = RedisConfig.from_env()
+    effective_config = replace(
+        env_config,
+        host=redis_host if redis_host is not None else env_config.host,
+        port=redis_port if redis_port is not None else env_config.port,
+        db=redis_db if redis_db is not None else env_config.db,
+        password=(
+            redis_password if redis_password is not None else env_config.password
+        ),
+        username=(
+            redis_username if redis_username is not None else env_config.username
+        ),
+        mode=redis_mode if redis_mode is not None else env_config.mode,
+        cluster_nodes=(
+            redis_cluster_nodes
+            if redis_cluster_nodes is not None
+            else env_config.cluster_nodes
+        ),
+    )
+    redis_client = init_redis(
+        config=effective_config, max_connections=actual_redis_max_conns
+    )
+    if effective_config.mode == "cluster":
         logger.info(
             "Worker Redis initialized in Cluster mode (nodes=%s)",
-            env_config.cluster_nodes,
-        )
-    else:
-        redis_client = init_redis(
-            host=redis_host,
-            port=redis_port,
-            db=redis_db,
-            password=redis_password,
-            username=redis_username,
-            max_connections=actual_redis_max_conns,
+            effective_config.cluster_nodes,
         )
 
     # 2.1 Configure history message storage backend
@@ -231,9 +245,9 @@ async def _run_worker_async(
 def run_worker(
     worker_class: Type[GatewayWorker],
     worker_id: str = "worker-1",
-    redis_host: str = "localhost",
-    redis_port: int = 6379,
-    redis_db: int = 0,
+    redis_host: Optional[str] = None,
+    redis_port: Optional[int] = None,
+    redis_db: Optional[int] = None,
     redis_password: Optional[str] = None,
     redis_username: Optional[str] = None,
     workspace_dir: str = "/tmp/gateway-workspace",
@@ -251,11 +265,24 @@ def run_worker(
     plugin_dir: Optional[str] = None,
     storage: Optional[FileStorage] = None,
     layout_builder: Optional[DataLayoutBuilder] = None,
+    redis_mode: Optional[Literal["standalone", "cluster"]] = None,
+    redis_cluster_nodes: Optional[List[Tuple[str, int]]] = None,
     **worker_kwargs,
 ):
     """
     Quick entry point for starting By-Framework Worker, for direct use by
     third-party businesses.
+
+    Redis configuration: every redis_* argument defaults to None, meaning
+    "not specified" - when not passed, the value is read from the
+    corresponding REDIS_* environment variable (REDIS_HOST, REDIS_PORT,
+    REDIS_DB, REDIS_PASSWORD, REDIS_USERNAME, REDIS_MODE,
+    REDIS_CLUSTER_NODES), falling back to "localhost"/6379/standalone if
+    neither is set. An explicitly-passed argument always takes precedence
+    over its env var, for every field, in both standalone and cluster mode
+    - so either mode can be configured purely programmatically (e.g.
+    ``redis_mode="cluster", redis_cluster_nodes=[("h1", 6379)]``) or purely
+    via env vars, without the two modes behaving inconsistently.
 
     Plugin support:
     - **Auto mode**: System automatically discovers and loads all subclasses
@@ -299,6 +326,8 @@ def run_worker(
                 plugin_dir=plugin_dir,
                 storage=storage,
                 layout_builder=layout_builder,
+                redis_mode=redis_mode,
+                redis_cluster_nodes=redis_cluster_nodes,
                 **worker_kwargs,
             )
         )

--- a/tests/worker/test_app.py
+++ b/tests/worker/test_app.py
@@ -86,15 +86,17 @@ async def test_run_worker_async_flow():
             fetch_count=5,
         )
 
-        # 1. Verify Redis initialization
-        mock_init_redis.assert_called_once_with(
-            host="localhost",
-            port=6379,
-            db=0,
-            password=None,
-            username=None,
-            max_connections=20,  # max_concurrency (10) + 10
-        )
+        # 1. Verify Redis initialization - routes through the unified
+        # config= path (same for standalone and cluster mode)
+        mock_init_redis.assert_called_once()
+        _, init_redis_kwargs = mock_init_redis.call_args
+        assert init_redis_kwargs["config"].host == "localhost"
+        assert init_redis_kwargs["config"].port == 6379
+        assert init_redis_kwargs["config"].db == 0
+        assert init_redis_kwargs["config"].password == ""
+        assert init_redis_kwargs["config"].username is None
+        assert init_redis_kwargs["config"].mode == "standalone"
+        assert init_redis_kwargs["max_connections"] == 20  # max_concurrency (10) + 10
 
         # 2. Verify core component instantiation
         mock_worker_registry.assert_called_once()
@@ -105,6 +107,122 @@ async def test_run_worker_async_flow():
 
         # 4. Verify resource cleanup
         mock_close_redis.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_worker_async_standalone_falls_back_to_env_when_arg_not_passed():
+    """Standalone mode must respect REDIS_HOST/REDIS_PASSWORD env vars when
+    the caller doesn't pass the corresponding explicit arg — today it
+    doesn't, since the standalone branch never consults
+    RedisConfig.from_env() at all."""
+    with (
+        patch.dict(
+            "os.environ",
+            {"REDIS_HOST": "env-host", "REDIS_PASSWORD": "env-secret"},
+            clear=False,
+        ),
+        patch("by_framework.worker.app.init_redis") as mock_init_redis,
+        patch("by_framework.worker.app.close_redis", new_callable=AsyncMock),
+        patch("by_framework.worker.app.WorkerRegistry"),
+        patch("by_framework.worker.app.WorkspaceManager"),
+        patch("by_framework.worker.app.WorkerRunner") as mock_runner,
+    ):
+        mock_init_redis.return_value = MagicMock()
+        mock_runner.return_value.start = AsyncMock()
+
+        await _run_worker_async(
+            worker_class=MyTestWorker,
+            worker_id="test-w1",
+            redis_host=None,
+            redis_port=None,
+            redis_db=None,
+            redis_password=None,
+            redis_username=None,
+            workspace_dir="/tmp/test-ws",
+            consumer_group="test-group",
+            max_concurrency=10,
+            fetch_count=5,
+        )
+
+        mock_init_redis.assert_called_once()
+        _, kwargs = mock_init_redis.call_args
+        assert kwargs["config"].host == "env-host"
+        assert kwargs["config"].password == "env-secret"
+        assert kwargs["config"].mode == "standalone"
+
+
+@pytest.mark.asyncio
+async def test_run_worker_async_explicit_arg_overrides_env_in_standalone_mode():
+    """An explicit arg must still win over an env var set for the same field."""
+    with (
+        patch.dict(
+            "os.environ",
+            {"REDIS_HOST": "env-host", "REDIS_PASSWORD": "env-secret"},
+            clear=False,
+        ),
+        patch("by_framework.worker.app.init_redis") as mock_init_redis,
+        patch("by_framework.worker.app.close_redis", new_callable=AsyncMock),
+        patch("by_framework.worker.app.WorkerRegistry"),
+        patch("by_framework.worker.app.WorkspaceManager"),
+        patch("by_framework.worker.app.WorkerRunner") as mock_runner,
+    ):
+        mock_init_redis.return_value = MagicMock()
+        mock_runner.return_value.start = AsyncMock()
+
+        await _run_worker_async(
+            worker_class=MyTestWorker,
+            worker_id="test-w1",
+            redis_host="explicit-host",
+            redis_port=None,
+            redis_db=None,
+            redis_password="explicit-secret",
+            redis_username=None,
+            workspace_dir="/tmp/test-ws",
+            consumer_group="test-group",
+            max_concurrency=10,
+            fetch_count=5,
+        )
+
+        _, kwargs = mock_init_redis.call_args
+        assert kwargs["config"].host == "explicit-host"
+        assert kwargs["config"].password == "explicit-secret"
+
+
+@pytest.mark.asyncio
+async def test_run_worker_async_supports_fully_programmatic_cluster_config():
+    """Cluster mode must be fully configurable via explicit args alone, with
+    no env vars at all - true parity with standalone's configurability,
+    which is the whole point of unifying the two resolution paths."""
+    with (
+        patch("by_framework.worker.app.init_redis") as mock_init_redis,
+        patch("by_framework.worker.app.close_redis", new_callable=AsyncMock),
+        patch("by_framework.worker.app.WorkerRegistry"),
+        patch("by_framework.worker.app.WorkspaceManager"),
+        patch("by_framework.worker.app.WorkerRunner") as mock_runner,
+    ):
+        mock_init_redis.return_value = MagicMock()
+        mock_runner.return_value.start = AsyncMock()
+
+        await _run_worker_async(
+            worker_class=MyTestWorker,
+            worker_id="test-w1",
+            redis_host=None,
+            redis_port=None,
+            redis_db=None,
+            redis_password="cluster-secret",
+            redis_username=None,
+            workspace_dir="/tmp/test-ws",
+            consumer_group="test-group",
+            max_concurrency=10,
+            fetch_count=5,
+            redis_mode="cluster",
+            redis_cluster_nodes=[("h1", 6379), ("h2", 6380)],
+        )
+
+        _, kwargs = mock_init_redis.call_args
+        assert kwargs["config"].mode == "cluster"
+        assert kwargs["config"].cluster_nodes == [("h1", 6379), ("h2", 6380)]
+        assert kwargs["config"].password == "cluster-secret"
 
 
 @pytest.mark.asyncio
@@ -458,4 +576,7 @@ def test_run_worker_sync_entry():
         args, _ = mock_run_async.call_args
         # positional: worker_class, worker_id, redis_host, ...
         assert args[1] == "sync-w1"
-        assert args[2] == "localhost"
+        # redis_host defaults to None (not "localhost") - "not specified",
+        # falls back to REDIS_HOST env var / RedisConfig's own default
+        # inside _run_worker_async, not here.
+        assert args[2] is None


### PR DESCRIPTION
## Summary
`_run_worker_async` resolved Redis config via two entirely separate, single-source paths depending on mode:
- **Standalone**: governed purely by explicit function args — `RedisConfig.from_env()` was never consulted, so `REDIS_HOST`/`REDIS_PASSWORD`/etc. env vars had zero effect.
- **Cluster**: governed purely by `RedisConfig.from_env()` — explicit args had zero effect, and there was no way to express `cluster_nodes` programmatically at all (only via `REDIS_CLUSTER_NODES` env).

For an SDK meant to be used by third parties who need to support both standalone and cluster deployments with minimal per-environment code, this asymmetry meant there was no single, consistent way to configure either mode.

## Fix
Collapsed both branches into one resolution path:
- Build one effective `RedisConfig` by starting from `RedisConfig.from_env()` and overriding each field with the explicit arg whenever it's not `None`, then always call `init_redis(config=effective_config, ...)` — no more mode-based branching.
- Added `redis_mode`/`redis_cluster_nodes` parameters to `run_worker()`/`_run_worker_async()` — added at the **end** of the parameter list so no existing positional caller of this third-party-facing public API breaks.
- Changed `redis_host`/`redis_port`/`redis_db`'s defaults from hardcoded literals (`"localhost"`, `6379`, `0`) to `None`, giving them the same "not specified" sentinel `redis_password`/`redis_username` already had.

## Intentional behavior change
Standalone mode now respects `REDIS_HOST`/`REDIS_PORT`/`REDIS_DB`/`REDIS_PASSWORD`/`REDIS_USERNAME` env vars when the caller doesn't pass the matching arg — it didn't before. When nothing is set anywhere, the end result is unchanged (`localhost:6379`, no password). This only changes behavior for a caller with stray `REDIS_*` env vars set who never passes the matching arg.

## Test plan
- [x] New test: standalone mode falls back to `REDIS_HOST`/`REDIS_PASSWORD` env vars when the args aren't passed
- [x] New test: an explicit arg still wins over an env var set for the same field
- [x] New test: cluster mode is fully configurable via explicit args alone (`redis_mode="cluster"`, `redis_cluster_nodes=[...]`), no env vars at all — true parity with standalone
- [x] Existing env-var-only cluster configuration test (from the earlier heartbeat/startup PR) continues to pass unchanged
- [x] Updated two pre-existing tests whose assertions checked the old flat-kwargs `init_redis` call shape, now checking the unified `config=` shape instead (same underlying behavior, updated expression)
- [x] `uv run pytest` — 545 passed, 1 skipped, 0 failures (pre-existing unrelated flaky `tests/metrics/test_catalog.py` test, confirmed present on `main` before this branch)
- [x] `make format-changed` / `make lint-changed` clean (pylint 10.00/10)

Closes #60