### PR TITLE
fix(client,registry): preserve execution identity across ask_user suspend/resume

### DIFF
--- a/src/by_framework/client/client.py
+++ b/src/by_framework/client/client.py
@@ -785,7 +785,28 @@ class GatewayClient:
             content=params["content"],
             extra_payload=params["extra_payload"],
         )
-        execution_id = f"{EXECUTION_ID_PREFIX}{uuid.uuid4().hex[:8]}"
+
+        # A RESUME reuses the message_id of the original AskAgentCommand so the
+        # worker can look the suspended execution back up. Reuse its
+        # execution_id too, and skip re-initializing the registry record for
+        # it below -- initialize_execution() would otherwise overwrite the
+        # message_id -> execution_id mapping and detach this resume from the
+        # execution it's meant to continue.
+        resumed_execution = None
+        if (
+            params["action_type"] == ActionType.RESUME.value
+            and self.registry
+            and hasattr(self.registry, "get_execution_by_message_id")
+        ):
+            resumed_execution = await self.registry.get_execution_by_message_id(
+                message_id, session_id=params["session_id"]
+            )
+
+        execution_id = (
+            resumed_execution["execution_id"]
+            if resumed_execution
+            else f"{EXECUTION_ID_PREFIX}{uuid.uuid4().hex[:8]}"
+        )
 
         # 3. Resolve route and optionally probe agent type/liveness
         should_dispatch_control = True
@@ -931,8 +952,14 @@ class GatewayClient:
                 error_code=ExecutionStatus.ERR_AGENT_TYPE_UNAVAILABLE,
             )
 
