### PR TITLE
feat(worker): add opt-in /readyz readiness endpoint for Docker/K8s health checks

### DIFF
--- a/.github/workflows/deploy-smoke-test.yml
+++ b/.github/workflows/deploy-smoke-test.yml
@@ -44,8 +44,15 @@ jobs:
       - name: Install by-framework (for the verify client script below)
         run: uv sync
 
+      # --wait blocks until every service with a healthcheck (redis, and now
+      # worker's own /readyz-backed HEALTHCHECK - see
+      # docs/architecture/worker-readiness-endpoint.md) reports healthy, and
+      # fails the step if that doesn't happen in time. This is the actual
+      # verification that the readiness endpoint works end to end in a real
+      # container - not just that the Python contract tests pass.
       - name: Build and start Redis + Worker via deploy/docker-compose.yml
-        run: docker compose -f deploy/docker-compose.yml up --build -d
+        run: |
+          docker compose -f deploy/docker-compose.yml up --build -d --wait --wait-timeout 60
 
       - name: Send a message and verify the Worker echoes it back
         run: uv run python examples/send_and_verify.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,7 @@ Pre-commit hooks are configured in `.pre-commit-config.yaml` and run isort, ruff
 | any source file | `docs/architecture/KEY_FILES.md` — find the file's entry |
 | Redis connection setup, cluster-mode, or key-schema versioning (`RedisConfig`, `RedisKeys`, `_get_redis()`, admin-index writes) | `docs/architecture/redis-cluster-mode.md` |
 | Worker deployment/production-readiness — README's 部署 section, `__main__.py` CLI flags, `run_worker()`'s signature, or shutdown/signal handling | `docs/architecture/production-deployment.md` |
+| Worker readiness/health-check endpoint (`WorkerHealthServer`, `/readyz`, `--health-port`) — building it, or touching anything that changes what "ready" means | `docs/architecture/worker-readiness-endpoint.md` |
 
 ## Maintaining this map
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -41,5 +41,21 @@ RUN uv venv /opt/venv \
 
 COPY deploy/entrypoint.sh /entrypoint.sh
 
+# Opt-in readiness endpoint (see
+# docs/architecture/worker-readiness-endpoint.md) - BYAI_WORKER_HEALTH_PORT
+# is run_worker()'s own env-var fallback for --health-port, so this alone
+# is enough to turn it on; no CMD change needed even if you override
+# --worker-class below.
+ENV BYAI_WORKER_HEALTH_PORT=8080
+EXPOSE 8080
+
+# Readiness only - see the hard rule in
+# docs/architecture/worker-readiness-endpoint.md: never turn this into a
+# liveness/restart-on-unhealthy check. urlopen() raises (non-zero exit) on
+# the endpoint's real 503, so this actually fails on "not ready" - unlike
+# a healthcheck that only checks "did the server respond at all".
+HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/readyz', timeout=3)"
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["--worker-class", "my_agent.MyAgent"]

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -32,6 +32,32 @@ services:
     depends_on:
       redis:
         condition: service_healthy
+    # Mirrors deploy/Dockerfile's HEALTHCHECK - redeclared here (Compose
+    # would otherwise just inherit the image's own) so this file is a
+    # self-contained example of the readiness endpoint's wiring, and so any
+    # future service added here can depend on
+    # `worker: condition: service_healthy` without having to go trace
+    # through the Dockerfile to confirm one exists. Readiness only - never
+    # liveness, see docs/architecture/worker-readiness-endpoint.md.
+    #
+    # No host port published for 8080/readyz on purpose: this file's
+    # documented `--scale worker=N` usage above would collide trying to
+    # publish the same fixed host port for every replica. The healthcheck
+    # itself needs no host port - Compose evaluates it inside the
+    # container's own network. deploy-smoke-test.yml verifies it via
+    # `up --wait`.
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/readyz', timeout=3)",
+        ]
+      interval: 10s
+      timeout: 3s
+      start_period: 10s
+      retries: 3
     environment:
       REDIS_HOST: redis
       REDIS_PORT: "6379"

--- a/deploy/kubernetes/worker-deployment.yaml
+++ b/deploy/kubernetes/worker-deployment.yaml
@@ -2,14 +2,15 @@
 # README's shell-`&` "水平扩展" example with a real, supervised, restart-on-
 # failure orchestration form. Adjust image/replicas/resources for your setup.
 #
-# No liveness/readiness probe is set here on purpose: the Worker process
-# exposes no HTTP/exec health surface today (tracked as a known gap in
-# docs/architecture/production-deployment.md, gap 5) - the only liveness
-# signal is the Redis-backed heartbeat TTL key, readable via
-# `by-admin worker list`/`worker info`, not a local probe target. Wiring a
-# probe to something that doesn't actually reflect health (e.g. bare
-# `pgrep`) would be worse than no probe - don't add one until a real
-# endpoint exists.
+# readinessProbe ONLY below - see docs/architecture/worker-readiness-endpoint.md.
+# Do NOT add a livenessProbe pointed at /readyz (or at anything else,
+# absent a separate deliberate design for one): a Worker's health depends
+# on Redis being reachable, and wiring this to liveness would mean a
+# transient Redis outage kills and restarts every Worker replica
+# simultaneously - a self-inflicted restart storm strictly worse than the
+# outage itself. A failing readinessProbe never kills anything; it only
+# stops this replica from being counted, which is exactly what "not
+# ready" should do.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -41,6 +42,18 @@ spec:
             # REDIS_MODE/REDIS_CLUSTER_HOST: see docs/architecture/redis-cluster-mode.md.
             - name: BYAI_WORKER_CONCURRENCY
               value: "50"
+            - name: BYAI_WORKER_HEALTH_PORT
+              value: "8080"
+          ports:
+            - name: readiness
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: readiness
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
           resources:
             requests:
               cpu: "250m"

--- a/docs/architecture/KEY_FILES.md
+++ b/docs/architecture/KEY_FILES.md
@@ -52,7 +52,11 @@ Entry anatomy:
   if more than one `by_framework_trace_*` provider factory activates from
   env — silently picking one would hide a misconfiguration. `close_redis()`
   must stay in the `finally` block (including on `asyncio.CancelledError`)
-  so restarts don't leak the connection pool.
+  so restarts don't leak the connection pool. `health_port` (readiness
+  endpoint, see [[worker-readiness-endpoint]]) is opt-in only — unlike
+  `max_concurrency`/`fetch_count`, its `BYAI_WORKER_HEALTH_PORT` env-var
+  fallback must never resolve to a default port number; leave it `None`
+  when unset so no port opens for deployments that never asked for one.
 
 - `src/by_framework/common/config.py` — `RedisConfig`/`WorkerConfig`/`LoggingConfig`
   env-loaded dataclasses. `RedisConfig.from_env()`'s cluster-mode/key-schema
