### PR TITLE
test(common): add regression coverage for empty REDIS_CLUSTER_HOST

### DIFF
--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -196,7 +196,7 @@ class TestRedisConfig(unittest.TestCase):
                     os.environ.pop(k, None)
 
     def test_from_env_empty_cluster_host_is_treated_as_unset(self):
-        """An empty REDIS_CLUSTER_HOST (var present but blank) must not imply cluster mode."""
+        """A blank REDIS_CLUSTER_HOST (present but empty) doesn't imply cluster mode."""
         env_vars = ["REDIS_MODE", "REDIS_CLUSTER_HOST", "REDIS_CLUSTER_NODES"]
         old_values = {k: os.environ.get(k) for k in env_vars}
         try:
@@ -215,7 +215,7 @@ class TestRedisConfig(unittest.TestCase):
                     os.environ.pop(k, None)
 
     def test_from_env_empty_cluster_host_falls_back_to_cluster_nodes(self):
-        """An empty REDIS_CLUSTER_HOST must not block fallback to REDIS_CLUSTER_NODES."""
+        """A blank REDIS_CLUSTER_HOST must not block fallback to REDIS_CLUSTER_NODES."""
         env_vars = ["REDIS_MODE", "REDIS_CLUSTER_HOST", "REDIS_CLUSTER_NODES"]
         old_values = {k: os.environ.get(k) for k in env_vars}
         try:

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -195,6 +195,44 @@ class TestRedisConfig(unittest.TestCase):
                 else:
                     os.environ.pop(k, None)
 
+    def test_from_env_empty_cluster_host_is_treated_as_unset(self):
+        """An empty REDIS_CLUSTER_HOST (var present but blank) must not imply cluster mode."""
+        env_vars = ["REDIS_MODE", "REDIS_CLUSTER_HOST", "REDIS_CLUSTER_NODES"]
+        old_values = {k: os.environ.get(k) for k in env_vars}
+        try:
+            os.environ.pop("REDIS_MODE", None)
+            os.environ["REDIS_CLUSTER_HOST"] = ""
+            os.environ.pop("REDIS_CLUSTER_NODES", None)
+
+            config = RedisConfig.from_env()
+            self.assertEqual(config.mode, "standalone")
+            self.assertIsNone(config.cluster_nodes)
+        finally:
+            for k, v in old_values.items():
+                if v is not None:
+                    os.environ[k] = v
+                else:
+                    os.environ.pop(k, None)
+
+    def test_from_env_empty_cluster_host_falls_back_to_cluster_nodes(self):
+        """An empty REDIS_CLUSTER_HOST must not block fallback to REDIS_CLUSTER_NODES."""
+        env_vars = ["REDIS_MODE", "REDIS_CLUSTER_HOST", "REDIS_CLUSTER_NODES"]
+        old_values = {k: os.environ.get(k) for k in env_vars}
+        try:
+            os.environ["REDIS_MODE"] = "cluster"
+            os.environ["REDIS_CLUSTER_HOST"] = ""
+            os.environ["REDIS_CLUSTER_NODES"] = "h1:6379,h2:6380"
+
+            config = RedisConfig.from_env()
+            self.assertEqual(config.mode, "cluster")
+            self.assertEqual(config.cluster_nodes, [("h1", 6379), ("h2", 6380)])
+        finally:
+            for k, v in old_values.items():
+                if v is not None:
+                    os.environ[k] = v
+                else:
+                    os.environ.pop(k, None)
+
     def test_from_env_with_custom_values(self):
         """Test from_env with custom environment variables."""
         old_values = {

--- a/tests/common/test_constants.py
+++ b/tests/common/test_constants.py
@@ -522,6 +522,12 @@ class TestGetKeySchemaVersion(unittest.TestCase):
         os.environ["REDIS_KEY_SCHEMA_VERSION"] = "v1"
         self.assertEqual(get_key_schema_version(), "v1")
 
+    def test_empty_cluster_host_is_treated_as_unset(self):
+        """An empty REDIS_CLUSTER_HOST (var present but blank) must not imply v2."""
+        os.environ.pop("REDIS_KEY_SCHEMA_VERSION", None)
+        os.environ["REDIS_CLUSTER_HOST"] = ""
+        self.assertEqual(get_key_schema_version(), "v1")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Closes beyonai/by-framework-python#73.
- `RedisConfig.from_env()` and `get_key_schema_version()` already treat `REDIS_CLUSTER_HOST=""` (present but blank) as unset, thanks to Python's string truthiness - no source change needed here.
- Adds explicit regression tests locking that behavior in, since it's easy to accidentally regress with a naive `is not None` check (that's exactly what broke the Java SDK: beyonai/by-framework-java#39).

## Test plan
- [x] `uv run pytest tests/common/test_config.py tests/common/test_constants.py -q` → 59 passed