-        # Initialize execution tracking
-        if self.registry and hasattr(self.registry, "initialize_execution"):
+        # Initialize execution tracking. Skipped for a RESUME that reattached
+        # to an existing execution -- that execution is already tracked, and
+        # re-initializing it here would overwrite its message_id mapping.
+        if (
+            not resumed_execution
+            and self.registry
+            and hasattr(self.registry, "initialize_execution")
+        ):
             try:
                 await self.registry.initialize_execution(
                     {

--- a/src/by_framework/core/registry.py
+++ b/src/by_framework/core/registry.py
@@ -1011,7 +1011,8 @@ class WorkerRegistry:
         old_execution = dict(current)
         current["status"] = status
         now = int(time.time() * 1000)
-        current["finished_at"] = now
+        if is_terminal_state(status):
+            current["finished_at"] = now
         current["updated_at"] = now
         if completion:
             for key, value in completion.items():

--- a/src/by_framework/worker/runner.py
+++ b/src/by_framework/worker/runner.py
@@ -505,6 +505,16 @@ class WorkerRunner:
                     header.message_id, session_id=header.session_id
                 )
 
+            if isinstance(command, ResumeCommand) and existing_execution is None:
+                logger.warning(
+                    "[%s] ResumeCommand did not resolve to an existing execution "
+                    "(message_id=%s, session_id=%s); starting a new, disconnected "
+                    "execution instead of continuing the suspended one.",
+                    self.worker.worker_id,
+                    header.message_id,
+                    header.session_id,
+                )
+
             # Skip terminal state replays
             if (
                 existing_execution

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1256,3 +1256,114 @@ async def test_byai_client_cancel_session_inherited_unmodified():
         "exec-a", "sess-1", "user abort"
     )
     assert redis.xadd.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_client_send_message_resume_reuses_existing_execution_id():
+    """Resuming a suspended execution must reuse its execution_id and must
+    not re-initialize the registry record for it. initialize_execution()
+    unconditionally overwrites the message_id -> execution_id mapping, which
+    would silently detach the ResumeCommand from the original (still
+    WAITING_USER) execution and orphan it."""
+    mock_redis = AsyncMock()
+    mock_registry = AsyncMock()
+    mock_registry.get_execution_by_message_id.return_value = {
+        "execution_id": "exec-original",
+        "message_id": "msg-1",
+        "session_id": "s1",
+        "status": "WAITING_USER",
+    }
+
+    client = GatewayClient(redis_client=mock_redis, registry=mock_registry)
+    await client.send_message(
+        target_agent_type="langgraph_agent",
+        session_id="s1",
+        content="user reply",
+        action_type="RESUME",
+        message_id="msg-1",
+        target_worker_id="worker-42",
+    )
+
+    mock_registry.get_execution_by_message_id.assert_awaited_once_with(
+        "msg-1", session_id="s1"
+    )
+    mock_registry.initialize_execution.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_client_send_message_resume_without_match_falls_back_to_new_execution():
+    """A RESUME whose message_id doesn't resolve to an existing execution
+    (e.g. a genuinely new resume-shaped message) falls back to today's
+    behavior: mint a fresh execution_id and initialize it in the registry."""
+    mock_redis = AsyncMock()
+    mock_registry = AsyncMock()
+    mock_registry.get_execution_by_message_id.return_value = None
+
+    client = GatewayClient(redis_client=mock_redis, registry=mock_registry)
+    await client.send_message(
+        target_agent_type="langgraph_agent",
+        session_id="s1",
+        content="user reply",
+        action_type="RESUME",
+        message_id="msg-unmatched",
+        target_worker_id="worker-42",
+    )
+
+    mock_registry.get_execution_by_message_id.assert_awaited_once_with(
+        "msg-unmatched", session_id="s1"
+    )
+    mock_registry.initialize_execution.assert_awaited_once()
+    initialized = mock_registry.initialize_execution.await_args.args[0]
+    assert initialized["message_id"] == "msg-unmatched"
+    assert initialized["execution_id"]
+
+
+@pytest.mark.asyncio
+async def test_client_send_message_ask_agent_does_not_query_registry_for_resume_match():
+    """A fresh ASK_AGENT dispatch always gets a new message_id, so there is
+    nothing to reattach to -- it should skip the resume lookup entirely and
+    keep minting+initializing a new execution as before."""
+    mock_redis = AsyncMock()
+    mock_registry = AsyncMock()
+
+    client = GatewayClient(redis_client=mock_redis, registry=mock_registry)
+    await client.send_message(
+        target_agent_type="langgraph_agent",
+        session_id="s1",
+        content="hello",
+        action_type="ASK_AGENT",
+        message_id="msg-new",
+        target_worker_id="worker-42",
+    )
+
+    mock_registry.get_execution_by_message_id.assert_not_called()
+    mock_registry.initialize_execution.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_client_send_message_resume_falls_back_when_registry_lacks_lookup():
+    """A registry double/implementation without get_execution_by_message_id
+    must not blow up a RESUME send -- mirror the defensive hasattr() guard
+    already used for initialize_execution() and fall back to minting a new
+    execution_id."""
+    mock_redis = AsyncMock()
+
+    class RegistryWithoutLookup:
+        async def initialize_execution(self, execution):
+            return None
+
+        async def is_worker_online(self, worker_id):
+            return True
+
+    client = GatewayClient(redis_client=mock_redis, registry=RegistryWithoutLookup())
+
+    response = await client.send_message(
+        target_agent_type="langgraph_agent",
+        session_id="s1",
+        content="user reply",
+        action_type="RESUME",
+        message_id="msg-1",
+        target_worker_id="worker-42",
+    )
+
+    assert response.success is True

--- a/tests/core/test_registry.py
+++ b/tests/core/test_registry.py
@@ -641,6 +641,38 @@ async def test_registry_tracks_execution_lifecycle():
     await registry.mark_execution_finished("exec-1", "sess-1", "CANCELLED")
     finished = await registry.get_execution("exec-1", "sess-1")
     assert finished["status"] == "CANCELLED"
+    assert finished["finished_at"] > 0
+
+
+@pytest.mark.asyncio
+async def test_mark_execution_finished_skips_finished_at_for_non_terminal_status():
+    """WAITING_USER (ask_user suspension) and other non-terminal statuses are
+    not "finished" -- stamping finished_at for them makes suspended
+    executions look completed to anything reading the registry (e.g.
+    metrics/snapshot.py's latency calculations)."""
+    redis_mock = MockRedis()
+    registry = WorkerRegistry(redis_mock)
+
+    execution = {
+        "execution_id": "exec-1",
+        "message_id": "msg-1",
+        "session_id": "sess-1",
+        "worker_id": "worker-1",
+        "target_agent_type": "langgraph_agent",
+        "status": "RUNNING",
+        "cancel_requested": False,
+    }
+    await registry.save_execution(execution)
+
+    await registry.mark_execution_finished("exec-1", "sess-1", "WAITING_USER")
+    suspended = await registry.get_execution("exec-1", "sess-1")
+    assert suspended["status"] == "WAITING_USER"
+    assert suspended.get("finished_at", 0) == 0
+
+    await registry.mark_execution_finished("exec-1", "sess-1", "COMPLETED")
+    finished = await registry.get_execution("exec-1", "sess-1")
+    assert finished["status"] == "COMPLETED"
+    assert finished["finished_at"] > 0
 
 
 @pytest.mark.asyncio

--- a/tests/worker/test_runner.py
+++ b/tests/worker/test_runner.py
@@ -17,6 +17,7 @@ from by_framework.core.protocol.commands import (
     AskAgentCommand,
     CancelTaskCommand,
     ReloadPluginsCommand,
+    ResumeCommand,
 )
 from by_framework.core.protocol.message_header import MessageHeader
 
@@ -780,6 +781,81 @@ class TestWorkerRunner(unittest.IsolatedAsyncioTestCase):
 
         worker.plugin_registry.log_hook_stats.assert_called_once()
         worker.plugin_registry.on_worker_shutdown.assert_awaited_once_with(worker)
+
+    async def test_runner_warns_when_resume_command_execution_lookup_misses(self):
+        """A ResumeCommand whose message_id/session_id don't resolve to an
+        existing execution silently starts a brand-new, disconnected
+        execution today. That failure mode should at least be visible in
+        logs instead of passing unnoticed."""
+        redis_mock = MockRedisRunner(message_to_return=[])
+        worker = DummyWorker()
+        worker.registry = AsyncMock()
+        worker.registry.get_execution_by_message_id.return_value = None
+
+        runner = WorkerRunner(
+            redis_client=redis_mock,
+            worker=worker,
+            group_name="test_group",
+            span_recorder=AsyncMock(),
+        )
+        runner._trace_writer = AsyncMock()
+        payload = ResumeCommand(
+            header=MessageHeader(
+                message_id="msg-orphan",
+                session_id="sess-orphan",
+                trace_id="trace-1",
+                target_agent_type="dummy_agent",
+            ),
+            content="user reply",
+        ).to_dict()
+
+        with self.assertLogs("by-framework", level="WARNING") as captured:
+            await runner._process_message_from_dict(
+                RedisKeys.ctrl_stream("dummy_agent"), "1-0", payload
+            )
+
+        self.assertTrue(
+            any(
+                "msg-orphan" in record and "sess-orphan" in record
+                for record in captured.output
+            ),
+            captured.output,
+        )
+
+    async def test_runner_does_not_warn_when_resume_command_execution_resolves(self):
+        """A ResumeCommand that correctly resolves to its suspended execution
+        should not trip the orphan-resume warning."""
+        redis_mock = MockRedisRunner(message_to_return=[])
+        worker = DummyWorker()
+        worker.registry = AsyncMock()
+        worker.registry.get_execution_by_message_id.return_value = {
+            "execution_id": "exec-1",
+            "message_id": "msg-1",
+            "session_id": "sess-1",
+            "status": "WAITING_USER",
+        }
+
+        runner = WorkerRunner(
+            redis_client=redis_mock,
+            worker=worker,
+            group_name="test_group",
+            span_recorder=AsyncMock(),
+        )
+        runner._trace_writer = AsyncMock()
+        payload = ResumeCommand(
+            header=MessageHeader(
+                message_id="msg-1",
+                session_id="sess-1",
+                trace_id="trace-1",
+                target_agent_type="dummy_agent",
+            ),
+            content="user reply",
+        ).to_dict()
+
+        with self.assertNoLogs("by-framework", level="WARNING"):
+            await runner._process_message_from_dict(
+                RedisKeys.ctrl_stream("dummy_agent"), "1-0", payload
+            )
 
     async def test_runner_invalid_control_message_is_acked_without_handler(self):
         """Test that invalid control messages are acked without calling the handler."""


### PR DESCRIPTION
## Summary

- `GatewayClient.send_message()` minted a fresh `execution_id` and re-ran `initialize_execution()` on every send, including `RESUME` — overwriting the `message_id -> execution_id` mapping and silently detaching a `ResumeCommand` from the original `WAITING_USER` execution (closes #75).
- `WorkerRegistry.mark_execution_finished()` stamped `finished_at` on any status, including non-terminal ones like `WAITING_USER`, corrupting `metrics/snapshot.py`'s latency/`completed_count` calculations (closes #76).
- Added a warning log when a `ResumeCommand`'s `message_id`/`session_id` don't resolve to an existing execution, so a broken suspend/resume link is visible instead of silently spinning up a disconnected execution (closes #77).

Built test-first (TDD) at each fix's public seam; see individual issues for full root-cause writeups.

Closes #75
Closes #76
Closes #77

## Test plan

- [x] `uv run pytest tests/` — 594 passed
- [x] `make lint` (ruff + pylint) — 10.00/10, clean
- [x] New regression tests per issue: resume reattachment (client), non-terminal `finished_at` (registry), orphan-resume warning (runner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)