@@ -121,7 +125,29 @@ Entry anatomy:
   failure mode this log surfaces (fix 90764e1, #77). Terminal-state
   replay-skip logic is coupled to `ResumeCommand` handling: skip replaying an
   execution already in a terminal state *unless* the command is a
-  `ResumeCommand`.
+  `ResumeCommand`. `_health_server` (see [[worker-readiness-endpoint]]) must
+  start before any other step in `start()` (currently first line of the
+  `try:` block) so a probe hitting the port during startup gets an honest
+  `starting` 503 instead of connection-refused, and must `stop()` as the
+  *last* step of `_shutdown()` — after every other teardown step, not
+  before — so `/readyz` stays reachable (reporting `draining`) for the
+  entire drain. `self._draining = True` must stay the first line of
+  `_shutdown()`, ahead of every other teardown step, not just ahead of the
+  health-server stop.
+
+- `src/by_framework/worker/health_server.py` — `WorkerHealthServer`: the
+  `/readyz` readiness HTTP endpoint, on its own daemon thread (mirrors
+  `heartbeat.py`'s "don't share the main event loop" pattern — see that
+  file's own docstring). Full design record, including why this exists and
+  the hard rule against ever wiring it to a liveness check:
+  [[worker-readiness-endpoint]]. `_compute_reason()`'s check order is the
+  entire contract — `starting > draining > evicted > suspended >
+  consumer_stalled > serving`, first match wins; reordering these checks
+  silently changes what an operator is told during a real incident. All
+  Worker state is read via constructor-injected callables (`has_started`,
+  `is_draining`, `admin_lifecycle`, `consumer_healthy`) — this class must
+  never reach into `WorkerRunner` directly, which is what keeps it testable
+  standalone against fake state (see `tests/worker/test_health_server.py`).
 
 - `src/by_framework/core/registry.py` — `WorkerRegistry`: Redis-backed worker
   membership/heartbeat/execution-state, admin lifecycle, locking primitives.

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -72,19 +72,14 @@ of quad-bullets.
    default — no downward-API wiring needed). README's shell-`&` example is
    kept as a quick-local-check note, no longer the only scaling story.
 
-5. **Still open: Worker process exposes no health-check surface.** Unlike
-   the dashboard (`/api/health`), the Worker has no HTTP/exec endpoint for a
-   Kubernetes liveness/readiness probe; the only liveness signal is the
-   Redis-backed heartbeat TTL key
-   (`byai_gateway:registry:worker:online:{worker_id}`), readable only via
-   `by-admin worker list`/`worker info` or something else that queries Redis
-   directly. `deploy/kubernetes/worker-deployment.yaml` deliberately omits a
-   probe rather than wiring one to a proxy signal (e.g. bare `pgrep`) that
-   doesn't actually reflect health — a probe that always reports "healthy"
-   is worse than no probe. **Designed, not yet implemented** — see
-   `docs/architecture/worker-readiness-endpoint.md` for the full design
-   record (a `/readyz` HTTP endpoint, readiness-only, opt-in via
-   `--health-port`) from the 2026-07-23 `/grilling` session.
+5. ~~**Worker process exposes no health-check surface.**~~ **Fixed.** The
+   Worker now has an opt-in `/readyz` HTTP endpoint (`--health-port`/
+   `BYAI_WORKER_HEALTH_PORT`), readiness-only by design — never wired to a
+   liveness probe. `deploy/`'s reference Dockerfile/Compose/Kubernetes
+   artifacts all wire it up, and `deploy-smoke-test.yml` verifies it
+   reports healthy in a real container via `docker compose up --wait`.
+   Full design record, including why readiness-only and the hard rule
+   against ever adding liveness: `docs/architecture/worker-readiness-endpoint.md`.
 
 ## CI validation
 

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -81,9 +81,10 @@ of quad-bullets.
    directly. `deploy/kubernetes/worker-deployment.yaml` deliberately omits a
    probe rather than wiring one to a proxy signal (e.g. bare `pgrep`) that
    doesn't actually reflect health — a probe that always reports "healthy"
-   is worse than no probe. Needs a real design decision (new HTTP port on
-   the Worker? a lightweight exec probe that shells out to `by-admin`? some
-   third option?) before it's implemented, not a quick fix.
+   is worse than no probe. **Designed, not yet implemented** — see
+   `docs/architecture/worker-readiness-endpoint.md` for the full design
+   record (a `/readyz` HTTP endpoint, readiness-only, opt-in via
+   `--health-port`) from the 2026-07-23 `/grilling` session.
 
 ## CI validation
 

--- a/docs/architecture/worker-readiness-endpoint.md
+++ b/docs/architecture/worker-readiness-endpoint.md
@@ -1,11 +1,11 @@
 # Worker readiness endpoint
 
-**Status: designed, not yet implemented.** This doc is the design record
-from the 2026-07-23 `/grilling` + `/domain-modeling` session that closed gap
-5 in `docs/architecture/production-deployment.md` ("Worker process exposes
-no health-check surface"). Build against this doc; update it in place if
-implementation reveals the design needs to change — don't let code and doc
-drift apart.
+**Status: implemented**, per GitHub issues #84-#88 against #83. This doc is
+the design record from the 2026-07-23 `/grilling` + `/domain-modeling`
+session that closed gap 5 in `docs/architecture/production-deployment.md`
+("Worker process exposes no health-check surface"). Keep it in sync with
+the code; update it in place if a future change touches this behavior —
+don't let code and doc drift apart.
 
 ## What it is
 
@@ -50,7 +50,7 @@ liveness (see Decision 1).
   Worker mid-shutdown should not be counted, independent of whether it's
   still functioning correctly in its final seconds.
 
-## Covers (once implemented)
+## Covers
 
 - `src/by_framework/worker/health_server.py` — new module, `WorkerHealthServer`
 - `src/by_framework/worker/runner.py` — `WorkerRunner` holds an optional
@@ -63,6 +63,9 @@ liveness (see Decision 1).
   `depends_on: condition: service_healthy` for anything that should wait on it
 - `deploy/kubernetes/worker-deployment.yaml` — `readinessProbe` (only —
   see Decision 1)
+- `.github/workflows/deploy-smoke-test.yml` — `docker compose up --wait`
+  fails the CI job if the readiness endpoint never reports healthy in a
+  real container, not just in the Python contract tests
 
 ## Decisions
 

--- a/docs/architecture/worker-readiness-endpoint.md
+++ b/docs/architecture/worker-readiness-endpoint.md
@@ -1,0 +1,237 @@
+# Worker readiness endpoint
+
+**Status: designed, not yet implemented.** This doc is the design record
+from the 2026-07-23 `/grilling` + `/domain-modeling` session that closed gap
+5 in `docs/architecture/production-deployment.md` ("Worker process exposes
+no health-check surface"). Build against this doc; update it in place if
+implementation reveals the design needs to change — don't let code and doc
+drift apart.
+
+## What it is
+
+The Worker process (`GatewayWorker`/`WorkerRunner`) has no way to tell an
+external orchestrator "am I ready to be counted as a healthy replica" — the
+only existing signal is the Redis-backed heartbeat TTL key
+(`byai_gateway:registry:worker:online:{worker_id}`), which requires querying
+Redis directly or via `by-admin worker info`, not something Docker's
+`HEALTHCHECK` or a Kubernetes probe can point at locally. This doc defines a
+local HTTP endpoint that closes that gap — readiness only, deliberately not
+liveness (see Decision 1).
+
+## Ubiquitous language
+
+- **Ready** — this Worker should currently be counted as an available
+  replica (safe to route work to, safe to count toward a rollout's "new
+  replicas are up" check). Maps 1:1 to the endpoint's HTTP status: `200` =
+  ready, `503` = not ready. This is the *only* thing the status code
+  encodes — never layer "why" into the status code, only into `reason`
+  (Decision 2).
+- **`reason`** — a single enum naming *why* the Worker is or isn't ready
+  right now, evaluated in strict priority order (`starting` > `draining` >
+  `evicted` > `suspended` > `consumer_stalled` > `serving`; first match
+  wins — see Body schema). Distinct from `admin_lifecycle`: `admin_lifecycle`
+  answers "did an operator deliberately pause this Worker" (an admin-control
+  concept, values `active`/`suspended`/`evicted`, already exists on
+  `WorkerRunner`); `reason` answers "is this Worker actually serving right
+  now" (a readiness concept). They coincide in the happy path
+  (`admin_lifecycle=active` and `reason=serving`) but are not the same
+  field and must not be collapsed into one — e.g. immediately after process
+  start, `admin_lifecycle` is already `active` but `reason` is `starting`
+  until the consume loop's first successful tick.
+- **Serving** — the specific `reason` value meaning "ready, and the reason
+  is simply that everything is fine" (not starting, not draining, not
+  suspended/evicted, consumer loop ticking normally). Deliberately not
+  reusing `admin_lifecycle`'s `active` string for this, per the distinction
+  above.
+- **Draining** — the `reason` value from the moment `SIGTERM`/`SIGINT` is
+  received until process exit. A draining Worker is *not ready* even though
+  it may still be correctly processing in-flight tasks — readiness here
+  means "should new work/rollout progress count on this replica," and a
+  Worker mid-shutdown should not be counted, independent of whether it's
+  still functioning correctly in its final seconds.
+
+## Covers (once implemented)
+
+- `src/by_framework/worker/health_server.py` — new module, `WorkerHealthServer`
+- `src/by_framework/worker/runner.py` — `WorkerRunner` holds an optional
+  `WorkerHealthServer` instance; starts it early in `start()`, flips it to
+  `draining` as the first step of `_shutdown()`
+- `src/by_framework/worker/app.py` — `run_worker()` gains `health_port`
+- `src/by_framework/__main__.py` — `--health-port` CLI flag
+- `deploy/Dockerfile` — `HEALTHCHECK` instruction
+- `deploy/docker-compose.yml` — `healthcheck:` on the `worker` service,
+  `depends_on: condition: service_healthy` for anything that should wait on it
+- `deploy/kubernetes/worker-deployment.yaml` — `readinessProbe` (only —
+  see Decision 1)
+
+## Decisions
+
+### 1. Readiness only — no liveness probe, ever
+
+**Context.** Kubernetes and Docker both support two different kinds of
+health signal. A failing *liveness* probe gets the container killed and
+restarted by the orchestrator. A failing *readiness* probe only removes it
+from consideration (Service endpoints, rollout-progress bookkeeping) without
+touching the running process.
+
+**Decision.** This endpoint is wired to readiness only. No liveness probe is
+provided, and `deploy/kubernetes/worker-deployment.yaml` must never gain a
+`livenessProbe` pointed at it (or at anything else, absent a separate,
+deliberate design for one).
+
+**Why.** A Worker's own health depends heavily on Redis being reachable. If
+this endpoint's "not ready" state were wired to `livenessProbe`, a transient
+Redis outage would cause every Worker replica's liveness probe to fail
+*simultaneously*, and Kubernetes would kill and restart the entire fleet at
+once — replacing a transient dependency outage with a self-inflicted
+thundering-herd restart storm, which is strictly worse. Readiness failures
+carry no such risk: they never trigger a kill, only routing/bookkeeping
+changes. This is also what makes Decision 4 (flip to `draining`/`suspended`
+immediately, even while still mid-drain and technically still functioning)
+safe — none of those states can ever cause a restart, because nothing here
+is ever liveness.
+
+**Alternative rejected.** Add both probes, liveness scoped to something
+narrower (e.g. "is the process not deadlocked" via a watchdog thread
+independent of Redis). Rejected for now as unnecessary scope — no incident
+has ever indicated a Worker gets stuck in a way `SIGTERM` doesn't resolve;
+revisit only if that changes.
+
+### 2. Status code is binary; `reason` carries the detail
+
+**Decision.** The HTTP status code encodes only `ready`/`not ready` (`200`/
+`503`). All diagnostic detail — *why* — lives in the JSON body's `reason`
+field, never in the status code (e.g. no `410` for evicted vs `503` for
+stalled).
+
+**Why.** Every consumer of this endpoint (kubelet's `httpGet` probe,
+Docker's `HEALTHCHECK`, Compose's `service_healthy` condition) only acts on
+the binary pass/fail signal — none of them branch on which non-2xx code
+came back. Encoding detail in the status code would add complexity with no
+consumer able to use it, while making the body's `reason` field redundant.
+One bit of machine-readable signal (status code), unlimited human-readable
+detail (body) — don't blend the two.
+
+### 3. Dedicated thread, not the main asyncio loop
+
+**Decision.** `WorkerHealthServer` runs on its own `threading.Thread` using
+stdlib `http.server.BaseHTTPRequestHandler`, mirroring
+`worker/heartbeat.py`'s existing pattern — not an async handler on
+`WorkerRunner`'s main event loop.
+
+**Why.** `heartbeat.py` already documents the exact failure mode this
+avoids: "heartbeat renewal is never starved by long-running tasks in the
+main event loop (e.g. LLM/LangGraph calls that hold the loop for tens of
+seconds)." An async health handler on the main loop would be unreachable
+during exactly the scenario an operator most wants to observe — the loop
+being stuck — degrading a diagnosable `503 consumer_stalled` into an
+unexplained connection timeout. A dedicated thread can always respond,
+because `WorkerRunner`'s internal state (`_is_consumer_healthy()`,
+`_admin_lifecycle`) is read via simple attribute access, safe across
+threads under the GIL without extra locking.
+
+**Alternative rejected.** Async handler on the main loop. Rejected because
+it degrades precisely when the signal matters most (see above). Also
+rejected: a new HTTP framework dependency (aiohttp/FastAPI) — stdlib
+`http.server` is already the proven, dependency-free pattern this codebase
+uses for `libs/by-framework-dashboard`.
+
+### 4. Opt-in, no default port
+
+**Decision.** `health_port: Optional[int] = None` on `run_worker()`;
+`--health-port`/`BYAI_WORKER_HEALTH_PORT` on the CLI. Unset (the default) =
+the health-check thread never starts, no port opens. No fallback default
+port number is provided if the flag is set — a concrete port must be given.
+
+**Why.** Opening a new network port is a behavior change for every existing
+deployment that upgrades. Defaulting it on would silently add a listening
+port to processes that never asked for one — a footgun for bare-metal/plain-
+process deployments that don't containerize at all. Requiring an explicit
+port (rather than a flag-with-a-baked-in-default) forces the deployer to
+consciously pick a port that doesn't collide with anything else in their
+environment, consistent with `deploy/`'s pattern: the framework provides
+the primitive, opt-in; `deploy/`'s reference artifacts turn it on by
+default *for that reference setup only*.
+
+### 5. `/readyz`, distinct from the dashboard's `/api/health`
+
+**Decision.** Path is `/readyz`.
+
+**Why.** Kubernetes' own control-plane components expose `/healthz`,
+`/readyz`, and `/livez` as three *separately-named, differently-behaved*
+endpoints specifically to avoid the ambiguity of one generic "health" path
+meaning different things to different callers. `/readyz` borrows that
+convention to say, unambiguously, "this is readiness, nothing else." It is
+deliberately not named `/health` or `/healthz` to avoid confusion with
+`libs/by-framework-dashboard`'s `/api/health`, which is a *different kind of
+endpoint* — an always-200 observability payload for humans/dashboards, not
+a pass/fail probe (see Decision 2's "why" for why conflating those two
+shapes under a similar name would be a trap for the next person wiring a
+probe against "the health endpoint").
+
+### 6. Starts early, flips to `draining` immediately on shutdown
+
+**Decision.** `WorkerHealthServer` starts as early as possible in
+`WorkerRunner.start()` (before `setup_control_streams()`), reporting
+`starting` honestly until the consume loop's first successful tick. On
+`SIGTERM`/`SIGINT`, `reason` flips to `draining` as the very first step of
+`WorkerRunner._shutdown()` — before in-flight tasks finish draining, not
+after.
+
+**Why (start early).** If the port doesn't open until the Worker is fully
+initialized, a probe hitting it during startup gets connection-refused,
+indistinguishable from "this Worker crashed before ever starting" — losing
+exactly the diagnostic value (a body saying `"reason": "starting"`) this
+endpoint exists to provide, and making `initialDelaySeconds`/
+`start_period` tuning guesswork instead of "however long `starting` is
+normally observed to last."
+
+**Why (flip on signal, not after drain).** Readiness means "should this
+replica currently be counted as available" — a Worker that has already
+begun exiting should stop being counted the instant that's true, not once
+it finishes exiting (at which point the process is gone anyway and the
+question is moot). This is safe only because of Decision 1: a `503` here
+never kills anything, it only stops counting a replica that was going away
+regardless.
+
+## Body schema
+
+```json
+{
+  "ready": false,
+  "reason": "suspended",
+  "worker_id": "worker-01",
+  "admin_lifecycle": "suspended",
+  "consumer_healthy": true,
+  "uptime_ms": 12345
+}
+```
+
+`reason` priority order, first match wins:
+
+1. `starting` — heartbeat/consumer loop hasn't completed its first tick yet
+2. `draining` — `SIGTERM`/`SIGINT` received, shutdown in progress
+3. `evicted` — `admin_lifecycle == "evicted"`
+4. `suspended` — `admin_lifecycle == "suspended"`
+5. `consumer_stalled` — consume loop stale past `_consumer_health_timeout_seconds`
+6. `serving` — none of the above; `ready=true`
+
+`ready` is `true` if and only if `reason == "serving"`.
+
+No authentication. The body must never carry secrets (Redis host,
+credentials, connection strings) — enforce this at review time for any
+future field added here, since that's the only thing that would turn "no
+auth needed" from a correct call into a vulnerability.
+
+## Hard rule
+
+**This endpoint must never be wired to a Kubernetes `livenessProbe`, a
+Docker restart-on-unhealthy supervisor, or anything else that reacts to
+"not ready" by killing/restarting the process.** Everything in Decision 6
+(flip to `draining` while still mid-drain, report `suspended`/`evicted` as
+not-ready) is safe *specifically because* nothing currently reacts to this
+endpoint by killing anything. Adding such a consumer later — even a
+seemingly unrelated one, e.g. a script that restarts "unhealthy" containers
+— silently reintroduces the exact restart-storm/premature-kill risk
+Decision 1 was written to avoid. If a genuine liveness need shows up later,
+it needs its own signal and its own design, not a repurposing of this one.

--- a/examples/send_and_verify.py
+++ b/examples/send_and_verify.py
@@ -28,7 +28,16 @@ async def _send_with_retry(client: GatewayClient, **kwargs):
     which is easy to miss since nothing looks like a failure at the call
     site. The Worker container may still be starting/registering when this
     script first runs, so callers MUST check .success, not just "did this
-    not raise"."""
+    not raise".
+
+    Kept even though deploy-smoke-test.yml's `docker compose up --wait`
+    already waits for /readyz to report "serving": readyz flips to serving
+    the instant WorkerRunner's consume loop ticks once, which happens
+    slightly *before* the Worker registers itself online in Redis
+    (heartbeat/registration starts after that same tick, not before) - see
+    docs/architecture/worker-readiness-endpoint.md. So "--wait succeeded"
+    narrows the race but doesn't fully close it; this retry loop is the
+    layer that actually does."""
     while True:
         resp = await client.send_message(**kwargs)
         if resp.success:

--- a/src/by_framework/__main__.py
+++ b/src/by_framework/__main__.py
@@ -101,6 +101,17 @@ def parse_args():
     parser.add_argument(
         "--redis-max-connections", type=int, help="Max Redis connections allowed"
     )
+    parser.add_argument(
+        "--health-port",
+        type=int,
+        default=None,
+        help=(
+            "Port for the local /readyz readiness endpoint (Docker/Kubernetes "
+            "health checks). Opt-in only - omit to leave it disabled, no "
+            "default port is provided. Also settable via BYAI_WORKER_HEALTH_PORT. "
+            "See docs/architecture/worker-readiness-endpoint.md."
+        ),
+    )
 
     return parser.parse_args()
 
@@ -146,6 +157,7 @@ def main():
         max_concurrency=args.max_concurrency,
         fetch_count=args.fetch_count,
         redis_max_connections=args.redis_max_connections,
+        health_port=args.health_port,
     )
 
 

--- a/src/by_framework/worker/app.py
+++ b/src/by_framework/worker/app.py
@@ -109,6 +109,7 @@ async def _run_worker_async(
     layout_builder: Optional[DataLayoutBuilder] = None,
     redis_mode: Optional[Literal["standalone", "cluster"]] = None,
     redis_cluster_nodes: Optional[List[Tuple[str, int]]] = None,
+    health_port: Optional[int] = None,
     **worker_kwargs,
 ):
     """Async worker runner initialization."""
@@ -244,6 +245,7 @@ async def _run_worker_async(
         group_name=consumer_group,
         max_concurrency=max_concurrency,
         fetch_count=fetch_count,
+        health_port=health_port,
     )
 
     try:
@@ -309,6 +311,7 @@ def run_worker(
     layout_builder: Optional[DataLayoutBuilder] = None,
     redis_mode: Optional[Literal["standalone", "cluster"]] = None,
     redis_cluster_nodes: Optional[List[Tuple[str, int]]] = None,
+    health_port: Optional[int] = None,
     **worker_kwargs,
 ):
     """
@@ -354,6 +357,13 @@ def run_worker(
         max_concurrency = int(os.environ.get("BYAI_WORKER_CONCURRENCY", 50))
     if fetch_count is None:
         fetch_count = int(os.environ.get("BYAI_WORKER_FETCH_COUNT", 10))
+    if health_port is None:
+        # Opt-in only, unlike the two above - no default port number, stays
+        # None (disabled) unless explicitly set. See
+        # docs/architecture/worker-readiness-endpoint.md Decision 4.
+        env_health_port = os.environ.get("BYAI_WORKER_HEALTH_PORT")
+        if env_health_port:
+            health_port = int(env_health_port)
 
     try:
         asyncio.run(
@@ -381,6 +391,7 @@ def run_worker(
                     layout_builder=layout_builder,
                     redis_mode=redis_mode,
                     redis_cluster_nodes=redis_cluster_nodes,
+                    health_port=health_port,
                     **worker_kwargs,
                 )
             )

--- a/src/by_framework/worker/health_server.py
+++ b/src/by_framework/worker/health_server.py
@@ -1,0 +1,169 @@
+"""Worker readiness HTTP endpoint for Docker/Kubernetes health checks.
+
+See docs/architecture/worker-readiness-endpoint.md for the full design
+record (why readiness-only, why a dedicated thread, why /readyz, the
+reason-priority order, and the hard rule against ever wiring this to a
+liveness probe).
+"""
+
+import json
+import threading
+import time
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Callable, Optional
+from urllib.parse import urlparse
+
+from by_framework.common.logger import logger
+
+READYZ_PATH = "/readyz"
+
+
+def _make_readyz_handler(
+    compute_state: Callable[[], dict],
+) -> type[BaseHTTPRequestHandler]:
+    """Build a request handler bound to the given state computation."""
+
+    class ReadyzHandler(BaseHTTPRequestHandler):
+        """Serves /readyz; every other path is 404."""
+
+        server_version = "ByFrameworkWorkerReadiness/0.1"
+
+        def do_GET(self) -> None:  # pylint: disable=invalid-name
+            if urlparse(self.path).path != READYZ_PATH:
+                self.send_response(HTTPStatus.NOT_FOUND)
+                self.end_headers()
+                return
+
+            state = compute_state()
+            status = HTTPStatus.OK if state["ready"] else HTTPStatus.SERVICE_UNAVAILABLE
+            body = json.dumps(state).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args) -> None:  # pylint: disable=redefined-builtin
+            # The stdlib default logs every request to stderr - a probe
+            # hitting this every few seconds would spam Worker logs.
+            pass
+
+    return ReadyzHandler
+
+
+class WorkerHealthServer:
+    """Runs /readyz on a dedicated thread, never the Worker's main event loop.
+
+    Mirrors WorkerHeartbeat's "dedicated thread" pattern for the same
+    reason: a busy consume loop must not make readiness checks
+    unreachable. Reads Worker state via plain callables passed in by the
+    caller (WorkerRunner) - this class has no knowledge of WorkerRunner
+    itself, so it can be started standalone against fake state in tests.
+    """
+
+    def __init__(
+        self,
+        worker_id: str,
+        port: int,
+        has_started: Callable[[], bool],
+        is_draining: Callable[[], bool],
+        admin_lifecycle: Callable[[], str],
+        consumer_healthy: Callable[[], bool],
+        host: str = "0.0.0.0",
+    ):
+        self.worker_id = worker_id
+        self.host = host
+        self.port = port
+        self._has_started = has_started
+        self._is_draining = is_draining
+        self._admin_lifecycle = admin_lifecycle
+        self._consumer_healthy = consumer_healthy
+        self._server: Optional[ThreadingHTTPServer] = None
+        self._thread: Optional[threading.Thread] = None
+        self._started_at_monotonic = 0.0
+
+    @staticmethod
+    def _compute_reason(
+        has_started: bool,
+        is_draining: bool,
+        admin_lifecycle: str,
+        consumer_healthy: bool,
+    ) -> str:
+        # Priority order, first match wins - see
+        # docs/architecture/worker-readiness-endpoint.md.
+        if not has_started:
+            return "starting"
+        if is_draining:
+            return "draining"
+        if admin_lifecycle == "evicted":
+            return "evicted"
+        if admin_lifecycle == "suspended":
+            return "suspended"
+        if not consumer_healthy:
+            return "consumer_stalled"
+        return "serving"
+
+    def _compute_state(self) -> dict:
+        # Read each accessor once - _compute_reason() takes the values
+        # rather than re-deriving them, so a request never calls into
+        # WorkerRunner's state twice for the same field.
+        admin_lifecycle = self._admin_lifecycle()
+        consumer_healthy = self._consumer_healthy()
+        reason = self._compute_reason(
+            has_started=self._has_started(),
+            is_draining=self._is_draining(),
+            admin_lifecycle=admin_lifecycle,
+            consumer_healthy=consumer_healthy,
+        )
+        uptime_ms = 0
+        if self._started_at_monotonic:
+            uptime_ms = int((time.monotonic() - self._started_at_monotonic) * 1000)
+        return {
+            "ready": reason == "serving",
+            "reason": reason,
+            "worker_id": self.worker_id,
+            "admin_lifecycle": admin_lifecycle,
+            "consumer_healthy": consumer_healthy,
+            "uptime_ms": uptime_ms,
+        }
+
+    @property
+    def is_running(self) -> bool:
+        """Whether the server has actually bound and is serving - distinct
+        from the WorkerHealthServer object merely having been constructed."""
+        return self._server is not None
+
+    def start(self) -> None:
+        """Bind and start serving /readyz on a dedicated thread. No-op if
+        already started."""
+        if self._server is not None:
+            return
+        self._started_at_monotonic = time.monotonic()
+        handler = _make_readyz_handler(self._compute_state)
+        self._server = ThreadingHTTPServer((self.host, self.port), handler)
+        self.port = self._server.server_address[1]
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            daemon=True,
+            name=f"health-server-{self.worker_id}",
+        )
+        self._thread.start()
+        logger.info(
+            "[%s] Readiness endpoint listening on %s:%d%s",
+            self.worker_id,
+            self.host,
+            self.port,
+            READYZ_PATH,
+        )
+
+    def stop(self) -> None:
+        """Stop serving and release the port. Safe to call more than once."""
+        if self._server is None:
+            return
+        self._server.shutdown()
+        self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+        self._server = None
+        self._thread = None

--- a/src/by_framework/worker/runner.py
+++ b/src/by_framework/worker/runner.py
@@ -41,6 +41,7 @@ from by_framework.trace.trace_schema import TraceRecord
 from by_framework.trace.trace_writer import TraceWriteClient
 from by_framework.util.generate_message_id import generate_message_id
 from by_framework.worker.context import current_worker_id_var
+from by_framework.worker.health_server import WorkerHealthServer
 from by_framework.worker.worker import GatewayWorker
 
 from ._control_handling import (
@@ -69,6 +70,7 @@ class WorkerRunner:
         max_concurrency: int = 50,
         fetch_count: int = 10,
         span_recorder: Optional[SpanRecorder] = None,
+        health_port: Optional[int] = None,
     ):
         if (
             worker is None
@@ -117,6 +119,22 @@ class WorkerRunner:
             float(self.worker.heartbeat_lease_ttl_seconds) * 2.0,
             stream_block_seconds * 3.0,
         )
+        # Set as the first step of _shutdown() - see
+        # docs/architecture/worker-readiness-endpoint.md Decision 6.
+        self._draining: bool = False
+        # Opt-in only - see docs/architecture/worker-readiness-endpoint.md.
+        # None (the default) means no port opens and nothing here changes
+        # behavior for existing deployments.
+        self._health_server: Optional[WorkerHealthServer] = None
+        if health_port is not None:
+            self._health_server = WorkerHealthServer(
+                worker_id=self.worker.worker_id,
+                port=health_port,
+                has_started=lambda: self._consumer_last_tick_monotonic > 0,
+                is_draining=lambda: self._draining,
+                admin_lifecycle=lambda: self._admin_lifecycle,
+                consumer_healthy=self._is_consumer_healthy,
+            )
 
     @property
     def _terminal_execution_states(self) -> frozenset[str]:
@@ -916,6 +934,12 @@ class WorkerRunner:
         """Start the worker runner main loop."""
         self._running_tasks = set()
         try:
+            # As early as possible, so a probe hitting the port during
+            # startup gets an honest "starting" 503 instead of connection-
+            # refused - see docs/architecture/worker-readiness-endpoint.md.
+            if self._health_server is not None:
+                self._health_server.start()
+
             if hasattr(self.worker.registry, "claim_worker_id"):
                 self._lock_token = await self._claim_worker_id_with_retry()
 
@@ -984,6 +1008,10 @@ class WorkerRunner:
 
     async def _shutdown(self):
         """Graceful shutdown sequence."""
+        # First step, deliberately - readiness must flip the instant
+        # shutdown begins, not once the drain below finishes. See
+        # docs/architecture/worker-readiness-endpoint.md Decision 6.
+        self._draining = True
         if self._metrics_collector_task:
             self._metrics_collector_task.cancel()
             await asyncio.gather(self._metrics_collector_task, return_exceptions=True)
@@ -1029,3 +1057,8 @@ class WorkerRunner:
             if getattr(plugin_registry, "log_hook_stats_on_shutdown", True):
                 plugin_registry.log_hook_stats()
             await plugin_registry.on_worker_shutdown(self.worker)
+
+        # Stopped last, deliberately - the readiness endpoint should keep
+        # responding for the entire drain, not disappear before it.
+        if self._health_server is not None:
+            self._health_server.stop()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -111,3 +111,70 @@ def test_main_leaves_cluster_nodes_none_when_flag_not_passed():
 
     _, kwargs = mock_run_worker.call_args
     assert kwargs["redis_cluster_nodes"] is None
+
+
+def test_parse_args_health_port_defaults_to_none():
+    """Opt-in only - see docs/architecture/worker-readiness-endpoint.md
+    Decision 4. Omitting --health-port must mean the endpoint never
+    starts."""
+    with patch("sys.argv", ["by_framework", "--worker-class", "my_agent.MyAgent"]):
+        args = parse_args()
+
+    assert args.health_port is None
+
+
+def test_parse_args_accepts_health_port():
+    with patch(
+        "sys.argv",
+        [
+            "by_framework",
+            "--worker-class",
+            "my_agent.MyAgent",
+            "--health-port",
+            "9000",
+        ],
+    ):
+        args = parse_args()
+
+    assert args.health_port == 9000
+
+
+def test_main_passes_health_port_through_to_run_worker():
+    with (
+        patch(
+            "sys.argv",
+            [
+                "by_framework",
+                "--worker-class",
+                "my_agent.MyAgent",
+                "--health-port",
+                "9000",
+            ],
+        ),
+        patch("by_framework.__main__.get_class_from_string") as mock_get_class,
+        patch("by_framework.__main__.run_worker") as mock_run_worker,
+    ):
+        mock_worker_class = MagicMock()
+        mock_worker_class.__name__ = "MyAgent"
+        mock_get_class.return_value = mock_worker_class
+
+        main()
+
+    _, kwargs = mock_run_worker.call_args
+    assert kwargs["health_port"] == 9000
+
+
+def test_main_leaves_health_port_none_when_flag_not_passed():
+    with (
+        patch("sys.argv", ["by_framework", "--worker-class", "my_agent.MyAgent"]),
+        patch("by_framework.__main__.get_class_from_string") as mock_get_class,
+        patch("by_framework.__main__.run_worker") as mock_run_worker,
+    ):
+        mock_worker_class = MagicMock()
+        mock_worker_class.__name__ = "MyAgent"
+        mock_get_class.return_value = mock_worker_class
+
+        main()
+
+    _, kwargs = mock_run_worker.call_args
+    assert kwargs["health_port"] is None

--- a/tests/worker/test_app.py
+++ b/tests/worker/test_app.py
@@ -172,6 +172,37 @@ async def test_run_worker_async_flow():
 
 
 @pytest.mark.asyncio
+async def test_run_worker_async_passes_health_port_through_to_runner():
+    """health_port must reach WorkerRunner so the opt-in readiness endpoint
+    (see docs/architecture/worker-readiness-endpoint.md) actually starts."""
+    with (
+        patch("by_framework.worker.app.init_redis") as mock_init_redis,
+        patch("by_framework.worker.app.close_redis", new_callable=AsyncMock),
+        patch("by_framework.worker.app.WorkerRegistry"),
+        patch("by_framework.worker.app.WorkspaceManager"),
+        patch("by_framework.worker.app.WorkerRunner") as mock_runner,
+    ):
+        mock_init_redis.return_value = MagicMock()
+        mock_runner.return_value.start = AsyncMock()
+
+        await _run_worker_async(
+            worker_class=MyTestWorker,
+            worker_id="test-w1",
+            redis_host="localhost",
+            redis_port=6379,
+            redis_db=0,
+            redis_password=None,
+            redis_username=None,
+            workspace_dir="/tmp/test-ws",
+            consumer_group="test-group",
+            health_port=9000,
+        )
+
+        _, runner_kwargs = mock_runner.call_args
+        assert runner_kwargs["health_port"] == 9000
+
+
+@pytest.mark.asyncio
 async def test_run_worker_async_standalone_falls_back_to_env_when_arg_not_passed():
     """Standalone mode must respect REDIS_HOST/REDIS_PASSWORD env vars when
     the caller doesn't pass the corresponding explicit arg — today it
@@ -725,3 +756,75 @@ def test_run_worker_sync_entry():
         # Verify the SIGTERM/SIGINT-handling wrapper actually wraps the
         # _run_worker_async coroutine, not something else.
         mock_graceful_shutdown.assert_called_once_with(mock_run_async.return_value)
+
+
+def test_run_worker_sync_entry_passes_health_port_through():
+    """health_port must reach _run_worker_async from the sync entry point too."""
+    with (
+        patch("by_framework.worker.app.asyncio.run"),
+        patch(
+            "by_framework.worker.app._run_worker_async", new_callable=MagicMock
+        ) as mock_run_async,
+        patch(
+            "by_framework.worker.app._run_with_graceful_shutdown",
+            new_callable=MagicMock,
+        ),
+    ):
+        run_worker(worker_class=MyTestWorker, worker_id="sync-w1", health_port=9000)
+
+        _, kwargs = mock_run_async.call_args
+        assert kwargs["health_port"] == 9000
+
+
+def test_run_worker_sync_entry_health_port_defaults_to_none():
+    """Omitting health_port must default to None (off) - opt-in only."""
+    with (
+        patch("by_framework.worker.app.asyncio.run"),
+        patch(
+            "by_framework.worker.app._run_worker_async", new_callable=MagicMock
+        ) as mock_run_async,
+        patch(
+            "by_framework.worker.app._run_with_graceful_shutdown",
+            new_callable=MagicMock,
+        ),
+    ):
+        run_worker(worker_class=MyTestWorker, worker_id="sync-w1")
+
+        _, kwargs = mock_run_async.call_args
+        assert kwargs["health_port"] is None
+
+
+def test_run_worker_sync_entry_health_port_falls_back_to_env_var():
+    with (
+        patch.dict("os.environ", {"BYAI_WORKER_HEALTH_PORT": "9001"}, clear=False),
+        patch("by_framework.worker.app.asyncio.run"),
+        patch(
+            "by_framework.worker.app._run_worker_async", new_callable=MagicMock
+        ) as mock_run_async,
+        patch(
+            "by_framework.worker.app._run_with_graceful_shutdown",
+            new_callable=MagicMock,
+        ),
+    ):
+        run_worker(worker_class=MyTestWorker, worker_id="sync-w1")
+
+        _, kwargs = mock_run_async.call_args
+        assert kwargs["health_port"] == 9001
+
+
+def test_run_worker_sync_entry_health_port_explicit_arg_overrides_env_var():
+    with (
+        patch.dict("os.environ", {"BYAI_WORKER_HEALTH_PORT": "9001"}, clear=False),
+        patch("by_framework.worker.app.asyncio.run"),
+        patch(
+            "by_framework.worker.app._run_worker_async", new_callable=MagicMock
+        ) as mock_run_async,
+        patch(
+            "by_framework.worker.app._run_with_graceful_shutdown",
+            new_callable=MagicMock,
+        ),
+    ):
+        run_worker(worker_class=MyTestWorker, worker_id="sync-w1", health_port=9002)
+
+        _, kwargs = mock_run_async.call_args
+        assert kwargs["health_port"] == 9002

--- a/tests/worker/test_health_server.py
+++ b/tests/worker/test_health_server.py
@@ -1,0 +1,256 @@
+"""Contract tests for the Worker readiness HTTP endpoint (/readyz).
+
+Mirrors libs/by-framework-dashboard/tests/test_dashboard_server.py's
+pattern: bind a real server to an OS-assigned ephemeral port, exercise it
+with a real HTTP client, assert on the real response - never reach into
+private state.
+"""
+
+import http.client
+import json
+
+import pytest
+
+from by_framework.worker.health_server import WorkerHealthServer
+
+
+def _start(**overrides):
+    defaults = {
+        "worker_id": "worker-1",
+        "port": 0,
+        "has_started": lambda: False,
+        "is_draining": lambda: False,
+        "admin_lifecycle": lambda: "active",
+        "consumer_healthy": lambda: True,
+    }
+    defaults.update(overrides)
+    server = WorkerHealthServer(**defaults)
+    server.start()
+    return server
+
+
+def _get(server, path="/readyz"):
+    connection = http.client.HTTPConnection("127.0.0.1", server.port, timeout=5)
+    try:
+        connection.request("GET", path)
+        response = connection.getresponse()
+        raw = response.read()
+        body = json.loads(raw.decode("utf-8")) if raw else None
+        return response.status, body
+    finally:
+        connection.close()
+
+
+def test_readyz_reports_starting_before_consumer_has_ticked():
+    server = _start(has_started=lambda: False)
+    try:
+        status, body = _get(server)
+    finally:
+        server.stop()
+
+    assert status == 503
+    assert body["ready"] is False
+    assert body["reason"] == "starting"
+
+
+def test_readyz_reports_serving_once_consumer_has_ticked():
+    server = _start(has_started=lambda: True)
+    try:
+        status, body = _get(server)
+    finally:
+        server.stop()
+
+    assert status == 200
+    assert body["ready"] is True
+    assert body["reason"] == "serving"
+
+
+def test_readyz_reports_draining_once_shutdown_signal_received():
+    server = _start(has_started=lambda: True, is_draining=lambda: True)
+    try:
+        status, body = _get(server)
+    finally:
+        server.stop()
+
+    assert status == 503
+    assert body["ready"] is False
+    assert body["reason"] == "draining"
+
+
+def test_draining_outranks_serving_even_if_consumer_still_healthy():
+    # A Worker mid-shutdown must never be reported "serving", regardless of
+    # whether its consume loop happens to still be healthy in the meantime.
+    server = _start(
+        has_started=lambda: True,
+        is_draining=lambda: True,
+        consumer_healthy=lambda: True,
+    )
+    try:
+        _, body = _get(server)
+    finally:
+        server.stop()
+
+    assert body["reason"] == "draining"
+
+
+def test_starting_outranks_draining():
+    # Priority order per docs/architecture/worker-readiness-endpoint.md:
+    # starting > draining. A Worker that receives a shutdown signal before
+    # it ever finished starting reports "starting", not "draining".
+    server = _start(has_started=lambda: False, is_draining=lambda: True)
+    try:
+        _, body = _get(server)
+    finally:
+        server.stop()
+
+    assert body["reason"] == "starting"
+
+
+def test_readyz_reports_suspended_from_admin_lifecycle():
+    server = _start(has_started=lambda: True, admin_lifecycle=lambda: "suspended")
+    try:
+        status, body = _get(server)
+    finally:
+        server.stop()
+
+    assert status == 503
+    assert body["ready"] is False
+    assert body["reason"] == "suspended"
+    assert body["admin_lifecycle"] == "suspended"
+
+
+def test_readyz_reports_evicted_from_admin_lifecycle():
+    server = _start(has_started=lambda: True, admin_lifecycle=lambda: "evicted")
+    try:
+        status, body = _get(server)
+    finally:
+        server.stop()
+
+    assert status == 503
+    assert body["ready"] is False
+    assert body["reason"] == "evicted"
+    assert body["admin_lifecycle"] == "evicted"
+
+
+def test_draining_outranks_suspended_and_evicted():
+    for lifecycle in ("suspended", "evicted"):
+        server = _start(
+            has_started=lambda: True,
+            is_draining=lambda: True,
+            admin_lifecycle=lambda lc=lifecycle: lc,
+        )
+        try:
+            _, body = _get(server)
+        finally:
+            server.stop()
+
+        assert body["reason"] == "draining"
+
+
+def test_readyz_reports_consumer_stalled_once_started_but_gone_stale():
+    server = _start(has_started=lambda: True, consumer_healthy=lambda: False)
+    try:
+        status, body = _get(server)
+    finally:
+        server.stop()
+
+    assert status == 503
+    assert body["ready"] is False
+    assert body["reason"] == "consumer_stalled"
+    assert body["consumer_healthy"] is False
+
+
+def test_consumer_stalled_is_lowest_priority():
+    # suspended/evicted/draining must all outrank consumer_stalled - an
+    # administratively-paused or shutting-down Worker is never reported as
+    # merely stalled, even if its consume loop also happens to be stale.
+    for override in (
+        {"is_draining": lambda: True},
+        {"admin_lifecycle": lambda: "suspended"},
+        {"admin_lifecycle": lambda: "evicted"},
+    ):
+        server = _start(
+            has_started=lambda: True, consumer_healthy=lambda: False, **override
+        )
+        try:
+            _, body = _get(server)
+        finally:
+            server.stop()
+
+        assert body["reason"] != "consumer_stalled"
+
+
+def test_readyz_body_includes_diagnostic_fields():
+    server = _start(
+        worker_id="worker-42",
+        has_started=lambda: True,
+        admin_lifecycle=lambda: "active",
+        consumer_healthy=lambda: True,
+    )
+    try:
+        _, body = _get(server)
+    finally:
+        server.stop()
+
+    assert body["worker_id"] == "worker-42"
+    assert body["admin_lifecycle"] == "active"
+    assert body["consumer_healthy"] is True
+    assert isinstance(body["uptime_ms"], int)
+    assert body["uptime_ms"] >= 0
+
+
+def test_readyz_body_never_leaks_secrets():
+    server = _start()
+    try:
+        _, body = _get(server)
+    finally:
+        server.stop()
+
+    serialized = json.dumps(body).lower()
+    for forbidden in ("password", "redis://", "token", "secret"):
+        assert forbidden not in serialized
+
+
+def test_unknown_path_returns_404():
+    server = _start()
+    try:
+        status, _ = _get(server, path="/nope")
+    finally:
+        server.stop()
+
+    assert status == 404
+
+
+def test_start_is_idempotent_and_stop_frees_the_port():
+    server = _start(has_started=lambda: True)
+    server.start()  # calling start() twice must not raise or rebind
+
+    status, _ = _get(server)
+    assert status == 200
+
+    server.stop()
+    with pytest.raises(ConnectionRefusedError):
+        _get(server)
+
+
+def test_is_running_reflects_actual_bind_state():
+    server = WorkerHealthServer(
+        worker_id="worker-1",
+        port=0,
+        has_started=lambda: True,
+        is_draining=lambda: False,
+        admin_lifecycle=lambda: "active",
+        consumer_healthy=lambda: True,
+    )
+    assert server.is_running is False
+
+    server.start()
+    assert server.is_running is True
+    assert server.port != 0  # sanity: an ephemeral port was actually assigned
+
+    server.stop()
+    assert server.is_running is False
+
+    # Stopping an already-stopped server must be a safe no-op.
+    server.stop()
+    assert server.is_running is False

--- a/tests/worker/test_runner.py
+++ b/tests/worker/test_runner.py
@@ -1,4 +1,5 @@
 import asyncio
+import http.client
 import json
 import unittest
 from typing import Any
@@ -16,10 +17,41 @@ from by_framework.core.protocol.agent_state import AgentState
 from by_framework.core.protocol.commands import (
     AskAgentCommand,
     CancelTaskCommand,
+    EvictWorkerCommand,
     ReloadPluginsCommand,
     ResumeCommand,
+    SuspendWorkerCommand,
 )
 from by_framework.core.protocol.message_header import MessageHeader
+
+
+def _request_readyz(port: int):
+    connection = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+    try:
+        connection.request("GET", "/readyz")
+        response = connection.getresponse()
+        body = json.loads(response.read().decode("utf-8"))
+        return response.status, body
+    finally:
+        connection.close()
+
+
+async def _wait_until(predicate, timeout=2.0, interval=0.02):
+    """Poll predicate (which may itself raise, e.g. ConnectionRefusedError
+    while a server is still binding) until it returns truthy or timeout."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    last_exc = None
+    while loop.time() < deadline:
+        try:
+            if predicate():
+                return
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            last_exc = exc
+        await asyncio.sleep(interval)
+    if last_exc is not None:
+        raise last_exc
+    raise AssertionError("condition not met within timeout")
 
 
 class MockRedisRunner:
@@ -894,6 +926,177 @@ class TestWorkerRunner(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(handled)
         runner._handle_control_message.assert_not_called()
         self.assertTrue(redis_mock.acked)
+
+    async def test_runner_health_endpoint_is_wired_into_startup_and_shutdown(self):
+        """Supplying health_port starts a real /readyz server during real
+        startup, tied to the real consume loop's liveness signal via
+        _mark_consumer_tick(), and tears it down on shutdown."""
+        worker = DummyWorker()
+        worker.start_heartbeat = AsyncMock()
+        worker.stop_heartbeat = AsyncMock()
+        redis_mock = MockRedisRunner(message_to_return=[])
+        runner = WorkerRunner(
+            redis_client=redis_mock,
+            worker=worker,
+            group_name="test_group",
+            health_port=0,
+        )
+        runner._control_loop = AsyncMock()
+
+        run_task = asyncio.ensure_future(runner.start())
+        try:
+            await _wait_until(lambda: runner._health_server.is_running)
+            port = runner._health_server.port
+            await _wait_until(lambda: _request_readyz(port)[0] in (200, 503))
+
+            status, body = _request_readyz(port)
+            self.assertEqual(status, 200)
+            self.assertTrue(body["ready"])
+            self.assertEqual(body["reason"], "serving")
+        finally:
+            run_task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await run_task
+
+        with self.assertRaises(ConnectionRefusedError):
+            _request_readyz(port)
+
+    async def test_runner_shutdown_reports_draining_before_health_server_stops(self):
+        """_shutdown() must flip to draining as its first step - before the
+        rest of the drain runs, not after - and the readiness server must
+        stay reachable (still reporting draining) throughout the drain,
+        not disappear before it. Hooks into stop_heartbeat, which
+        _shutdown() calls partway through, to observe /readyz mid-drain."""
+        worker = DummyWorker()
+        redis_mock = MockRedisRunner(message_to_return=[])
+        runner = WorkerRunner(
+            redis_client=redis_mock,
+            worker=worker,
+            group_name="test_group",
+            health_port=0,
+        )
+        runner._health_server.start()
+        runner._mark_consumer_tick()  # simulate "already past starting"
+        observed = {}
+
+        async def observe_mid_shutdown():
+            port = runner._health_server.port
+            observed["status"], observed["body"] = _request_readyz(port)
+
+        worker.stop_heartbeat = observe_mid_shutdown
+
+        await runner._shutdown()
+
+        self.assertEqual(observed["status"], 503)
+        self.assertEqual(observed["body"]["reason"], "draining")
+        # And the server itself is torn down only once the drain is done.
+        self.assertFalse(runner._health_server.is_running)
+
+    async def test_runner_without_health_port_starts_no_server(self):
+        """Omitting health_port must leave _health_server unset - the
+        default (opted-out) case must have zero new behavior."""
+        worker = DummyWorker()
+        redis_mock = MockRedisRunner(message_to_return=[])
+        runner = WorkerRunner(
+            redis_client=redis_mock, worker=worker, group_name="test_group"
+        )
+
+        self.assertIsNone(runner._health_server)
+
+    async def test_runner_health_endpoint_reflects_admin_suspend_and_evict_live(self):
+        """Real SuspendWorkerCommand/EvictWorkerCommand messages, dispatched
+        through the Worker's actual control-message pipeline
+        (_run_control_once -> parse_control_command ->
+        handle_suspend_worker/handle_evict_worker - not just the
+        _set_admin_lifecycle callback directly), must be reflected in
+        /readyz immediately, without a process restart."""
+        worker = DummyWorker()
+        redis_mock = MockRedisRunner(message_to_return=[])
+        runner = WorkerRunner(
+            redis_client=redis_mock,
+            worker=worker,
+            group_name="test_group",
+            health_port=0,
+        )
+        runner._health_server.start()
+        runner._mark_consumer_tick()
+        # Fake a live _consumer_task so _is_consumer_healthy() reflects
+        # staleness, not "no task at all" - not what this test is about.
+        runner._consumer_task = asyncio.ensure_future(asyncio.sleep(10))
+        try:
+            _, body = _request_readyz(runner._health_server.port)
+            self.assertEqual(body["reason"], "serving")
+
+            suspend_cmd = SuspendWorkerCommand(
+                header=MessageHeader(session_id="s1", trace_id="t1", message_id="m1"),
+                reason="maintenance",
+            )
+            redis_mock.msg = [
+                [
+                    RedisKeys.worker_ctrl_stream("worker-1").encode(),
+                    [(b"1-0", {b"data": json.dumps(suspend_cmd.to_dict()).encode()})],
+                ]
+            ]
+            await runner._run_control_once(block=1)
+            _, body = _request_readyz(runner._health_server.port)
+            self.assertEqual(body["reason"], "suspended")
+
+            evict_cmd = EvictWorkerCommand(
+                header=MessageHeader(session_id="s1", trace_id="t1", message_id="m2"),
+                force=False,
+            )
+            redis_mock.msg = [
+                [
+                    RedisKeys.worker_ctrl_stream("worker-1").encode(),
+                    [(b"2-0", {b"data": json.dumps(evict_cmd.to_dict()).encode()})],
+                ]
+            ]
+            await runner._run_control_once(block=1)
+            _, body = _request_readyz(runner._health_server.port)
+            self.assertEqual(body["reason"], "evicted")
+        finally:
+            runner._health_server.stop()
+            runner._consumer_task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await runner._consumer_task
+
+    async def test_runner_health_endpoint_reflects_consumer_staleness_live(self):
+        """Transition from serving -> consumer_stalled -> serving must be
+        observable through /readyz without a restart, driven by the same
+        staleness signal (_consumer_last_tick_monotonic vs
+        _consumer_health_timeout_seconds) _is_consumer_healthy() already
+        uses internally."""
+        worker = DummyWorker()
+        redis_mock = MockRedisRunner(message_to_return=[])
+        runner = WorkerRunner(
+            redis_client=redis_mock,
+            worker=worker,
+            group_name="test_group",
+            health_port=0,
+        )
+        runner._health_server.start()
+        runner._mark_consumer_tick()
+        # Fake a _consumer_task so _is_consumer_healthy() doesn't
+        # short-circuit on "no task" - only staleness is under test here.
+        runner._consumer_task = asyncio.ensure_future(asyncio.sleep(10))
+        try:
+            _, body = _request_readyz(runner._health_server.port)
+            self.assertEqual(body["reason"], "serving")
+
+            runner._consumer_last_tick_monotonic -= (
+                runner._consumer_health_timeout_seconds + 1
+            )
+            _, body = _request_readyz(runner._health_server.port)
+            self.assertEqual(body["reason"], "consumer_stalled")
+
+            runner._mark_consumer_tick()
+            _, body = _request_readyz(runner._health_server.port)
+            self.assertEqual(body["reason"], "serving")
+        finally:
+            runner._health_server.stop()
+            runner._consumer_task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await runner._consumer_task
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Gives the Worker a local, unauthenticated `/readyz` HTTP endpoint so Docker `HEALTHCHECK`, Compose `depends_on: condition: service_healthy`, and Kubernetes `readinessProbe` have something to point at directly — previously the only signal was a Redis-backed heartbeat key, requiring a round-trip to read.

Full design record (why readiness-only, why a dedicated thread, why `/readyz`, the `reason` priority order, and the hard rule against ever wiring this to a liveness probe): `docs/architecture/worker-readiness-endpoint.md`.

Closes #84
Closes #85
Closes #86
Closes #87
Closes #88
Closes #83

## What's in this PR

- **New `WorkerHealthServer`** (`src/by_framework/worker/health_server.py`) — runs on a dedicated thread (mirrors `WorkerHeartbeat`'s existing pattern) so a busy consume loop can't make it unreachable. Computes a priority-ordered `reason` (`starting` > `draining` > `evicted` > `suspended` > `consumer_stalled` > `serving`) from Worker state read via injected callables — no new HTTP framework dependency, no reach into `WorkerRunner` internals.
- **`WorkerRunner` wiring** — starts the health server as the first step of `start()` (before control-stream setup, so a probe during startup gets an honest 503 instead of connection-refused) and stops it as the *last* step of `_shutdown()` (after flipping to `draining` as `_shutdown()`'s very first line, so `/readyz` stays reachable for the whole drain).
- **Opt-in only** — `run_worker()`/`--health-port`/`BYAI_WORKER_HEALTH_PORT` all default to unset. No port opens, no behavior change, unless a port is explicitly configured. No default port number is provided.
- **Readiness only, by design** — this must never be wired to a Kubernetes `livenessProbe` or any restart-on-unhealthy mechanism: a Worker's health is coupled to Redis reachability, so treating a transient Redis blip as a liveness failure would restart the entire fleet simultaneously. `deploy/kubernetes/worker-deployment.yaml` carries an explicit comment enforcing this.
- **`deploy/`'s reference Dockerfile/Compose/Kubernetes manifest** all wire it up out of the box; `deploy-smoke-test.yml` verifies it via `docker compose up --wait`, which fails the CI job if the endpoint never reports healthy in a real container.

## Test plan

- [x] Standalone HTTP-contract tests (`tests/worker/test_health_server.py`) — mirrors the observability dashboard's `ThreadingHTTPServer` + `http.client` test pattern, exhaustive `reason`/priority coverage against injected fake state
- [x] `WorkerRunner` wiring tests (`tests/worker/test_runner.py`) — real startup/shutdown against the existing fake-Redis lifecycle harness, including real `SuspendWorkerCommand`/`EvictWorkerCommand` messages dispatched through the actual control-message pipeline
- [x] `uv run pytest tests/` — 633 passed, 1 pre-existing unrelated failure (confirmed via `git stash` before this work started)
- [x] `make format`/`make lint` — pylint 10.00/10, ruff/isort clean
- [x] `bash scripts/verify.sh` — all guards green (including `docs/architecture/KEY_FILES.md` freshness)
- [x] Reviewed via a Standards/Spec two-axis code review against `upstream/main`; findings fixed inline (see commit message for detail)
- [ ] `docker compose -f deploy/docker-compose.yml up --build --wait` — not run locally (no Docker daemon available in the sandbox this was authored in); `deploy-smoke-test.yml` will exercise it in CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)