### PR TITLE
Unify call_agent/call_agents (dispatch_group) dispatch and resume behavior

### DIFF
--- a/.github/workflows/deploy-smoke-test.yml
+++ b/.github/workflows/deploy-smoke-test.yml
@@ -5,6 +5,11 @@ name: Deploy Smoke Test
 # -> Worker consumes -> Worker replies -> Redis data stream -> client reads
 # - using examples/echo_worker.py, built from THIS commit's source (not the
 # last PyPI release; see deploy/Dockerfile's BY_FRAMEWORK_SOURCE=local mode).
+# examples/send_and_verify.py also drives echo_worker.py's "fanout" agent
+# type, which fans out to two more "echo" calls via call_agents and resumes
+# on their aggregated Group Join result - the only place that path runs
+# against a real, separate-process Redis Streams deployment instead of the
+# in-memory fakes tests/ uses.
 # See docs/architecture/production-deployment.md.
 
 on:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,7 @@ Pre-commit hooks are configured in `.pre-commit-config.yaml` and run isort, ruff
 | Redis connection setup, cluster-mode, or key-schema versioning (`RedisConfig`, `RedisKeys`, `_get_redis()`, admin-index writes) | `docs/architecture/redis-cluster-mode.md` |
 | Worker deployment/production-readiness — README's 部署 section, `__main__.py` CLI flags, `run_worker()`'s signature, or shutdown/signal handling | `docs/architecture/production-deployment.md` |
 | Worker readiness/health-check endpoint (`WorkerHealthServer`, `/readyz`, `--health-port`) — building it, or touching anything that changes what "ready" means | `docs/architecture/worker-readiness-endpoint.md` |
+| Scatter-gather / Task Groups — `call_agents`/`dispatch_group`, Group Join, the `task_group:*` hash fields, or anything a Java/TS SDK also reads | `docs/adr/0001-unify-call-agent-and-call-agents-behavior.md` |
 
 ## Maintaining this map
 

--- a/README.md
+++ b/README.md
@@ -270,8 +270,8 @@ async def process_command(self, command, context: AgentContext):
         wait_for_reply=True,
     )
 
-    # Scatter-gather fan-out
-    group = await context.dispatch_group([
+    # Scatter-gather fan-out — call_agent's plural
+    group = await context.call_agents([
         {"target_agent_type": "researcher", "content": "Find references"},
         {"target_agent_type": "writer",    "content": "Draft summary"},
     ])
@@ -381,20 +381,58 @@ The framework handles:
 
 ### Scatter-Gather Dispatch
 
-Fan out multiple sub-tasks in parallel and collect their results:
+`call_agents` is `call_agent`'s plural: each task behaves exactly like the equivalent single
+`call_agent` call, and the caller is resumed once — with every task's result — after all of
+them complete. `dispatch_group` is a permanent alias of it, not deprecated.
 
 ```python
-group = await context.dispatch_group([
+group = await context.call_agents([
     {"target_agent_type": "researcher", "content": "Find papers"},
     {"target_agent_type": "analyst",    "content": "Summarize findings"},
 ], wait_for_reply=True)
-
-results = await context.collect_group_results(group["task_group_id"])
-for r in results.values():
-    print(r["content"])
+# {"status": "QUEUED", "task_group_id": "tg-...", "dispatched_tasks": [...]}
 ```
 
-Group progress is tracked in Redis; `dispatch_group` returns immediately with a `task_group_id` that can be polled via `collect_group_results`.
+The Worker is resumed with a `ResumeCommand` whose `reply_data` is the ordered aggregate,
+one entry per task, in dispatch order:
+
+```python
+async def process_command(self, command, context):
+    if isinstance(command, ResumeCommand):
+        for item in command.reply_data:
+            print(item["target_agent_type"], item["status"], item["content"])
+        # command.content is "" on a group resume: reply_data is the single
+        # aggregation channel.
+        return {"status": "completed", "content": summarize(command.reply_data)}
+```
+
+`collect_group_results(task_group_id)` remains available for polling the same results from
+outside a resume.
+
+Per task, every option `call_agent` takes is accepted, with the same defaults:
+
+| Key | Default | Notes |
+|---|---|---|
+| `target_agent_type` | — | required |
+| `content` | `""` | |
+| `extra_payload`, `metadata` | `{}` | |
+| `message_id` | generated | pass one per task; a batch cannot share one (results are keyed per sub-task) |
+| `route_policy` | `FAIL_FAST` | `SEND_ANYWAY` queues for an agent type whose workers have not started yet |
+| `availability_timeout_ms` | `30000` | |
+| `region`, `priority` | `None`, `0` | |
+
+Behavior worth knowing:
+
+- An unavailable target fails **that task only** — it is recorded as a `FAILED` entry in the
+  aggregate with `reply_data["error_code"]`, and its siblings still dispatch.
+- `call_agents([])` raises `ValueError` rather than silently succeeding.
+- A dispatch-time infrastructure failure marks the group aborted; late sibling replies are
+  discarded instead of resuming a caller execution that already failed.
+
+**Upgrading:** the Task Group state contract is versioned
+(`docs/adr/0001-unify-call-agent-and-call-agents-behavior.md`). A new Worker joins an old
+group with the old semantics, but an old Worker cannot do the reverse — **drain in-flight
+task groups, or restart the whole agent-type pool at once, before upgrading a mixed pool.**
 
 ### User-in-the-Loop
 

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ Per task, every option `call_agent` takes is accepted, with the same defaults:
 | `target_agent_type` | — | required |
 | `content` | `""` | |
 | `extra_payload`, `metadata` | `{}` | |
-| `message_id` | generated | pass one per task; a batch cannot share one (results are keyed per sub-task) |
+| `message_id` | generated | pass one per task for exact IDs; a legacy batch-level value expands to `<id>:0`, `<id>:1`, ... |
 | `route_policy` | `FAIL_FAST` | `SEND_ANYWAY` queues for an agent type whose workers have not started yet |
 | `availability_timeout_ms` | `30000` | |
 | `region`, `priority` | `None`, `0` | |
@@ -424,7 +424,8 @@ Per task, every option `call_agent` takes is accepted, with the same defaults:
 Behavior worth knowing:
 
 - An unavailable target fails **that task only** — it is recorded as a `FAILED` entry in the
-  aggregate with `reply_data["error_code"]`, and its siblings still dispatch.
+  aggregate with top-level `error`/`error_code` and the same values retained in
+  `reply_data`, and its siblings still dispatch.
 - `call_agents([])` raises `ValueError` rather than silently succeeding.
 - A dispatch-time infrastructure failure marks the group aborted; late sibling replies are
   discarded instead of resuming a caller execution that already failed.

--- a/README_zh.md
+++ b/README_zh.md
@@ -411,15 +411,15 @@ async def process_command(self, command, context):
 | `target_agent_type` | — | 必填 |
 | `content` | `""` | |
 | `extra_payload`、`metadata` | `{}` | |
-| `message_id` | 自动生成 | 需逐任务传入；整批不能共用一个（结果按子任务键存储） |
+| `message_id` | 自动生成 | 精确 ID 可逐任务传入；旧的批级值会展开为 `<id>:0`、`<id>:1`…… |
 | `route_policy` | `FAIL_FAST` | `SEND_ANYWAY` 可把消息排入尚未启动的 agent type |
 | `availability_timeout_ms` | `30000` | |
 | `region`、`priority` | `None`、`0` | |
 
 几点行为需要知道：
 
-- 目标不可用**只让该任务失败** —— 它会作为一条 `FAILED` 记录进入聚合结果（带
-  `reply_data["error_code"]`），其余任务照常派发。
+- 目标不可用**只让该任务失败** —— 它会作为一条 `FAILED` 记录进入聚合结果，顶层带
+  `error`/`error_code`，并在 `reply_data` 中保留相同值；其余任务照常派发。
 - `call_agents([])` 抛 `ValueError`，不再静默成功。
 - 派发过程中的基础设施故障会把该组标记为 aborted；迟到的兄弟回包被丢弃，不会去唤醒一个已经失败的
   调用方执行。

--- a/README_zh.md
+++ b/README_zh.md
@@ -268,8 +268,8 @@ async def process_command(self, command, context: AgentContext):
         wait_for_reply=True,
     )
 
-    # Scatter-gather 扇出
-    group = await context.dispatch_group([
+    # Scatter-gather 扇出 —— call_agent 的复数形式
+    group = await context.call_agents([
         {"target_agent_type": "researcher", "content": "查找参考资料"},
         {"target_agent_type": "writer", "content": "起草摘要"},
     ])
@@ -379,20 +379,54 @@ Worker 可通过 `context.call_agent()` 委托另一个 Agent 执行。当 `wait
 
 ### Scatter-Gather 分发
 
-并行扇出多个子任务并收集结果：
+`call_agents` 是 `call_agent` 的复数形式：每个子任务的行为与等价的单次 `call_agent` 调用完全一致，
+区别只在于所有子任务完成后，调用方被**一次性**唤醒并拿到全部结果。`dispatch_group` 是它的永久别名，
+不是废弃 API。
 
 ```python
-group = await context.dispatch_group([
+group = await context.call_agents([
     {"target_agent_type": "researcher", "content": "查找论文"},
     {"target_agent_type": "analyst",    "content": "总结发现"},
 ], wait_for_reply=True)
-
-results = await context.collect_group_results(group["task_group_id"])
-for r in results.values():
-    print(r["content"])
+# {"status": "QUEUED", "task_group_id": "tg-...", "dispatched_tasks": [...]}
 ```
 
-组进度在 Redis 中追踪；`dispatch_group` 立即返回 `task_group_id`，可通过 `collect_group_results` 轮询结果。
+Worker 收到的 `ResumeCommand` 中，`reply_data` 是按派发顺序排列的聚合结果，每个子任务一条：
+
+```python
+async def process_command(self, command, context):
+    if isinstance(command, ResumeCommand):
+        for item in command.reply_data:
+            print(item["target_agent_type"], item["status"], item["content"])
+        # 组恢复时 command.content 为 ""：reply_data 是唯一的聚合通道
+        return {"status": "completed", "content": summarize(command.reply_data)}
+```
+
+`collect_group_results(task_group_id)` 仍可用于在 resume 之外轮询同一批结果。
+
+每个子任务都可以带上 `call_agent` 的全部参数，默认值也一致：
+
+| 键 | 默认值 | 说明 |
+|---|---|---|
+| `target_agent_type` | — | 必填 |
+| `content` | `""` | |
+| `extra_payload`、`metadata` | `{}` | |
+| `message_id` | 自动生成 | 需逐任务传入；整批不能共用一个（结果按子任务键存储） |
+| `route_policy` | `FAIL_FAST` | `SEND_ANYWAY` 可把消息排入尚未启动的 agent type |
+| `availability_timeout_ms` | `30000` | |
+| `region`、`priority` | `None`、`0` | |
+
+几点行为需要知道：
+
+- 目标不可用**只让该任务失败** —— 它会作为一条 `FAILED` 记录进入聚合结果（带
+  `reply_data["error_code"]`），其余任务照常派发。
+- `call_agents([])` 抛 `ValueError`，不再静默成功。
+- 派发过程中的基础设施故障会把该组标记为 aborted；迟到的兄弟回包被丢弃，不会去唤醒一个已经失败的
+  调用方执行。
+
+**升级注意**：Task Group 的状态契约带版本号（见
+`docs/adr/0001-unify-call-agent-and-call-agents-behavior.md`）。新 Worker 能按旧语义处理旧组，
+但旧 Worker 无法反向兼容 —— **升级混合部署的 worker 池前，必须排空进行中的 task group，或者整池一次性重启。**
 
 ### 人机交互流程
 

--- a/docs/adr/0001-unify-call-agent-and-call-agents-behavior.md
+++ b/docs/adr/0001-unify-call-agent-and-call-agents-behavior.md
@@ -1,0 +1,182 @@
+# ADR 0001 — Unify `call_agent` and `call_agents` behavior
+
+Status: accepted
+Date: 2026-08-17
+Applies to: `by-framework-python`, `by-framework-java`, `by-framework-ts`
+
+## Context
+
+`call_agent` (one sub-task) and `dispatch_group` (a batch) grew separately. They built
+their `AskAgentCommand`s differently, and only `call_agent` consulted the availability
+control plane; the batch path did a blind `xadd`. Group Join, on the worker side, resumed
+the caller with whichever sub-task's reply happened to complete the group, and stored every
+sibling's result under the *caller's* own `message_id` — a key identical across siblings, so
+the result hash never held more than one entry and `collect_group_results` for an N-task
+group polled to its timeout and returned one result.
+
+The two APIs were therefore not two spellings of one idea; they were two behaviors, and the
+batch one was the easier to misuse.
+
+## Decision
+
+**`call_agents` is `call_agent`'s plural.** Per-task behavior is indistinguishable from a
+single `call_agent` call. The only increment is that the caller is resumed once, with every
+sub-task's result aggregated, after all tasks complete.
+
+Concretely:
+
+1. One dispatch path. Both APIs build, availability-check, and dispatch through the same
+   internal single-task routine. Every per-call option `call_agent` accepts —
+   `route_policy`, `availability_timeout_ms`, `region`, `priority`, `message_id` — is
+   accepted per task in a batch, with the same defaults.
+2. One accounting path. Storing a sub-task result, incrementing the completion counter,
+   deciding the group is done, and aggregating happen **only** in the worker's Group Join.
+   A dispatcher must never book-keep the group itself.
+3. A sub-task whose target agent type is unavailable at dispatch time produces the reply a
+   sub-agent *would* have sent had it started and failed, delivered to the caller's control
+   stream. It is not special-cased anywhere downstream.
+4. `dispatch_group` (Python/TS) and its equivalents remain permanent, source-compatible
+   aliases. Not deprecated.
+
+## The Task Group contract
+
+This section is normative. Implementations in other runtimes must satisfy it exactly.
+
+### Group hash — `task_group:{group_id}`
+
+| Field | Written by | Meaning |
+|---|---|---|
+| `total` | dispatcher | number of tasks dispatched |
+| `completed` | Group Join **only** | replies counted so far |
+| `source_agent_type` | dispatcher | the caller's agent type |
+| `aborted` | dispatcher | `"1"` once a dispatch-time infrastructure failure aborted the batch |
+| `protocol_version` | dispatcher | `"2"` for this contract; **absent** means a pre-2 dispatcher |
+| `task_order` | dispatcher, after the dispatch loop | JSON array of sub-task dispatch `message_id`s, in dispatch order |
+
+`protocol_version` is the rolling-upgrade hinge. A joiner reads it and branches:
+
+- `"2"` → this contract.
+- absent → the legacy contract (results keyed by the reply's `message_id`, no aggregation,
+  `content` left untouched). An in-flight group created by a not-yet-upgraded dispatcher
+  must keep being joined the way it was written, or a mixed fleet silently reinterprets it.
+
+`task_order` is written after the loop so it records exactly what was dispatched.
+
+### Result hash — `task_group:{group_id}:results`
+
+Under `protocol_version = "2"`, each reply is stored under the reply's
+**`header.parent_message_id`**.
+
+This is not arbitrary. An agent return sets:
+
+- `header.message_id` = the original dispatch's `parent_message_id` — the **caller's own**
+  message id. The runner reattaches a `RESUME` to the suspended execution by looking this
+  up, so it must not change. It is identical across every sibling in a group.
+- `header.parent_message_id` = the original dispatch's `message_id` — the **sub-task's own**
+  id, unique per sibling.
+
+So the reply's `parent_message_id` is the only per-sibling-unique key available, and keying
+by `message_id` (the legacy behavior) is what made siblings overwrite each other.
+
+Stored value:
+
+```json
+{
+  "status": "<sub-task's final status>",
+  "reply_data": "<sub-task's reply_data>",
+  "content": "<sub-task's content>",
+  "target_agent_type": "<reply header.source_agent_type — the agent that produced it>",
+  "metadata": {},
+  "extra_payload": {}
+}
+```
+
+### Dispatch-time failure
+
+When availability rejects a task, the dispatcher emits to the **caller's** control stream:
+
+| Field | Value |
+|---|---|
+| `header.message_id` | the caller's resolved message id |
+| `header.parent_message_id` | that sub-task's dispatch `message_id` |
+| `header.source_agent_type` | the requested target agent type |
+| `header.target_agent_type` | the caller's agent type |
+| `header.task_group_id` | the group id |
+| `status` | `FAILED` |
+| `content` | `""` |
+| `reply_data` | `{"error": <reason>, "error_code": <code, default "AGENT_TYPE_UNAVAILABLE">}` |
+
+`reply_data` carries the detail because that is where a *real* failure carries it — the
+worker's error path returns `status=FAILED, reply_data={"error": ...}`. A dispatch-time
+failure that put the reason anywhere else would defeat the whole point of decision 3.
+
+**Timing.** These replies are flushed *after* the caller's `process_command` returns, not
+inline in the dispatch loop. Sending inline would put a reply on the caller's control stream
+strictly before the caller suspends, turning the pre-existing "very fast sub-agent replies
+first" race from unlikely into certain. If `process_command` raises, the replies are
+dropped — the group is aborted and the caller execution they would resume has already
+failed.
+
+### Group Join
+
+```
+if header.task_group_id and group hash has `total`:
+    if `aborted` is set:            discard the reply, do not count it
+    read `protocol_version`
+    store the result under (v2 ? header.parent_message_id : header.message_id)
+    completed = hincrby(completed, 1)
+    if completed < total:           the caller stays suspended
+    else if v2:
+        aggregate in `task_order` order
+        resume the caller with reply_data = aggregate, content = ""
+```
+
+### Aggregate shape
+
+An ordered list, one entry per dispatched task, in `task_order` order:
+
+```json
+[{"message_id": "...", "status": "...", "reply_data": ..., "content": "...",
+  "target_agent_type": "...", "metadata": {}, "extra_payload": {}}]
+```
+
+Rules:
+- Order is dispatch order, never the Redis hash's iteration order.
+- Results present in Redis but absent from `task_order` are **appended**, never dropped.
+- A short result set still resumes the caller, but must be logged at error level naming the
+  missing `message_id`s. Silently returning fewer results than were dispatched is forbidden.
+- `content` on the resume is `""`. `reply_data` is the single aggregation channel; leaving
+  `content` as whichever sibling replied last gives the caller two channels that disagree.
+
+## Consequences
+
+### For callers
+
+- `reply_data` on a Task Group resume is a list, not a single sub-task's payload.
+- `content` on a Task Group resume is `""`.
+- An unavailable target fails that task only; siblings still dispatch.
+- `route_policy: "SEND_ANYWAY"` per task restores the pre-unification behavior of queueing
+  for an agent type whose workers have not started (control-stream consumer groups are
+  created at id `0`, so such a message is delivered on start).
+- One `message_id` cannot be shared across a batch — results are keyed per sub-task. Pass a
+  per-task `message_id` instead.
+
+### For operators — upgrade requirement
+
+`protocol_version` makes a *new* worker safe on an *old* group. The reverse — an old worker
+joining a new group — cannot be solved in-band: the old code has no version branch and will
+key results the legacy way.
+
+**Therefore: drain in-flight task groups (or restart the whole agent-type pool at once)
+before upgrading a mixed pool.** A partial rollout with live task groups can resume a caller
+with an incomplete aggregate.
+
+### Rejected alternatives
+
+- *After the dispatch loop, check `completed >= total` and resume locally.* Fixes the known
+  deadlock but leaves two implementations of group accounting alive, so the next variant of
+  the same bug is still reachable. Decision 2 exists to make it unrepresentable.
+- *Aggregate into `content` as well.* `content`'s list arm is the multimodal content-block
+  position; reusing it for sub-task results is type abuse.
+- *Keep the top-level `error`/`error_code` keys on failed aggregate entries.* Diverges from
+  how real sub-agent failures arrive, which is exactly the asymmetry this ADR removes.

--- a/docs/adr/0001-unify-call-agent-and-call-agents-behavior.md
+++ b/docs/adr/0001-unify-call-agent-and-call-agents-behavior.md
@@ -29,9 +29,9 @@ Concretely:
    internal single-task routine. Every per-call option `call_agent` accepts —
    `route_policy`, `availability_timeout_ms`, `region`, `priority`, `message_id` — is
    accepted per task in a batch, with the same defaults.
-2. One accounting path. Storing a sub-task result, incrementing the completion counter,
-   deciding the group is done, and aggregating happen **only** in the worker's Group Join.
-   A dispatcher must never book-keep the group itself.
+2. One accounting module. `TaskGroupStore` owns group creation, abort, atomic result
+   recording, completion claims, ordering, and aggregation. The worker's Group Join calls
+   that interface; a dispatcher must never store results or increment `completed` itself.
 3. A sub-task whose target agent type is unavailable at dispatch time produces the reply a
    sub-agent *would* have sent had it started and failed, delivered to the caller's control
    stream. It is not special-cased anywhere downstream.
@@ -51,7 +51,10 @@ This section is normative. Implementations in other runtimes must satisfy it exa
 | `source_agent_type` | dispatcher | the caller's agent type |
 | `aborted` | dispatcher | `"1"` once a dispatch-time infrastructure failure aborted the batch |
 | `protocol_version` | dispatcher | `"2"` for this contract; **absent** means a pre-2 dispatcher |
-| `task_order` | dispatcher, after the dispatch loop | JSON array of sub-task dispatch `message_id`s, in dispatch order |
+| `task_order` | dispatcher, before the first task is sent | JSON array of unique sub-task dispatch `message_id`s, in dispatch order |
+| `join_claim` | Group Join | token leasing the right to resume a completed group |
+| `join_claim_expires_at` | Group Join | claim expiry in Unix epoch milliseconds |
+| `joined` | Group Join | `"1"` after the claimed caller resume returns successfully |
 
 `protocol_version` is the rolling-upgrade hinge. A joiner reads it and branches:
 
@@ -60,7 +63,14 @@ This section is normative. Implementations in other runtimes must satisfy it exa
   `content` left untouched). An in-flight group created by a not-yet-upgraded dispatcher
   must keep being joined the way it was written, or a mixed fleet silently reinterprets it.
 
-`task_order` is written after the loop so it records exactly what was dispatched.
+All sub-task IDs are resolved and validated before group creation. `task_order` is written
+in the same group-creation write as `total` and `protocol_version`, before the first task is
+sent. A fast sibling can therefore never complete against a missing or partial order.
+
+The legacy batch-level `message_id` argument remains accepted. For a one-task batch it is
+used unchanged; for a multi-task batch it becomes a prefix (`<message_id>:0`,
+`<message_id>:1`, ...). Explicit per-task IDs override derived IDs, and any collision is
+rejected before Redis or stream state is written.
 
 ### Result hash — `task_group:{group_id}:results`
 
@@ -90,6 +100,10 @@ Stored value:
   "extra_payload": {}
 }
 ```
+
+A failed result also repeats `error` and `error_code` at the top level while retaining them
+inside `reply_data`. Existing consumers keep their current failure payload; helpers shared
+with `call_agent` can use the common top-level shape.
 
 ### Dispatch-time failure
 
@@ -121,15 +135,29 @@ failed.
 
 ```
 if header.task_group_id and group hash has `total`:
-    if `aborted` is set:            discard the reply, do not count it
+    if `aborted` is set:                 discard the reply, do not count it
     read `protocol_version`
-    store the result under (v2 ? header.parent_message_id : header.message_id)
-    completed = hincrby(completed, 1)
-    if completed < total:           the caller stays suspended
-    else if v2:
+    if v2:
+        atomically HSETNX the result and increment only when newly inserted
+        if completed < total:            the caller stays suspended
+        atomically claim the completed join (expired claims are recoverable)
+        if already claimed:              leave the stream entry unacknowledged
+        if already joined:               do not resume again
         aggregate in `task_order` order
-        resume the caller with reply_data = aggregate, content = ""
+        resume with reply_data = aggregate, content = ""
+        mark the claim `joined` after process_command returns or its failure is
+        terminally handled by the framework
+    else:
+        preserve the legacy store/count/resume behavior
 ```
+
+The store-and-count operation is one Redis script. A worker crash after counting but before
+`XACK` can therefore redeliver the same reply without incrementing `completed` twice. The
+join claim closes the second window: a completed group has one active resumer; a crash
+before successful resume can be recovered after the claim lease expires, while a reply
+redelivered after `joined=1` is ACKed without touching caller execution state. `WorkerRunner`
+uses `XAUTOCLAIM` to reclaim stream entries idle for the claim lease; claim contention is
+internal control flow and must not mark the caller execution `FAILED`.
 
 ### Aggregate shape
 
@@ -137,8 +165,11 @@ An ordered list, one entry per dispatched task, in `task_order` order:
 
 ```json
 [{"message_id": "...", "status": "...", "reply_data": ..., "content": "...",
-  "target_agent_type": "...", "metadata": {}, "extra_payload": {}}]
+  "target_agent_type": "...", "metadata": {}, "extra_payload": {},
+  "error": "...", "error_code": "..."}]
 ```
+
+`error` and `error_code` are present only for failed entries.
 
 Rules:
 - Order is dispatch order, never the Redis hash's iteration order.
@@ -158,8 +189,8 @@ Rules:
 - `route_policy: "SEND_ANYWAY"` per task restores the pre-unification behavior of queueing
   for an agent type whose workers have not started (control-stream consumer groups are
   created at id `0`, so such a message is delivered on start).
-- One `message_id` cannot be shared across a batch — results are keyed per sub-task. Pass a
-  per-task `message_id` instead.
+- A legacy batch-level `message_id` remains accepted and is expanded into unique per-task
+  IDs. Explicit per-task IDs are preferred when callers need exact identifiers.
 
 ### For operators — upgrade requirement
 
@@ -178,5 +209,6 @@ with an incomplete aggregate.
   the same bug is still reachable. Decision 2 exists to make it unrepresentable.
 - *Aggregate into `content` as well.* `content`'s list arm is the multimodal content-block
   position; reusing it for sub-task results is type abuse.
-- *Keep the top-level `error`/`error_code` keys on failed aggregate entries.* Diverges from
-  how real sub-agent failures arrive, which is exactly the asymmetry this ADR removes.
+- *Put failure details only in `reply_data`.* Preserves the raw worker-return shape but does
+  not let single-call and batch helpers share the specified top-level failure interface.
+  Failed aggregate entries therefore keep `reply_data` and repeat `error`/`error_code`.

--- a/docs/architecture/KEY_FILES.md
+++ b/docs/architecture/KEY_FILES.md
@@ -94,7 +94,35 @@ Entry anatomy:
   (`admin_workers()`, `trace_index_session/worker/agent`) are deliberately
   left *untagged* relative to the per-entity keys they index — never share a
   Cluster hash tag with them (fix 8501407). `WORKER_DEFAULT_LEASE_TTL_SECONDS
-  = 30` must stay ~6x `WORKER_DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 5`.
+  = 30` must stay ~6x `WORKER_DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 5`. The
+  `TASK_GROUP_FIELD_*` block is a cross-runtime wire contract, not local
+  naming: Java and TS read the same hash. `TASK_GROUP_FIELD_PROTOCOL_VERSION`
+  absent means "written by a pre-v2 dispatcher" and *must* keep selecting the
+  legacy Group Join path — see `docs/adr/0001-unify-call-agent-and-call-agents-behavior.md`; renaming or defaulting it would
+  silently reinterpret in-flight groups during a rolling upgrade.
+
+- `src/by_framework/worker/context.py` — `AgentContext`: the runtime handed to
+  `process_command`. `call_agent` and `call_agents` (alias `dispatch_group`)
+  both dispatch through `_dispatch_single_task`, the one place that builds,
+  availability-checks, and sends an `AskAgentCommand`; per-task routing
+  options in a batch exist so a group member behaves exactly like the
+  equivalent single call. `call_agents` must **never** book-keep the Task
+  Group itself — storing results and incrementing `completed` belong to
+  `GatewayWorker`'s Group Join, and a second copy here is what could push
+  `completed` to `total` with no reply left to resume the caller. A target
+  that fails its availability check is queued onto `_pending_group_replies`
+  as the reply a sub-agent would have sent, and the worker flushes it after
+  `process_command` returns. See `docs/adr/0001-unify-call-agent-and-call-agents-behavior.md`.
+
+- `src/by_framework/worker/worker.py` — `GatewayWorker`. `_enqueue_agent_return`'s
+  header derivation is load-bearing in two directions: a reply's
+  `header.message_id` is the *caller's* id (what `WorkerRunner` reattaches the
+  suspended execution by) and its `header.parent_message_id` is the sub-task's
+  own id (the only per-sibling-unique key, so what Group Join keys the result
+  hash by under protocol v2). `_handle_message`'s Group Join owns all Task
+  Group accounting and branches on `protocol_version`; `_aggregate_task_group`
+  orders by `task_order` and must log loudly rather than silently return a
+  short result set. See `docs/adr/0001-unify-call-agent-and-call-agents-behavior.md`.
 
 - `src/by_framework/client/client.py` — `GatewayClient.send_message()` and
   friends; publishes commands to Redis control streams and drives registry

--- a/docs/architecture/KEY_FILES.md
+++ b/docs/architecture/KEY_FILES.md
@@ -114,15 +114,22 @@ Entry anatomy:
   as the reply a sub-agent would have sent, and the worker flushes it after
   `process_command` returns. See `docs/adr/0001-unify-call-agent-and-call-agents-behavior.md`.
 
+- `src/by_framework/worker/task_group.py` — `TaskGroupStore`, the single Task
+  Group persistence and accounting module. It resolves collision-free sibling
+  IDs, writes the complete group contract before dispatch, atomically records
+  each unique reply, leases/commits Group Join, and supplies the ordered result
+  view used by both automatic resume and `collect_group_results`. Do not add
+  direct Task Group result writes or completion increments outside this module.
+
 - `src/by_framework/worker/worker.py` — `GatewayWorker`. `_enqueue_agent_return`'s
   header derivation is load-bearing in two directions: a reply's
   `header.message_id` is the *caller's* id (what `WorkerRunner` reattaches the
   suspended execution by) and its `header.parent_message_id` is the sub-task's
   own id (the only per-sibling-unique key, so what Group Join keys the result
-  hash by under protocol v2). `_handle_message`'s Group Join owns all Task
-  Group accounting and branches on `protocol_version`; `_aggregate_task_group`
-  orders by `task_order` and must log loudly rather than silently return a
-  short result set. See `docs/adr/0001-unify-call-agent-and-call-agents-behavior.md`.
+  hash by under protocol v2). `_handle_message`'s Group Join branches on
+  `protocol_version` and delegates the v2 contract to `TaskGroupStore`; legacy
+  unstamped groups retain their original behavior. See
+  `docs/adr/0001-unify-call-agent-and-call-agents-behavior.md`.
 
 - `src/by_framework/client/client.py` — `GatewayClient.send_message()` and
   friends; publishes commands to Redis control streams and drives registry
@@ -141,7 +148,10 @@ Entry anatomy:
 
 - `src/by_framework/worker/runner.py` — `WorkerRunner`, the consume loop:
   `XREADGROUP` fetch, command dispatch, resume/suspend bookkeeping, denylist
-  enforcement. `_active_agent_type_streams()` must read only the in-memory
+  enforcement. It also reclaims lease-expired pending entries with per-stream
+  `XAUTOCLAIM`; a contended Task Group Join stays pending without becoming an
+  execution failure, while a committed Join replay is ACK-only and cannot
+  rewrite caller registry state. `_active_agent_type_streams()` must read only the in-memory
   `self._denied_agent_types` frozenset — no Redis `SISMEMBER` call inside the
   hot consume-loop path; refreshed only by the heartbeat thread's
   `denylist_refresh` callback (bounded staleness ~1 heartbeat interval) (fix

--- a/examples/echo_worker.py
+++ b/examples/echo_worker.py
@@ -1,23 +1,55 @@
-"""Minimal reference Worker: echoes back whatever content it receives.
+"""Minimal reference Worker: echoes back whatever content it receives, and
+fans a request out to two "echo" sub-calls via call_agents.
 
 Doubles as the target of .github/workflows/deploy-smoke-test.yml, which
 builds deploy/Dockerfile in "local source" mode and drives this Worker
 through the full client -> Redis control stream -> Worker -> Redis data
-stream -> client round trip via examples/send_and_verify.py.
+stream -> client round trip via examples/send_and_verify.py. The "fanout"
+agent type specifically exercises call_agents end to end against a real,
+separate Redis Streams deployment (not the in-memory fakes the unit/
+integration tests use), so a real-Redis-only bug in Group Join couldn't
+hide behind those.
 """
 
-from by_framework import AgentContext, GatewayWorker, run_worker
+from by_framework import (
+    AgentContext,
+    AgentState,
+    GatewayWorker,
+    ResumeCommand,
+    run_worker,
+)
 
 
 class EchoWorker(GatewayWorker):
 
     def get_agent_types(self):
-        return ["echo"]
+        return ["echo", "fanout"]
 
     async def process_command(self, command, context: AgentContext):
+        if context.current_agent_id == "fanout":
+            return await self._handle_fanout(command, context)
+
         reply = f"echo: {command.content}"
         await context.emit_chunk(reply)
         return {"status": "completed", "content": reply}
+
+    async def _handle_fanout(self, command, context: AgentContext):
+        if isinstance(command, ResumeCommand):
+            # The Task Group has completed: command.reply_data is the
+            # aggregated list Group Join built, one entry per echo call.
+            aggregate = command.reply_data or []
+            parts = [str(item.get("content", "")) for item in aggregate]
+            reply = "fanout: " + " | ".join(parts)
+            await context.emit_chunk(reply)
+            return {"status": "completed", "content": reply}
+
+        await context.call_agents(
+            tasks=[
+                {"target_agent_type": "echo", "content": "one"},
+                {"target_agent_type": "echo", "content": "two"},
+            ],
+        )
+        return {"status": AgentState.QUEUED.value}
 
 
 if __name__ == "__main__":

--- a/examples/echo_worker.py
+++ b/examples/echo_worker.py
@@ -36,7 +36,10 @@ class EchoWorker(GatewayWorker):
     async def _handle_fanout(self, command, context: AgentContext):
         if isinstance(command, ResumeCommand):
             # The Task Group has completed: command.reply_data is the
-            # aggregated list Group Join built, one entry per echo call.
+            # aggregated list Group Join built, one entry per echo call, in
+            # the order the tasks were dispatched — so joining positionally is
+            # safe here. (command.content is "" on a group resume; reply_data
+            # is the single aggregation channel.)
             aggregate = command.reply_data or []
             parts = [str(item.get("content", "")) for item in aggregate]
             reply = "fanout: " + " | ".join(parts)

--- a/examples/send_and_verify.py
+++ b/examples/send_and_verify.py
@@ -1,18 +1,27 @@
 """Smoke-test client for examples/echo_worker.py.
 
-Sends one message to the "echo" agent type and waits for the Worker's
-echoed reply on the session data stream, exiting 0 on success or 1 on
-timeout. Used by .github/workflows/deploy-smoke-test.yml to validate that
-deploy/'s Dockerfile + docker-compose.yml deliver a message through the
-full pipeline: client -> Redis control stream -> Worker -> Redis data
-stream -> client. Also runnable by hand against `deploy/docker-compose.yml`
-locally.
+Runs two cases against the Worker and waits for each expected reply on the
+session data stream, exiting 0 on success or 1 on timeout:
+
+1. "echo" - single-call round trip: client -> Redis control stream ->
+   Worker -> Redis data stream -> client.
+2. "fanout" - the same round trip, but the Worker's reply is only produced
+   after it fans out to two more "echo" calls via call_agents and gets
+   resumed with their aggregated results. This is the only place call_agents
+   is exercised against a real, separate-process Redis Streams deployment
+   instead of the in-memory fakes tests/ uses, so it can catch a real-Redis-
+   only Group Join bug those can't.
+
+Used by .github/workflows/deploy-smoke-test.yml to validate that deploy/'s
+Dockerfile + docker-compose.yml deliver both flows end to end. Also runnable
+by hand against `deploy/docker-compose.yml` locally.
 """
 
 import asyncio
 import os
 import sys
 import uuid
+from typing import Callable
 
 from by_framework import GatewayClient, WorkerRegistry, close_redis, init_redis
 
@@ -46,6 +55,53 @@ async def _send_with_retry(client: GatewayClient, **kwargs):
         await asyncio.sleep(SEND_RETRY_INTERVAL_SECONDS)
 
 
+async def _run_case(
+    client: GatewayClient,
+    *,
+    target_agent_type: str,
+    content: str,
+    is_expected_reply: Callable[[str], bool],
+) -> None:
+    """Send one message and block until a data-stream event's content
+    satisfies is_expected_reply. Caller wraps this in asyncio.timeout."""
+    session_id = f"smoketest-{uuid.uuid4().hex[:8]}"
+    await _send_with_retry(
+        client,
+        target_agent_type=target_agent_type,
+        session_id=session_id,
+        content=content,
+    )
+    print(f"sent {content!r} to {target_agent_type!r} on session {session_id}")
+
+    last_id = "0-0"
+    while True:
+        entries = await client.read_data_messages(
+            session_id=session_id, last_id=last_id, block_ms=2000
+        )
+        for entry in entries:
+            last_id = entry.stream_id
+            delta = (
+                entry.message.data.get("choices", [{}])[0]
+                .get("delta", {})
+                .get("content")
+            )
+            print(
+                f"[{target_agent_type}] received "
+                f"event_type={entry.message.event_type!r} content={delta!r}"
+            )
+            if delta is not None and is_expected_reply(delta):
+                print(f"OK: {target_agent_type} received expected reply")
+                return
+
+
+def _is_expected_fanout_reply(delta: str, expected_parts: set[str]) -> bool:
+    prefix = "fanout: "
+    if not delta.startswith(prefix):
+        return False
+    parts = {part.strip() for part in delta[len(prefix) :].split("|")}
+    return parts == expected_parts
+
+
 async def main() -> int:
     redis = init_redis(
         host=os.environ.get("REDIS_HOST", "localhost"),
@@ -54,41 +110,31 @@ async def main() -> int:
     registry = WorkerRegistry(redis_client=redis)
     client = GatewayClient(redis_client=redis, registry=registry)
 
-    session_id = f"smoketest-{uuid.uuid4().hex[:8]}"
-    sent_content = f"ping-{uuid.uuid4().hex[:8]}"
-    expected_reply = f"echo: {sent_content}"
-
     try:
         async with asyncio.timeout(TIMEOUT_SECONDS):
-            await _send_with_retry(
+            echo_content = f"ping-{uuid.uuid4().hex[:8]}"
+            expected_echo = f"echo: {echo_content}"
+            await _run_case(
                 client,
                 target_agent_type="echo",
-                session_id=session_id,
-                content=sent_content,
+                content=echo_content,
+                is_expected_reply=lambda delta: delta == expected_echo,
             )
-            print(f"sent {sent_content!r} on session {session_id}")
 
-            last_id = "0-0"
-            while True:
-                entries = await client.read_data_messages(
-                    session_id=session_id, last_id=last_id, block_ms=2000
-                )
-                for entry in entries:
-                    last_id = entry.stream_id
-                    delta = (
-                        entry.message.data.get("choices", [{}])[0]
-                        .get("delta", {})
-                        .get("content")
-                    )
-                    print(
-                        f"received event_type={entry.message.event_type!r} "
-                        f"content={delta!r}"
-                    )
-                    if delta == expected_reply:
-                        print("OK: received expected echo")
-                        return 0
+            # echo_worker.py's "fanout" handler ignores the sent content and
+            # always fans out to two fixed "echo" sub-calls ("one", "two").
+            expected_fanout_parts = {"echo: one", "echo: two"}
+            await _run_case(
+                client,
+                target_agent_type="fanout",
+                content="ignored",
+                is_expected_reply=lambda delta: _is_expected_fanout_reply(
+                    delta, expected_fanout_parts
+                ),
+            )
+        return 0
     except TimeoutError:
-        print(f"FAILED: no matching echo within {TIMEOUT_SECONDS}s", file=sys.stderr)
+        print(f"FAILED: no matching reply within {TIMEOUT_SECONDS}s", file=sys.stderr)
         return 1
     finally:
         await close_redis()

--- a/src/by_framework/common/constants.py
+++ b/src/by_framework/common/constants.py
@@ -529,6 +529,10 @@ MSG_MAP_PREFIX = "msg_map:"
 TASK_GROUP_FIELD_TOTAL = "total"
 TASK_GROUP_FIELD_COMPLETED = "completed"
 TASK_GROUP_FIELD_SOURCE_AGENT = "source_agent_type"
+# Set once dispatch fails partway through a batch; any reply that arrives
+# for an aborted group is discarded instead of resuming the (already
+# terminated) caller execution.
+TASK_GROUP_FIELD_ABORTED = "aborted"
 
 
 # --- Timing and Sleep Constants ---

--- a/src/by_framework/common/constants.py
+++ b/src/by_framework/common/constants.py
@@ -545,9 +545,15 @@ TASK_GROUP_FIELD_PROTOCOL_VERSION = "protocol_version"
 # Group Join aggregates in this order, and uses it to name results that never
 # arrived instead of silently returning a short list.
 TASK_GROUP_FIELD_TASK_ORDER = "task_order"
+# Group Join claim state. The final unique reply claims the right to resume
+# the caller; Redis redelivery observes this state instead of resuming twice.
+TASK_GROUP_FIELD_JOIN_CLAIM = "join_claim"
+TASK_GROUP_FIELD_JOIN_CLAIM_EXPIRES_AT = "join_claim_expires_at"
+TASK_GROUP_FIELD_JOINED = "joined"
 # Version 2: per-sub-task result keys, ordered aggregation into the caller's
 # reply_data, and content cleared on group resume.
 TASK_GROUP_PROTOCOL_V2 = "2"
+TASK_GROUP_JOIN_CLAIM_TTL_MS = 60 * 60 * 1000
 
 
 # --- Timing and Sleep Constants ---

--- a/src/by_framework/common/constants.py
+++ b/src/by_framework/common/constants.py
@@ -533,6 +533,21 @@ TASK_GROUP_FIELD_SOURCE_AGENT = "source_agent_type"
 # for an aborted group is discarded instead of resuming the (already
 # terminated) caller execution.
 TASK_GROUP_FIELD_ABORTED = "aborted"
+# Task Group protocol version, stamped by the dispatcher. A group whose hash
+# carries no version was created by a pre-2 dispatcher: Group Join must then
+# fall back to the legacy behavior (results keyed by the caller's own
+# message_id, no aggregation) so a rolling upgrade cannot reinterpret an
+# in-flight group under the wrong contract. Named "protocol_version" rather
+# than "schema"/"version" to avoid confusion with RedisKeys' key-schema
+# versioning (see docs/architecture/redis-cluster-mode.md).
+TASK_GROUP_FIELD_PROTOCOL_VERSION = "protocol_version"
+# JSON array of the group's sub-task dispatch message_ids, in dispatch order.
+# Group Join aggregates in this order, and uses it to name results that never
+# arrived instead of silently returning a short list.
+TASK_GROUP_FIELD_TASK_ORDER = "task_order"
+# Version 2: per-sub-task result keys, ordered aggregation into the caller's
+# reply_data, and content cleared on group resume.
+TASK_GROUP_PROTOCOL_V2 = "2"
 
 
 # --- Timing and Sleep Constants ---

--- a/src/by_framework/worker/byai_context.py
+++ b/src/by_framework/worker/byai_context.py
@@ -13,12 +13,21 @@ from .context import AgentContext
 
 @dataclass(frozen=True)
 class ByaiAgentTask:
-    """Typed task descriptor for Byai group dispatch."""
+    """Typed task descriptor for Byai group dispatch.
+
+    Mirrors the per-task keys AgentContext.call_agents accepts, so a task in a
+    batch can be routed exactly like the equivalent single call_agent call.
+    """
 
     target_agent_type: str
     content: ByaiContent
     extra_payload: Optional[dict[str, Any]] = None
     metadata: Optional[dict[str, Any]] = None
+    message_id: Optional[str] = None
+    route_policy: str = RoutePolicy.FAIL_FAST
+    availability_timeout_ms: int = 30000
+    region: Optional[str] = None
+    priority: int = 0
 
 
 class ByaiAgentContext(AgentContext):
@@ -52,6 +61,40 @@ class ByaiAgentContext(AgentContext):
             priority=priority,
         )
 
+    async def call_agents(
+        self,
+        tasks: list[ByaiAgentTask],
+        wait_for_reply: bool = True,
+        message_id: Optional[str] = None,
+        parent_message_id: Optional[str] = None,
+    ) -> dict:
+        """Typed batch dispatch — the plural of this facade's call_agent.
+
+        This override, not dispatch_group's, is what has to exist: call_agents
+        is the primary batch entry point, so without it a caller holding a
+        ByaiAgentContext would reach AgentContext.call_agents and have its
+        ByaiAgentTask dataclasses subscripted as dicts.
+        """
+        return await super().call_agents(
+            tasks=[
+                {
+                    "target_agent_type": task.target_agent_type,
+                    "content": task.content,
+                    "extra_payload": task.extra_payload or {},
+                    "metadata": task.metadata or {},
+                    "message_id": task.message_id,
+                    "route_policy": task.route_policy,
+                    "availability_timeout_ms": task.availability_timeout_ms,
+                    "region": task.region,
+                    "priority": task.priority,
+                }
+                for task in tasks
+            ],
+            wait_for_reply=wait_for_reply,
+            message_id=message_id,
+            parent_message_id=parent_message_id,
+        )
+
     async def dispatch_group(
         self,
         tasks: list[ByaiAgentTask],
@@ -59,16 +102,9 @@ class ByaiAgentContext(AgentContext):
         message_id: Optional[str] = None,
         parent_message_id: Optional[str] = None,
     ) -> dict:
-        return await super().dispatch_group(
-            tasks=[
-                {
-                    "target_agent_type": task.target_agent_type,
-                    "content": task.content,
-                    "extra_payload": task.extra_payload or {},
-                    "metadata": task.metadata or {},
-                }
-                for task in tasks
-            ],
+        """Alias for call_agents, kept permanently for source compatibility."""
+        return await self.call_agents(
+            tasks,
             wait_for_reply=wait_for_reply,
             message_id=message_id,
             parent_message_id=parent_message_id,

--- a/src/by_framework/worker/context.py
+++ b/src/by_framework/worker/context.py
@@ -23,6 +23,7 @@ from typing_extensions import deprecated
 from by_framework.common.constants import (
     EXECUTION_ID_PREFIX,
     MESSAGE_ID_PREFIX,
+    TASK_GROUP_FIELD_ABORTED,
     TASK_GROUP_FIELD_COMPLETED,
     TASK_GROUP_FIELD_SOURCE_AGENT,
     TASK_GROUP_FIELD_TOTAL,
@@ -542,6 +543,42 @@ class AgentContext:
         Args:
             route_policy: Controls online checks and unavailable-agent behavior.
         """
+        return await self._dispatch_single_task(
+            target_agent_type=target_agent_type,
+            content=content,
+            extra_payload=extra_payload,
+            wait_for_reply=wait_for_reply,
+            metadata=metadata,
+            message_id=message_id,
+            parent_message_id=parent_message_id,
+            route_policy=route_policy,
+            availability_timeout_ms=availability_timeout_ms,
+            region=region,
+            priority=priority,
+        )
+
+    async def _dispatch_single_task(
+        self,
+        *,
+        target_agent_type: str,
+        content: object,
+        extra_payload: Optional[Dict[str, Any]] = None,
+        wait_for_reply: bool = True,
+        metadata: Optional[Dict[str, Any]] = None,
+        message_id: Optional[str] = None,
+        parent_message_id: Optional[str] = None,
+        task_group_id: str = "",
+        route_policy: str = RoutePolicy.FAIL_FAST,
+        availability_timeout_ms: int = 30000,
+        region: Optional[str] = None,
+        priority: int = 0,
+    ) -> dict:
+        """Build, availability-check, and dispatch one AskAgentCommand.
+
+        Shared by call_agent (a single task) and call_agents/dispatch_group
+        (a batch, one call per task). Returns a call_agent-shaped result dict:
+        {status, message_id, parent_message_id, target_agent_type, [error, error_code]}.
+        """
         message_id = message_id or self.generate_message_id()
         parent_message_id = parent_message_id if parent_message_id else self.message_id
         merged_extra_payload = dict(extra_payload or {})
@@ -573,6 +610,7 @@ class AgentContext:
                 source_agent_type=self.current_agent_id if wait_for_reply else "",
                 target_agent_type=target_agent_type,
                 parent_message_id=parent_message_id,
+                task_group_id=task_group_id,
                 user_code=self.agent_runtime_state.session_manager.user_code,
                 user_name=self.agent_runtime_state.session_manager.user_name,
                 metadata=metadata,
@@ -667,6 +705,11 @@ class AgentContext:
         delivery_stream = availability.stream_name or RedisKeys.ctrl_stream(
             target_agent_type
         )
+        target_worker_id = availability.target_worker_id
+        effective_route_status = availability.status
+        selected_agent_type = availability.selected_agent_type
+        availability_error_code = availability.error_code
+        availability_error = availability.error
 
         from by_framework.core.registry import WorkerRegistry
 
@@ -687,10 +730,10 @@ class AgentContext:
                         "stream_name": delivery_stream,
                         "status": "QUEUED",
                         "route_policy": route_policy,
-                        "route_status": availability.status,
-                        "selected_agent_type": availability.selected_agent_type,
-                        "availability_error_code": availability.error_code,
-                        "availability_error": availability.error,
+                        "route_status": effective_route_status,
+                        "selected_agent_type": selected_agent_type,
+                        "availability_error_code": availability_error_code,
+                        "availability_error": availability_error,
                     }
                 )
             except Exception:  # pylint: disable=broad-exception-caught
@@ -705,9 +748,9 @@ class AgentContext:
                 parent_message_id=parent_message_id,
                 source_agent_type=self.current_agent_id if wait_for_reply else "",
                 target_agent_type=target_agent_type,
-                target_worker_id=availability.target_worker_id,
+                target_worker_id=target_worker_id,
                 route_policy=route_policy,
-                route_status=availability.status,
+                route_status=effective_route_status,
                 start_ts=dispatch_started_at,
                 end_ts=int(time.time() * 1000),
             )
@@ -777,7 +820,7 @@ class AgentContext:
         except Exception as err:  # pylint: disable=broad-exception-caught
             logger.debug("Failed to record agent dispatch span: %s", err)
 
-    async def dispatch_group(
+    async def call_agents(
         self,
         tasks: list[dict[str, Any]],
         wait_for_reply: bool = True,
@@ -785,8 +828,9 @@ class AgentContext:
         parent_message_id: Optional[str] = None,
     ) -> dict:
         """
-        Dispatch multiple tasks concurrently as a group.
-        The caller agent will be resumed ONLY when ALL tasks in the group are completed.
+        Dispatch multiple tasks concurrently as a Task Group — call_agent's
+        plural. The caller agent will be resumed with every task's result,
+        aggregated, ONLY when ALL tasks in the group are complete.
 
         Args:
             tasks: A list of dicts, each containing:
@@ -799,7 +843,7 @@ class AgentContext:
             wait_for_reply: bool. If True, sets up Redis counters to wait for all.
         """
         if not tasks:
-            return {"status": "EMPTY", "task_group_id": ""}
+            raise ValueError("dispatch_group/call_agents requires at least one task")
 
         task_group_id = f"{TASK_GROUP_ID_PREFIX}{uuid.uuid4().hex[:8]}"
         total_tasks = len(tasks)
@@ -827,114 +871,63 @@ class AgentContext:
             content = task.get("content", "")
             extra_payload = task.get("extra_payload", {})
             metadata = dict(task.get("metadata", {}) or {})
-            serialized_content = self._serialize_outbound_content(content)
 
             current_message_id = message_id or self.generate_message_id()
-            parent_message_id = (
-                parent_message_id if parent_message_id else self.message_id
-            )
-            call_parent_span_id = f"{current_message_id}:client.dispatch"
-            trace_parent_span_id = self._resolve_call_trace_parent_span_id(
-                call_parent_span_id
-            )
-            metadata.setdefault("trace_parent_span_id", trace_parent_span_id)
-            metadata.setdefault("framework_parent_span_id", call_parent_span_id)
-            langfuse_parent_observation_id = (
-                str(metadata.get("langfuse_parent_observation_id", "") or "")
-                or self._resolve_call_langfuse_parent_id()
-            )
-            merged_extra_payload = dict(extra_payload)
-            if wait_for_reply:
-                merged_extra_payload["wait_for_reply"] = True
-
-            command = AskAgentCommand(
-                header=MessageHeader(
-                    message_id=current_message_id,
-                    session_id=self.session_id,
-                    trace_id=self.trace_id,
-                    source_agent_type=self.current_agent_id if wait_for_reply else "",
+            try:
+                task_result = await self._dispatch_single_task(
                     target_agent_type=target_agent_type,
+                    content=content,
+                    extra_payload=extra_payload,
+                    metadata=metadata,
+                    wait_for_reply=wait_for_reply,
+                    message_id=current_message_id,
                     parent_message_id=parent_message_id,
                     task_group_id=task_group_id,
-                    user_code=self.agent_runtime_state.session_manager.user_code,
-                    user_name=self.agent_runtime_state.session_manager.user_name,
-                    metadata=metadata,
-                    trace_parent_span_id=trace_parent_span_id,
-                    langfuse_parent_observation_id=langfuse_parent_observation_id,
-                ),
-                content=serialized_content,
-                wait_for_reply=wait_for_reply,
-                extra_payload={
-                    k: v
-                    for k, v in merged_extra_payload.items()
-                    if k != "wait_for_reply"
-                },
-            )
-
-            if self.plugin_registry:
-                await self.plugin_registry.on_call_agent_start(self, command)
-
-            execution_id = f"{EXECUTION_ID_PREFIX}{uuid.uuid4().hex[:8]}"
-            from by_framework.core.registry import WorkerRegistry
-
-            registry = WorkerRegistry(self.redis)
-            if hasattr(registry, "initialize_execution"):
-                try:
-                    await registry.initialize_execution(
-                        {
-                            "execution_id": execution_id,
-                            "message_id": current_message_id,
-                            "session_id": self.session_id,
-                            "trace_id": self.trace_id,
-                            "parent_message_id": parent_message_id or "",
-                            "source_agent_type": self.current_agent_id
-                            if wait_for_reply
-                            else "",
-                            "target_agent_type": target_agent_type,
-                            "stream_name": RedisKeys.ctrl_stream(target_agent_type),
-                            "status": "QUEUED",
-                        }
+                )
+            except Exception:
+                # A genuine dispatch-time failure (not an availability-check
+                # rejection, which _dispatch_single_task already turns into a
+                # FAILED result instead of raising). Stop fanning out and mark
+                # the group aborted so already-sent siblings' replies don't
+                # later resume this (now-failed) caller execution.
+                if wait_for_reply:
+                    await self.redis.hset(  # type: ignore
+                        RedisKeys.task_group(task_group_id),
+                        TASK_GROUP_FIELD_ABORTED,
+                        "1",
                     )
-                except Exception:  # pylint: disable=broad-exception-caught
-                    pass  # Fallback if registry fails
-
-            dispatch_started_at = int(time.time() * 1000)
-            try:
-                await self.redis.xadd(
-                    RedisKeys.ctrl_stream(target_agent_type), command.to_redis_payload()
-                )
-                await self._record_agent_dispatch_span(
-                    message_id=current_message_id,
-                    parent_message_id=parent_message_id,
-                    source_agent_type=self.current_agent_id if wait_for_reply else "",
-                    target_agent_type=target_agent_type,
-                    target_worker_id="",
-                    route_policy=RoutePolicy.SEND_ANYWAY,
-                    route_status="GROUP_DISPATCH",
-                    start_ts=dispatch_started_at,
-                    end_ts=int(time.time() * 1000),
-                )
-            except Exception as error:
-                if self.plugin_registry:
-                    await self.plugin_registry.on_call_agent_error(self, command, error)
                 raise
 
-            if self.plugin_registry:
-                await self.plugin_registry.on_call_agent_complete(
-                    self,
-                    command,
-                    {
-                        "status": AgentState.QUEUED.value,
-                        "message_id": current_message_id,
-                        "parent_message_id": parent_message_id,
-                        "target_agent_type": target_agent_type,
-                    },
+            if task_result["status"] == AgentState.FAILED.value and wait_for_reply:
+                # Target agent type unavailable: record the failure as this
+                # task's result immediately, without blocking the rest of
+                # the batch or waiting for a reply that will never arrive.
+                result_data = {
+                    "status": task_result["status"],
+                    "reply_data": None,
+                    "content": "",
+                    "target_agent_type": target_agent_type,
+                    "metadata": {},
+                    "extra_payload": {},
+                    "error": task_result.get("error"),
+                    "error_code": task_result.get("error_code"),
+                }
+                results_key = RedisKeys.task_group_results(task_group_id)
+                await self.redis.hset(  # type: ignore
+                    results_key, current_message_id, json.dumps(result_data)
+                )
+                await self.redis.expire(results_key, TASK_GROUP_TTL_SECONDS)
+                await self.redis.hincrby(  # type: ignore
+                    RedisKeys.task_group(task_group_id), TASK_GROUP_FIELD_COMPLETED, 1
                 )
 
             dispatched.append(
                 {
                     "message_id": current_message_id,
-                    "target_agent_type": target_agent_type,
+                    # task_result["target_agent_type"] reflects any fallback
+                    # reroute _dispatch_single_task performed, so this stays
+                    # consistent with what Group Join later reports.
+                    "target_agent_type": task_result["target_agent_type"],
                 }
             )
 
@@ -970,10 +963,29 @@ class AgentContext:
             logger.debug("Failed to record dispatch_group span: %s", err)
 
         return {
-            "status": "GROUP_QUEUED",
+            "status": AgentState.QUEUED.value,
             "task_group_id": task_group_id,
             "dispatched_tasks": dispatched,
         }
+
+    async def dispatch_group(
+        self,
+        tasks: list[dict[str, Any]],
+        wait_for_reply: bool = True,
+        message_id: Optional[str] = None,
+        parent_message_id: Optional[str] = None,
+    ) -> dict:
+        """Alias for call_agents, kept permanently for source compatibility.
+
+        Not deprecated: shares call_agents' implementation and behavior
+        exactly, so existing callers upgrade automatically without a rename.
+        """
+        return await self.call_agents(
+            tasks,
+            wait_for_reply=wait_for_reply,
+            message_id=message_id,
+            parent_message_id=parent_message_id,
+        )
 
     def _serialize_outbound_content(self, content: object) -> WireContent:
         if self.content_codec is not None:

--- a/src/by_framework/worker/context.py
+++ b/src/by_framework/worker/context.py
@@ -9,7 +9,6 @@ and inter-agent communication.
 from __future__ import annotations
 
 import asyncio
-import json
 import os
 import time
 import uuid
@@ -23,15 +22,7 @@ from typing_extensions import deprecated
 from by_framework.common.constants import (
     EXECUTION_ID_PREFIX,
     MESSAGE_ID_PREFIX,
-    TASK_GROUP_FIELD_ABORTED,
-    TASK_GROUP_FIELD_COMPLETED,
-    TASK_GROUP_FIELD_PROTOCOL_VERSION,
-    TASK_GROUP_FIELD_SOURCE_AGENT,
-    TASK_GROUP_FIELD_TASK_ORDER,
-    TASK_GROUP_FIELD_TOTAL,
     TASK_GROUP_ID_PREFIX,
-    TASK_GROUP_PROTOCOL_V2,
-    TASK_GROUP_TTL_SECONDS,
     RedisKeys,
 )
 from by_framework.common.emitter import DataLayoutBuilder, GatewayDataEmitter
@@ -60,6 +51,8 @@ from by_framework.core.runtime import AgentRuntimeState
 from by_framework.core.runtime.file_permissions import FilePermissionPolicy
 from by_framework.core.runtime.filestore.base import FileStorage
 from by_framework.trace.span_recorder import (SpanRecorder, TraceSpan, str_to_uint64)
+
+from .task_group import TaskGroupStore
 
 if TYPE_CHECKING:
     from by_framework.core.extensions import PluginRegistry
@@ -864,11 +857,10 @@ class AgentContext:
                        "priority": int,                    # default 0
                    }
             wait_for_reply: bool. If True, sets up Redis counters to wait for all.
-            message_id: Single-task convenience only. A Task Group keys its
-                   results by each sub-task's own dispatch message_id, so one
-                   id shared across a batch would make siblings overwrite each
-                   other; passing it with more than one task raises ValueError.
-                   Use the per-task "message_id" key instead.
+            message_id: Legacy batch-level message ID. For one task it is used
+                   unchanged; for multiple tasks it becomes the prefix for
+                   collision-free per-task IDs. A per-task ``message_id``
+                   overrides the derived value.
 
         Returns:
             {"status": "QUEUED", "task_group_id": str, "dispatched_tasks": [...]}
@@ -881,46 +873,35 @@ class AgentContext:
         if not tasks:
             raise ValueError("dispatch_group/call_agents requires at least one task")
 
-        if message_id and len(tasks) > 1:
-            raise ValueError(
-                "call_agents/dispatch_group cannot share one message_id across "
-                f"{len(tasks)} tasks: Task Group results are keyed by each "
-                "sub-task's own message_id, so the siblings would overwrite "
-                'each other. Pass a per-task "message_id" instead.'
-            )
+        task_message_ids = TaskGroupStore.resolve_message_ids(
+            [task.get("message_id") for task in tasks],
+            shared_message_id=message_id,
+            generate_message_id=self.generate_message_id,
+        )
 
         task_group_id = f"{TASK_GROUP_ID_PREFIX}{uuid.uuid4().hex[:8]}"
         total_tasks = len(tasks)
         group_dispatch_start_ts = int(time.time() * 1000)
-        group_key = RedisKeys.task_group(task_group_id)
+        task_group_store = TaskGroupStore(self.redis)
 
         if wait_for_reply:
-            await self.redis.hset(  # type: ignore
-                group_key,
-                mapping={
-                    TASK_GROUP_FIELD_TOTAL: str(total_tasks),
-                    TASK_GROUP_FIELD_COMPLETED: "0",
-                    TASK_GROUP_FIELD_SOURCE_AGENT: self.current_agent_id,
-                    TASK_GROUP_FIELD_PROTOCOL_VERSION: TASK_GROUP_PROTOCOL_V2,
-                },
+            await task_group_store.create(
+                task_group_id,
+                message_ids=task_message_ids,
+                source_agent_type=self.current_agent_id,
             )
-            # Ensure the key expires to prevent leak
-            await self.redis.expire(group_key, TASK_GROUP_TTL_SECONDS)
             self._is_suspended = True
         else:
             self._permission_transferred = True
 
         dispatched = []
         pending_failures: list[ResumeCommand] = []
-        for task in tasks:
+        for task, current_message_id in zip(tasks, task_message_ids):
             target_agent_type = task["target_agent_type"]
             content = task.get("content", "")
             extra_payload = task.get("extra_payload", {})
             metadata = dict(task.get("metadata", {}) or {})
 
-            current_message_id = (
-                task.get("message_id") or message_id or self.generate_message_id()
-            )
             try:
                 task_result = await self._dispatch_single_task(
                     target_agent_type=target_agent_type,
@@ -945,11 +926,7 @@ class AgentContext:
                 # replies queued so far are dropped with the raise: the worker
                 # only flushes them once process_command returns normally.
                 if wait_for_reply:
-                    await self.redis.hset(  # type: ignore
-                        group_key,
-                        TASK_GROUP_FIELD_ABORTED,
-                        "1",
-                    )
+                    await task_group_store.abort(task_group_id)
                 raise
 
             if task_result["status"] == AgentState.FAILED.value and wait_for_reply:
@@ -992,14 +969,6 @@ class AgentContext:
             dispatched.append(dispatched_task)
 
         if wait_for_reply:
-            # Written after the loop so it records exactly what was dispatched.
-            # Group Join aggregates in this order and uses it to name results
-            # that never arrived.
-            await self.redis.hset(  # type: ignore
-                group_key,
-                TASK_GROUP_FIELD_TASK_ORDER,
-                json.dumps([item["message_id"] for item in dispatched]),
-            )
             self._pending_group_replies.extend(pending_failures)
 
         # Record aggregate span for the entire group dispatch.
@@ -1038,6 +1007,12 @@ class AgentContext:
             "task_group_id": task_group_id,
             "dispatched_tasks": dispatched,
         }
+
+    def drain_pending_group_replies(self) -> list[ResumeCommand]:
+        """Return and clear synthetic Task Group replies queued by dispatch."""
+        replies = list(self._pending_group_replies)
+        self._pending_group_replies.clear()
+        return replies
 
     def _build_group_failure_reply(
         self,
@@ -1235,53 +1210,7 @@ class AgentContext:
                 "content": Optional[str]
             }
         """
-        if not task_group_id:
-            return []
-
-        results_key = RedisKeys.task_group_results(task_group_id)
-        group_key = RedisKeys.task_group(task_group_id)
-        field = TASK_GROUP_FIELD_TOTAL
-        total_str = await self.redis.hget(group_key, field)  # type: ignore
-        if total_str is None:
-            # No group found, try to get whatever results exist
-            total = float("inf")
-        else:
-            total = int(total_str)
-
-        # Ordering mirrors what Group Join hands the caller on resume: dispatch
-        # order, not the Redis hash's unspecified iteration order. A group from
-        # a pre-v2 dispatcher has no task_order and keeps hash order.
-        raw_order = await self.redis.hget(  # type: ignore
-            group_key, TASK_GROUP_FIELD_TASK_ORDER
+        return await TaskGroupStore(self.redis).collect(
+            task_group_id,
+            timeout=timeout,
         )
-        try:
-            order = json.loads(raw_order) if raw_order else []
-        except (TypeError, ValueError):
-            order = []
-
-        start_time = asyncio.get_running_loop().time()
-        results: list[dict[str, Any]] = []
-
-        while len(results) < total:
-            elapsed = asyncio.get_running_loop().time() - start_time
-            if elapsed >= timeout:
-                break
-
-            raw_results = await self.redis.hgetall(results_key)  # type: ignore
-            if raw_results:
-                ordered_ids = [m for m in order if m in raw_results]
-                ordered_ids += [m for m in raw_results if m not in set(order)]
-                results = [
-                    {
-                        "message_id": msg_id,
-                        **json.loads(raw_results[msg_id]),
-                    }
-                    for msg_id in ordered_ids
-                ]
-                if len(results) >= total:
-                    break
-
-            # Wait a bit before polling again
-            await asyncio.sleep(0.1)
-
-        return results

--- a/src/by_framework/worker/context.py
+++ b/src/by_framework/worker/context.py
@@ -25,9 +25,12 @@ from by_framework.common.constants import (
     MESSAGE_ID_PREFIX,
     TASK_GROUP_FIELD_ABORTED,
     TASK_GROUP_FIELD_COMPLETED,
+    TASK_GROUP_FIELD_PROTOCOL_VERSION,
     TASK_GROUP_FIELD_SOURCE_AGENT,
+    TASK_GROUP_FIELD_TASK_ORDER,
     TASK_GROUP_FIELD_TOTAL,
     TASK_GROUP_ID_PREFIX,
+    TASK_GROUP_PROTOCOL_V2,
     TASK_GROUP_TTL_SECONDS,
     RedisKeys,
 )
@@ -155,6 +158,13 @@ class AgentContext:
         self._permission_transferred = False
         # Flag: execution suspended due to calling agents or waiting
         self._is_suspended = False
+        # Task Group sub-tasks that never reached a worker (their target agent
+        # type was unavailable at dispatch time). Each is a fully-formed
+        # ResumeCommand addressed back at this caller, so Group Join counts and
+        # aggregates it exactly like a real sub-agent's failure reply. The
+        # worker flushes these AFTER process_command returns — see
+        # GatewayWorker._flush_pending_group_replies for why not inline.
+        self._pending_group_replies: list[ResumeCommand] = []
         self._trace_parent_observation_id = ""
         self._token_usage: dict[str, Any] = {}
         self.plugin_registry = plugin_registry
@@ -690,6 +700,11 @@ class AgentContext:
                 )
             return {
                 "status": AgentState.FAILED.value,
+                # message_id stays empty: nothing was dispatched, so there is
+                # no in-flight message to refer to. parent_message_id is the
+                # RESOLVED caller message id (not the raw argument) because
+                # call_agents needs it to address the synthetic failure reply
+                # back at the caller's own suspended execution.
                 "message_id": "",
                 "parent_message_id": parent_message_id or "",
                 "target_agent_type": target_agent_type,
@@ -833,30 +848,60 @@ class AgentContext:
         aggregated, ONLY when ALL tasks in the group are complete.
 
         Args:
-            tasks: A list of dicts, each containing:
+            tasks: A list of dicts. Every key call_agent takes per call is
+                   accepted here per task, with call_agent's own defaults, so a
+                   task that names no routing options behaves exactly like the
+                   equivalent call_agent call:
                    {
-                       "target_agent_type": str,
-                       "content": str,
+                       "target_agent_type": str,           # required
+                       "content": object,
                        "extra_payload": Optional[Dict[str, Any]],
-                       "metadata": Optional[Dict[str, Any]]
+                       "metadata": Optional[Dict[str, Any]],
+                       "message_id": Optional[str],
+                       "route_policy": str,                # default FAIL_FAST
+                       "availability_timeout_ms": int,     # default 30000
+                       "region": Optional[str],
+                       "priority": int,                    # default 0
                    }
             wait_for_reply: bool. If True, sets up Redis counters to wait for all.
+            message_id: Single-task convenience only. A Task Group keys its
+                   results by each sub-task's own dispatch message_id, so one
+                   id shared across a batch would make siblings overwrite each
+                   other; passing it with more than one task raises ValueError.
+                   Use the per-task "message_id" key instead.
+
+        Returns:
+            {"status": "QUEUED", "task_group_id": str, "dispatched_tasks": [...]}
+            where each dispatched task carries message_id, target_agent_type,
+            status, and — when dispatch failed — reply_data with the error.
+
+        On resume, the caller's ResumeCommand carries reply_data as the ordered
+        list of every sub-task's result (dispatch order) and content as "".
         """
         if not tasks:
             raise ValueError("dispatch_group/call_agents requires at least one task")
 
+        if message_id and len(tasks) > 1:
+            raise ValueError(
+                "call_agents/dispatch_group cannot share one message_id across "
+                f"{len(tasks)} tasks: Task Group results are keyed by each "
+                "sub-task's own message_id, so the siblings would overwrite "
+                'each other. Pass a per-task "message_id" instead.'
+            )
+
         task_group_id = f"{TASK_GROUP_ID_PREFIX}{uuid.uuid4().hex[:8]}"
         total_tasks = len(tasks)
         group_dispatch_start_ts = int(time.time() * 1000)
+        group_key = RedisKeys.task_group(task_group_id)
 
         if wait_for_reply:
-            group_key = RedisKeys.task_group(task_group_id)
             await self.redis.hset(  # type: ignore
                 group_key,
                 mapping={
                     TASK_GROUP_FIELD_TOTAL: str(total_tasks),
                     TASK_GROUP_FIELD_COMPLETED: "0",
                     TASK_GROUP_FIELD_SOURCE_AGENT: self.current_agent_id,
+                    TASK_GROUP_FIELD_PROTOCOL_VERSION: TASK_GROUP_PROTOCOL_V2,
                 },
             )
             # Ensure the key expires to prevent leak
@@ -866,13 +911,16 @@ class AgentContext:
             self._permission_transferred = True
 
         dispatched = []
+        pending_failures: list[ResumeCommand] = []
         for task in tasks:
             target_agent_type = task["target_agent_type"]
             content = task.get("content", "")
             extra_payload = task.get("extra_payload", {})
             metadata = dict(task.get("metadata", {}) or {})
 
-            current_message_id = message_id or self.generate_message_id()
+            current_message_id = (
+                task.get("message_id") or message_id or self.generate_message_id()
+            )
             try:
                 task_result = await self._dispatch_single_task(
                     target_agent_type=target_agent_type,
@@ -883,53 +931,76 @@ class AgentContext:
                     message_id=current_message_id,
                     parent_message_id=parent_message_id,
                     task_group_id=task_group_id,
+                    route_policy=task.get("route_policy", RoutePolicy.FAIL_FAST),
+                    availability_timeout_ms=task.get("availability_timeout_ms", 30000),
+                    region=task.get("region"),
+                    priority=task.get("priority", 0),
                 )
             except Exception:
                 # A genuine dispatch-time failure (not an availability-check
                 # rejection, which _dispatch_single_task already turns into a
                 # FAILED result instead of raising). Stop fanning out and mark
                 # the group aborted so already-sent siblings' replies don't
-                # later resume this (now-failed) caller execution.
+                # later resume this (now-failed) caller execution. Synthetic
+                # replies queued so far are dropped with the raise: the worker
+                # only flushes them once process_command returns normally.
                 if wait_for_reply:
                     await self.redis.hset(  # type: ignore
-                        RedisKeys.task_group(task_group_id),
+                        group_key,
                         TASK_GROUP_FIELD_ABORTED,
                         "1",
                     )
                 raise
 
             if task_result["status"] == AgentState.FAILED.value and wait_for_reply:
-                # Target agent type unavailable: record the failure as this
-                # task's result immediately, without blocking the rest of
-                # the batch or waiting for a reply that will never arrive.
-                result_data = {
-                    "status": task_result["status"],
-                    "reply_data": None,
-                    "content": "",
-                    "target_agent_type": target_agent_type,
-                    "metadata": {},
-                    "extra_payload": {},
+                # The target agent type was unavailable, so no worker will ever
+                # reply for this sub-task. Rather than book-keeping the group
+                # here — a second implementation of the accounting that lives in
+                # GatewayWorker's Group Join, and the one that could push
+                # `completed` to `total` with nobody left to resume the caller —
+                # synthesize the reply that a sub-agent WOULD have sent had it
+                # started and failed. Group Join then counts, stores and
+                # aggregates it through the single path it already owns.
+                pending_failures.append(
+                    self._build_group_failure_reply(
+                        task_group_id=task_group_id,
+                        caller_message_id=task_result["parent_message_id"],
+                        task_message_id=current_message_id,
+                        target_agent_type=task_result["target_agent_type"],
+                        error=task_result.get("error"),
+                        error_code=task_result.get("error_code"),
+                        metadata=metadata,
+                    )
+                )
+
+            dispatched_task = {
+                "message_id": current_message_id,
+                # task_result["target_agent_type"] reflects any fallback
+                # reroute _dispatch_single_task performed, so this stays
+                # consistent with what Group Join later reports.
+                "target_agent_type": task_result["target_agent_type"],
+                "status": task_result["status"],
+            }
+            if task_result["status"] == AgentState.FAILED.value:
+                # Same shape a real sub-agent failure arrives in
+                # (GatewayWorker._handle_message's error path), so callers read
+                # dispatch-time and run-time failures the same way.
+                dispatched_task["reply_data"] = {
                     "error": task_result.get("error"),
                     "error_code": task_result.get("error_code"),
                 }
-                results_key = RedisKeys.task_group_results(task_group_id)
-                await self.redis.hset(  # type: ignore
-                    results_key, current_message_id, json.dumps(result_data)
-                )
-                await self.redis.expire(results_key, TASK_GROUP_TTL_SECONDS)
-                await self.redis.hincrby(  # type: ignore
-                    RedisKeys.task_group(task_group_id), TASK_GROUP_FIELD_COMPLETED, 1
-                )
+            dispatched.append(dispatched_task)
 
-            dispatched.append(
-                {
-                    "message_id": current_message_id,
-                    # task_result["target_agent_type"] reflects any fallback
-                    # reroute _dispatch_single_task performed, so this stays
-                    # consistent with what Group Join later reports.
-                    "target_agent_type": task_result["target_agent_type"],
-                }
+        if wait_for_reply:
+            # Written after the loop so it records exactly what was dispatched.
+            # Group Join aggregates in this order and uses it to name results
+            # that never arrived.
+            await self.redis.hset(  # type: ignore
+                group_key,
+                TASK_GROUP_FIELD_TASK_ORDER,
+                json.dumps([item["message_id"] for item in dispatched]),
             )
+            self._pending_group_replies.extend(pending_failures)
 
         # Record aggregate span for the entire group dispatch.
         group_parent_span_id = (
@@ -967,6 +1038,56 @@ class AgentContext:
             "task_group_id": task_group_id,
             "dispatched_tasks": dispatched,
         }
+
+    def _build_group_failure_reply(
+        self,
+        *,
+        task_group_id: str,
+        caller_message_id: str,
+        task_message_id: str,
+        target_agent_type: str,
+        error: Optional[str],
+        error_code: Optional[str],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> ResumeCommand:
+        """Build the reply a sub-agent WOULD have sent had it started and failed.
+
+        The header derivation mirrors GatewayWorker._enqueue_agent_return
+        exactly, because that shape is load-bearing in two places:
+
+        - header.message_id must be the CALLER's own message id: WorkerRunner
+          reattaches a ResumeCommand to the suspended execution via
+          get_execution_by_message_id(header.message_id), so any other value
+          would orphan the caller's execution instead of resuming it.
+        - header.parent_message_id must be this sub-task's dispatch message id:
+          it is what Group Join keys the result hash by, and it is the only
+          per-sibling-unique id available on a reply.
+
+        reply_data carries the failure detail because that is how a real
+        failure arrives (GatewayWorker._handle_message returns
+        status=FAILED, reply_data={"error": ...}); putting it anywhere else
+        would make dispatch-time and run-time failures read differently.
+        """
+        return ResumeCommand(
+            header=MessageHeader(
+                message_id=caller_message_id,
+                session_id=self.session_id,
+                trace_id=self.trace_id,
+                source_agent_type=target_agent_type,
+                target_agent_type=self.current_agent_id,
+                parent_message_id=task_message_id,
+                task_group_id=task_group_id,
+                user_code=self.agent_runtime_state.session_manager.user_code,
+                user_name=self.agent_runtime_state.session_manager.user_name,
+                metadata=dict(metadata or {}),
+            ),
+            status=AgentState.FAILED.value,
+            content="",
+            reply_data={
+                "error": error,
+                "error_code": error_code or "AGENT_TYPE_UNAVAILABLE",
+            },
+        )
 
     async def dispatch_group(
         self,
@@ -1127,6 +1248,17 @@ class AgentContext:
         else:
             total = int(total_str)
 
+        # Ordering mirrors what Group Join hands the caller on resume: dispatch
+        # order, not the Redis hash's unspecified iteration order. A group from
+        # a pre-v2 dispatcher has no task_order and keeps hash order.
+        raw_order = await self.redis.hget(  # type: ignore
+            group_key, TASK_GROUP_FIELD_TASK_ORDER
+        )
+        try:
+            order = json.loads(raw_order) if raw_order else []
+        except (TypeError, ValueError):
+            order = []
+
         start_time = asyncio.get_running_loop().time()
         results: list[dict[str, Any]] = []
 
@@ -1137,12 +1269,14 @@ class AgentContext:
 
             raw_results = await self.redis.hgetall(results_key)  # type: ignore
             if raw_results:
+                ordered_ids = [m for m in order if m in raw_results]
+                ordered_ids += [m for m in raw_results if m not in set(order)]
                 results = [
                     {
                         "message_id": msg_id,
-                        **json.loads(data),
+                        **json.loads(raw_results[msg_id]),
                     }
-                    for msg_id, data in raw_results.items()
+                    for msg_id in ordered_ids
                 ]
                 if len(results) >= total:
                     break

--- a/src/by_framework/worker/runner.py
+++ b/src/by_framework/worker/runner.py
@@ -15,6 +15,7 @@ from by_framework.common.constants import (
     CONTROL_LOOP_SLEEP_SECONDS,
     EXECUTION_ID_PREFIX,
     STREAM_READ_LAST_ID,
+    TASK_GROUP_JOIN_CLAIM_TTL_MS,
     WAIT_FOR_TASKS_TIMEOUT_SECONDS,
     RedisKeys,
 )
@@ -42,6 +43,11 @@ from by_framework.trace.trace_writer import TraceWriteClient
 from by_framework.util.generate_message_id import generate_message_id
 from by_framework.worker.context import current_worker_id_var
 from by_framework.worker.health_server import WorkerHealthServer
+from by_framework.worker.task_group import (
+    TASK_GROUP_JOIN_PENDING_STATUS,
+    TASK_GROUP_JOINED_STATUS,
+    TaskGroupStore,
+)
 from by_framework.worker.worker import GatewayWorker
 
 from ._control_handling import (
@@ -113,6 +119,7 @@ class WorkerRunner:
         # Round-robin cursor for fetch_messages' phase-two blocking read, so
         # no agent_type is permanently starved of the blocking slot.
         self._primary_cursor: int = 0
+        self._pending_claim_last_monotonic: dict[str, float] = {}
         self._consumer_last_tick_monotonic = 0.0
         stream_block_seconds = float(WorkerConfig.stream_block_ms) / 1000.0
         self._consumer_health_timeout_seconds = max(
@@ -244,6 +251,10 @@ class WorkerRunner:
 
         stream_names = list(streams.keys())
 
+        claimed = await self._claim_stale_messages(stream_names, count=count)
+        if claimed:
+            return claimed
+
         async def read_nonblocking(stream_name: str):
             return await self.redis.xreadgroup(
                 groupname=self.group_name,
@@ -269,6 +280,61 @@ class WorkerRunner:
             block=block,
         )
         return await self._parse_xreadgroup_results([blocked])
+
+    async def _claim_stale_messages(
+        self, stream_names: list[str], *, count: int
+    ) -> list[tuple[str, str, dict]]:
+        """Reclaim unacknowledged entries whose Group Join lease can expire."""
+        if not callable(getattr(type(self.redis), "xautoclaim", None)):
+            return []
+
+        now = time.monotonic()
+        scan_interval = min(TASK_GROUP_JOIN_CLAIM_TTL_MS / 2000.0, 60.0)
+        eligible = [
+            stream_name
+            for stream_name in stream_names
+            if now - self._pending_claim_last_monotonic.get(stream_name, float("-inf"))
+            >= scan_interval
+        ]
+        if not eligible:
+            return []
+        for stream_name in eligible:
+            self._pending_claim_last_monotonic[stream_name] = now
+
+        async def claim(stream_name: str):
+            try:
+                response = await self.redis.xautoclaim(
+                    stream_name,
+                    self.group_name,
+                    self.consumer_name,
+                    min_idle_time=TASK_GROUP_JOIN_CLAIM_TTL_MS,
+                    start_id="0-0",
+                    count=count,
+                )
+                return stream_name, response
+            except Exception as error:  # pylint: disable=broad-exception-caught
+                logger.warning(
+                    "[%s] Failed to reclaim pending messages from %s: %s",
+                    self.worker.worker_id,
+                    stream_name,
+                    error,
+                )
+                return stream_name, None
+
+        batches = await asyncio.gather(*(claim(name) for name in eligible))
+        results: list[tuple[str, str, dict]] = []
+        for stream_name, response in batches:
+            if not response or len(response) < 2:
+                continue
+            for msg_id_raw, msg_data in response[1]:
+                msg_id = decode_message_id(msg_id_raw)
+                try:
+                    data_dict = await parse_message_data(msg_data)
+                except Exception:  # pylint: disable=broad-exception-caught
+                    logger.error("Failed to parse reclaimed message: %s", msg_id)
+                    continue
+                results.append((stream_name, msg_id, data_dict))
+        return results
 
     @staticmethod
     async def _parse_xreadgroup_results(batches: list) -> list[tuple[str, str, dict]]:
@@ -515,6 +581,22 @@ class WorkerRunner:
             if not header.message_id:
                 header.message_id = generate_message_id()
 
+            # A committed Task Group duplicate is ACK-only. Check before
+            # touching execution registry state; GatewayWorker repeats this
+            # decision atomically to close the race with mark_joined().
+            if (
+                isinstance(command, ResumeCommand)
+                and header.task_group_id
+                and await TaskGroupStore(self.redis).is_joined(header.task_group_id)
+            ):
+                await self.redis.xack(stream_name, self.group_name, msg_id)
+                logger.info(
+                    "[%s] ACK-only replay for joined TaskGroup %s",
+                    self.worker.worker_id,
+                    header.task_group_id,
+                )
+                return
+
             registry = getattr(self.worker, "registry", None)
             existing_execution = None
 
@@ -652,6 +734,37 @@ class WorkerRunner:
                     cancel_reason=cancel_reason,
                     execution=self._tracker.get_execution(execution_id),
                 )
+                if task_result.status == TASK_GROUP_JOIN_PENDING_STATUS:
+                    logger.info(
+                        "[%s] Leaving TaskGroup %s reply pending for claim recovery",
+                        self.worker.worker_id,
+                        header.task_group_id,
+                    )
+                    return
+                if task_result.status == TASK_GROUP_JOINED_STATUS:
+                    # mark_joined raced the preflight above. Restore the prior
+                    # execution state, ACK the duplicate, and do not emit a
+                    # second completion/trace update.
+                    if (
+                        registry
+                        and existing_execution
+                        and hasattr(registry, "update_execution_status")
+                    ):
+                        await registry.update_execution_status(
+                            execution_id,
+                            header.session_id,
+                            existing_execution.get(
+                                "status", AgentState.COMPLETED.value
+                            ),
+                            worker_id=self.worker.worker_id,
+                        )
+                    await self.redis.xack(stream_name, self.group_name, msg_id)
+                    logger.info(
+                        "[%s] ACK-only raced replay for joined TaskGroup %s",
+                        self.worker.worker_id,
+                        header.task_group_id,
+                    )
+                    return
                 execution_finished_at = int(time.time() * 1000)
                 final_status = task_result.status
                 completion_fields = self._build_completion_observability_fields(

--- a/src/by_framework/worker/task_group.py
+++ b/src/by_framework/worker/task_group.py
@@ -1,0 +1,347 @@
+"""Task Group planning, persistence, and join semantics."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+import uuid
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Optional
+
+from by_framework.common.constants import (
+    TASK_GROUP_FIELD_ABORTED,
+    TASK_GROUP_FIELD_COMPLETED,
+    TASK_GROUP_FIELD_JOIN_CLAIM,
+    TASK_GROUP_FIELD_JOIN_CLAIM_EXPIRES_AT,
+    TASK_GROUP_FIELD_JOINED,
+    TASK_GROUP_FIELD_PROTOCOL_VERSION,
+    TASK_GROUP_FIELD_SOURCE_AGENT,
+    TASK_GROUP_FIELD_TASK_ORDER,
+    TASK_GROUP_FIELD_TOTAL,
+    TASK_GROUP_JOIN_CLAIM_TTL_MS,
+    TASK_GROUP_PROTOCOL_V2,
+    TASK_GROUP_TTL_SECONDS,
+    RedisKeys,
+)
+from by_framework.common.logger import logger
+from by_framework.common.redis_client import Redis
+
+_RECORD_REPLY_SCRIPT = """
+local total_raw = redis.call('HGET', KEYS[1], ARGV[1])
+if not total_raw then
+    return {0, 0, 0}
+end
+local total = tonumber(total_raw)
+local completed = tonumber(redis.call('HGET', KEYS[1], ARGV[2]) or '0')
+if redis.call('HEXISTS', KEYS[1], ARGV[3]) == 1 then
+    return {1, completed, total}
+end
+
+local added = redis.call('HSETNX', KEYS[2], ARGV[4], ARGV[5])
+if added == 1 then
+    redis.call('EXPIRE', KEYS[2], tonumber(ARGV[6]))
+    completed = redis.call('HINCRBY', KEYS[1], ARGV[2], 1)
+end
+if completed < total then
+    return {2, completed, total}
+end
+if redis.call('HGET', KEYS[1], ARGV[7]) == '1' then
+    return {5, completed, total}
+end
+
+local now_ms = tonumber(ARGV[10])
+local current_claim = redis.call('HGET', KEYS[1], ARGV[8])
+local claim_expires_at = tonumber(
+    redis.call('HGET', KEYS[1], ARGV[9]) or '0'
+)
+if current_claim and current_claim ~= ARGV[11] and claim_expires_at > now_ms then
+    return {4, completed, total}
+end
+
+redis.call('HSET', KEYS[1], ARGV[8], ARGV[11])
+redis.call('HSET', KEYS[1], ARGV[9], now_ms + tonumber(ARGV[12]))
+return {3, completed, total}
+"""
+
+_MARK_JOINED_SCRIPT = """
+if redis.call('HGET', KEYS[1], ARGV[1]) ~= ARGV[2] then
+    return 0
+end
+redis.call('HSET', KEYS[1], ARGV[3], '1')
+redis.call('HDEL', KEYS[1], ARGV[1], ARGV[4])
+return 1
+"""
+
+# Internal WorkerRunner control statuses. They never leave the runner as
+# execution states: one keeps the stream entry pending, the other is ACK-only.
+TASK_GROUP_JOIN_PENDING_STATUS = "__task_group_join_pending__"
+TASK_GROUP_JOINED_STATUS = "__task_group_joined__"
+
+
+class TaskGroupJoinState(StrEnum):
+    """Outcome of recording one Task Group reply."""
+
+    NOT_FOUND = "not_found"
+    ABORTED = "aborted"
+    WAITING = "waiting"
+    READY = "ready"
+    CLAIMED = "claimed"
+    JOINED = "joined"
+
+
+@dataclass(frozen=True)
+class TaskGroupJoinDecision:
+    """Atomic Group Join decision returned by :meth:`record_reply`."""
+
+    state: TaskGroupJoinState
+    completed: int
+    total: int
+    claim_token: str = ""
+
+
+class TaskGroupStore:
+    """Own the invariants shared by Task Group dispatch and Group Join."""
+
+    def __init__(self, redis_client: Redis, *, worker_id: str = ""):
+        self.redis = redis_client
+        self.worker_id = worker_id
+
+    async def create(
+        self,
+        task_group_id: str,
+        *,
+        message_ids: Sequence[str],
+        source_agent_type: str,
+    ) -> None:
+        """Persist the complete group contract before any task is dispatched."""
+        if not message_ids:
+            raise ValueError("Task Group requires at least one message_id")
+        if len(message_ids) != len(set(message_ids)):
+            raise ValueError("Task Group message_ids must be unique within a batch")
+        group_key = RedisKeys.task_group(task_group_id)
+        await self.redis.hset(
+            group_key,
+            mapping={
+                TASK_GROUP_FIELD_TOTAL: str(len(message_ids)),
+                TASK_GROUP_FIELD_COMPLETED: "0",
+                TASK_GROUP_FIELD_SOURCE_AGENT: source_agent_type,
+                TASK_GROUP_FIELD_PROTOCOL_VERSION: TASK_GROUP_PROTOCOL_V2,
+                TASK_GROUP_FIELD_TASK_ORDER: json.dumps(list(message_ids)),
+            },
+        )
+        await self.redis.expire(group_key, TASK_GROUP_TTL_SECONDS)
+
+    async def abort(self, task_group_id: str) -> None:
+        """Mark a partially-dispatched group so late replies are discarded."""
+        await self.redis.hset(
+            RedisKeys.task_group(task_group_id),
+            TASK_GROUP_FIELD_ABORTED,
+            "1",
+        )
+
+    @staticmethod
+    def build_result(
+        *,
+        status: str,
+        reply_data: Any,
+        content: Any,
+        target_agent_type: str,
+        metadata: dict,
+        extra_payload: dict,
+    ) -> dict[str, Any]:
+        """Return the shared single/batch result shape persisted by Group Join."""
+        result = {
+            "status": status,
+            "reply_data": reply_data,
+            "content": content,
+            "target_agent_type": target_agent_type,
+            "metadata": metadata,
+            "extra_payload": extra_payload,
+        }
+        if status == "FAILED":
+            failure = reply_data if isinstance(reply_data, dict) else {}
+            result["error"] = failure.get("error")
+            result["error_code"] = failure.get("error_code")
+        return result
+
+    async def record_reply(
+        self,
+        task_group_id: str,
+        *,
+        task_message_id: str,
+        result: dict,
+        now_ms: Optional[int] = None,
+        claim_token: Optional[str] = None,
+    ) -> TaskGroupJoinDecision:
+        """Store and count a reply exactly once, then claim a completed join."""
+        token = claim_token or uuid.uuid4().hex
+        raw = await self.redis.eval(
+            _RECORD_REPLY_SCRIPT,
+            2,
+            RedisKeys.task_group(task_group_id),
+            RedisKeys.task_group_results(task_group_id),
+            TASK_GROUP_FIELD_TOTAL,
+            TASK_GROUP_FIELD_COMPLETED,
+            TASK_GROUP_FIELD_ABORTED,
+            task_message_id,
+            json.dumps(result),
+            str(TASK_GROUP_TTL_SECONDS),
+            TASK_GROUP_FIELD_JOINED,
+            TASK_GROUP_FIELD_JOIN_CLAIM,
+            TASK_GROUP_FIELD_JOIN_CLAIM_EXPIRES_AT,
+            str(now_ms if now_ms is not None else int(time.time() * 1000)),
+            token,
+            str(TASK_GROUP_JOIN_CLAIM_TTL_MS),
+        )
+        code, completed, total = (int(value) for value in raw)
+        states = {
+            0: TaskGroupJoinState.NOT_FOUND,
+            1: TaskGroupJoinState.ABORTED,
+            2: TaskGroupJoinState.WAITING,
+            3: TaskGroupJoinState.READY,
+            4: TaskGroupJoinState.CLAIMED,
+            5: TaskGroupJoinState.JOINED,
+        }
+        return TaskGroupJoinDecision(
+            state=states[code],
+            completed=completed,
+            total=total,
+            claim_token=token if code == 3 else "",
+        )
+
+    async def mark_joined(self, task_group_id: str, claim_token: str) -> bool:
+        """Commit a successful caller resume owned by ``claim_token``."""
+        result = await self.redis.eval(
+            _MARK_JOINED_SCRIPT,
+            1,
+            RedisKeys.task_group(task_group_id),
+            TASK_GROUP_FIELD_JOIN_CLAIM,
+            claim_token,
+            TASK_GROUP_FIELD_JOINED,
+            TASK_GROUP_FIELD_JOIN_CLAIM_EXPIRES_AT,
+        )
+        return bool(result)
+
+    async def is_joined(self, task_group_id: str) -> bool:
+        """Return whether caller resumption for this group is committed."""
+        joined = await self.redis.hget(
+            RedisKeys.task_group(task_group_id), TASK_GROUP_FIELD_JOINED
+        )
+        return joined == "1" or joined == b"1"
+
+    async def aggregate(
+        self,
+        task_group_id: str,
+        *,
+        total: Optional[int] = None,
+        log_incomplete: bool = True,
+    ) -> list[dict[str, Any]]:
+        """Return results in dispatch order from the shared persistence shape."""
+        group_key = RedisKeys.task_group(task_group_id)
+        results_key = RedisKeys.task_group_results(task_group_id)
+        raw_results = await self.redis.hgetall(results_key)
+        raw_order = await self.redis.hget(group_key, TASK_GROUP_FIELD_TASK_ORDER)
+        try:
+            order = json.loads(raw_order) if raw_order else []
+        except (TypeError, ValueError):
+            logger.error(
+                "[%s] TaskGroup %s has an unreadable %s field (%r); falling "
+                "back to Redis hash order",
+                self.worker_id,
+                task_group_id,
+                TASK_GROUP_FIELD_TASK_ORDER,
+                raw_order,
+            )
+            order = []
+
+        order_set = set(order)
+        ordered_ids = [message_id for message_id in order if message_id in raw_results]
+        ordered_ids.extend(
+            message_id for message_id in raw_results if message_id not in order_set
+        )
+        aggregated = [
+            {
+                "message_id": message_id,
+                **json.loads(raw_results[message_id]),
+            }
+            for message_id in ordered_ids
+        ]
+
+        if total is None:
+            raw_total = await self.redis.hget(group_key, TASK_GROUP_FIELD_TOTAL)
+            total = int(raw_total) if raw_total is not None else None
+        if log_incomplete and total is not None and len(aggregated) != total:
+            missing = [
+                message_id for message_id in order if message_id not in raw_results
+            ]
+            logger.error(
+                "[%s] TaskGroup %s aggregated %d result(s) but expected %d; "
+                "missing sub-task message_ids=%s. Resuming the caller with an "
+                "incomplete result set.",
+                self.worker_id,
+                task_group_id,
+                len(aggregated),
+                total,
+                missing or "unknown",
+            )
+        return aggregated
+
+    async def collect(
+        self,
+        task_group_id: str,
+        *,
+        timeout: float,
+    ) -> list[dict[str, Any]]:
+        """Poll the same ordered result view used by automatic Group Join."""
+        if not task_group_id:
+            return []
+
+        raw_total = await self.redis.hget(
+            RedisKeys.task_group(task_group_id), TASK_GROUP_FIELD_TOTAL
+        )
+        total = int(raw_total) if raw_total is not None else None
+        start_time = asyncio.get_running_loop().time()
+        results: list[dict[str, Any]] = []
+        while total is None or len(results) < total:
+            if asyncio.get_running_loop().time() - start_time >= timeout:
+                break
+            results = await self.aggregate(
+                task_group_id,
+                total=total,
+                log_incomplete=False,
+            )
+            if total is not None and len(results) >= total:
+                break
+            await asyncio.sleep(0.1)
+        return results
+
+    @staticmethod
+    def resolve_message_ids(
+        explicit_ids: Sequence[Optional[str]],
+        *,
+        shared_message_id: Optional[str],
+        generate_message_id: Callable[[], str],
+    ) -> list[str]:
+        """Resolve collision-free sub-task IDs before creating any group state.
+
+        The legacy batch-level ``message_id`` remains accepted. For a batch it
+        becomes a stable prefix; for a single task it keeps its historical
+        exact value. An explicit per-task ID always wins.
+        """
+        is_batch = len(explicit_ids) > 1
+        resolved = [
+            explicit_id
+            or (
+                f"{shared_message_id}:{index}"
+                if shared_message_id and is_batch
+                else shared_message_id
+            )
+            or generate_message_id()
+            for index, explicit_id in enumerate(explicit_ids)
+        ]
+        if len(resolved) != len(set(resolved)):
+            raise ValueError("Task Group message_ids must be unique within a batch")
+        return resolved

--- a/src/by_framework/worker/worker.py
+++ b/src/by_framework/worker/worker.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 from by_framework.common.config import WorkerConfig
 from by_framework.common.constants import (
     MESSAGE_ID_PREFIX,
+    TASK_GROUP_FIELD_ABORTED,
     TASK_GROUP_FIELD_COMPLETED,
     TASK_GROUP_FIELD_TOTAL,
     TASK_GROUP_TTL_SECONDS,
@@ -654,12 +655,33 @@ class GatewayWorker(ABC):
                         group_key, TASK_GROUP_FIELD_TOTAL
                     )
                     if total_str is not None:
+                        aborted = await self.redis.hget(  # type: ignore
+                            group_key, TASK_GROUP_FIELD_ABORTED
+                        )
+                        if aborted:
+                            logger.warning(
+                                "[%s] TaskGroup %s is aborted, discarding late "
+                                "reply from message_id=%s",
+                                self.worker_id,
+                                header.task_group_id,
+                                header.message_id,
+                            )
+                            return AgentTaskResult(
+                                status=f"{AgentState.CANCELLED.value}: group_aborted"
+                            )
+
                         # Store result in Redis Hash for distributed access
                         if isinstance(raw_command, ResumeCommand):
                             result_data = {
                                 "status": raw_command.status,
                                 "reply_data": raw_command.reply_data,
                                 "content": raw_command.content,
+                                # This ResumeCommand flows FROM the sub-agent
+                                # back TO the caller, so its header's
+                                # source_agent_type is the sub-agent that
+                                # produced this result — i.e. the original
+                                # dispatch's target_agent_type.
+                                "target_agent_type": header.source_agent_type,
                                 "metadata": raw_command.header.metadata,
                                 "extra_payload": raw_command.extra_payload,
                             }
@@ -690,6 +712,15 @@ class GatewayWorker(ABC):
                             header.task_group_id,
                             total_str,
                         )
+                        raw_results = await self.redis.hgetall(  # type: ignore
+                            results_key
+                        )
+                        aggregated_results = [
+                            {"message_id": msg_id, **json.loads(data)}
+                            for msg_id, data in raw_results.items()
+                        ]
+                        if isinstance(command, ResumeCommand):
+                            command.reply_data = aggregated_results
 
                 # await context.emit_state(
                 #     StateChangeEvent(state=AgentState.RESUMED.value)

--- a/src/by_framework/worker/worker.py
+++ b/src/by_framework/worker/worker.py
@@ -661,10 +661,10 @@ class GatewayWorker(ABC):
                         if aborted:
                             logger.warning(
                                 "[%s] TaskGroup %s is aborted, discarding late "
-                                "reply from message_id=%s",
+                                "reply from sub-task message_id=%s",
                                 self.worker_id,
                                 header.task_group_id,
-                                header.message_id,
+                                header.parent_message_id,
                             )
                             return AgentTaskResult(
                                 status=f"{AgentState.CANCELLED.value}: group_aborted"
@@ -685,9 +685,18 @@ class GatewayWorker(ABC):
                                 "metadata": raw_command.header.metadata,
                                 "extra_payload": raw_command.extra_payload,
                             }
+                            # _enqueue_agent_return sets a reply's header.
+                            # message_id to the ORIGINAL dispatch's
+                            # parent_message_id (the caller's own message
+                            # id) — identical across every sibling in this
+                            # Task Group. Keying results by that would let
+                            # siblings overwrite each other; header.
+                            # parent_message_id on the reply is the
+                            # sub-task's own dispatch-time message_id
+                            # instead, which is unique per task.
                             await self.redis.hset(  # type: ignore
                                 results_key,
-                                header.message_id,
+                                header.parent_message_id,
                                 json.dumps(result_data),
                             )
                             await self.redis.expire(results_key, TASK_GROUP_TTL_SECONDS)

--- a/src/by_framework/worker/worker.py
+++ b/src/by_framework/worker/worker.py
@@ -25,7 +25,10 @@ from by_framework.common.constants import (
     MESSAGE_ID_PREFIX,
     TASK_GROUP_FIELD_ABORTED,
     TASK_GROUP_FIELD_COMPLETED,
+    TASK_GROUP_FIELD_PROTOCOL_VERSION,
+    TASK_GROUP_FIELD_TASK_ORDER,
     TASK_GROUP_FIELD_TOTAL,
+    TASK_GROUP_PROTOCOL_V2,
     TASK_GROUP_TTL_SECONDS,
     RedisKeys,
 )
@@ -300,6 +303,103 @@ class GatewayWorker(ABC):
             await self._heartbeat.stop()
             self._heartbeat = None
             logger.info("[%s] Heartbeat stopped", self.worker_id)
+
+    async def _aggregate_task_group(
+        self,
+        *,
+        group_key: str,
+        results_key: str,
+        task_group_id: str,
+        total: int,
+    ) -> list[dict[str, Any]]:
+        """Collect a completed Task Group's results in dispatch order.
+
+        Order comes from the group's `task_order` field rather than from
+        `hgetall`, whose order is unspecified — callers fanning out to N
+        agents need to know which result is which without matching by hand.
+
+        Results present in Redis but absent from `task_order` are appended
+        rather than dropped, and a short result set is logged loudly. Silently
+        returning fewer results than the caller dispatched is the failure mode
+        this repo's North Star rules out.
+        """
+        raw_results = await self.redis.hgetall(results_key)  # type: ignore
+        raw_order = await self.redis.hget(  # type: ignore
+            group_key, TASK_GROUP_FIELD_TASK_ORDER
+        )
+        try:
+            order = json.loads(raw_order) if raw_order else []
+        except (TypeError, ValueError):
+            logger.error(
+                "[%s] TaskGroup %s has an unreadable %s field (%r); falling "
+                "back to Redis hash order",
+                self.worker_id,
+                task_group_id,
+                TASK_GROUP_FIELD_TASK_ORDER,
+                raw_order,
+            )
+            order = []
+
+        aggregated: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for msg_id in order:
+            if msg_id in raw_results:
+                aggregated.append(
+                    {"message_id": msg_id, **json.loads(raw_results[msg_id])}
+                )
+                seen.add(msg_id)
+        for msg_id, data in raw_results.items():
+            if msg_id not in seen:
+                aggregated.append({"message_id": msg_id, **json.loads(data)})
+
+        if len(aggregated) != total:
+            missing = [msg_id for msg_id in order if msg_id not in raw_results]
+            logger.error(
+                "[%s] TaskGroup %s aggregated %d result(s) but expected %d; "
+                "missing sub-task message_ids=%s. Resuming the caller with an "
+                "incomplete result set.",
+                self.worker_id,
+                task_group_id,
+                len(aggregated),
+                total,
+                missing or "unknown",
+            )
+        return aggregated
+
+    async def _flush_pending_group_replies(self, context: AgentContext) -> None:
+        """Deliver replies for Task Group sub-tasks that never reached a worker.
+
+        AgentContext.call_agents queues these instead of sending them inline:
+        sending during the dispatch loop would put a reply on the caller's
+        control stream strictly before the caller's process_command returns,
+        turning the pre-existing "a very fast sub-agent replies before the
+        caller suspends" race from unlikely into certain. Flushing here keeps
+        that race no worse than it is for real sub-agents.
+
+        Failures are logged, never raised: a Task Group that cannot be told
+        about a dispatch failure will time out, whereas raising here would
+        also destroy the caller's own result.
+        """
+        pending = getattr(context, "_pending_group_replies", None)
+        if not pending:
+            return
+        replies = list(pending)
+        pending.clear()
+        for reply in replies:
+            try:
+                await self.redis.xadd(
+                    RedisKeys.ctrl_stream(reply.header.target_agent_type),
+                    reply.to_redis_payload(),
+                )
+            except Exception as error:  # pylint: disable=broad-exception-caught
+                logger.error(
+                    "[%s] Failed to deliver Task Group %s dispatch-failure "
+                    "reply for sub-task %s: %s",
+                    self.worker_id,
+                    reply.header.task_group_id,
+                    reply.header.parent_message_id,
+                    error,
+                )
 
     async def _enqueue_agent_return(
         self,
@@ -670,6 +770,18 @@ class GatewayWorker(ABC):
                                 status=f"{AgentState.CANCELLED.value}: group_aborted"
                             )
 
+                        # Which Task Group contract this group was dispatched
+                        # under. A group with no stamp was created by a
+                        # pre-v2 dispatcher, possibly by a worker still
+                        # running the old code during a rolling upgrade, so
+                        # it must keep being joined the old way — reading an
+                        # in-flight group under the wrong contract is exactly
+                        # the silent corruption this repo guards against.
+                        protocol_version = await self.redis.hget(  # type: ignore
+                            group_key, TASK_GROUP_FIELD_PROTOCOL_VERSION
+                        )
+                        is_v2 = protocol_version == TASK_GROUP_PROTOCOL_V2
+
                         # Store result in Redis Hash for distributed access
                         if isinstance(raw_command, ResumeCommand):
                             result_data = {
@@ -693,10 +805,15 @@ class GatewayWorker(ABC):
                             # siblings overwrite each other; header.
                             # parent_message_id on the reply is the
                             # sub-task's own dispatch-time message_id
-                            # instead, which is unique per task.
+                            # instead, which is unique per task. Pre-v2
+                            # groups keep the old (colliding) key so their
+                            # readers see what they were written to expect.
+                            result_field = (
+                                header.parent_message_id if is_v2 else header.message_id
+                            )
                             await self.redis.hset(  # type: ignore
                                 results_key,
-                                header.parent_message_id,
+                                result_field,
                                 json.dumps(result_data),
                             )
                             await self.redis.expire(results_key, TASK_GROUP_TTL_SECONDS)
@@ -721,20 +838,29 @@ class GatewayWorker(ABC):
                             header.task_group_id,
                             total_str,
                         )
-                        raw_results = await self.redis.hgetall(  # type: ignore
-                            results_key
-                        )
-                        aggregated_results = [
-                            {"message_id": msg_id, **json.loads(data)}
-                            for msg_id, data in raw_results.items()
-                        ]
-                        if isinstance(command, ResumeCommand):
+                        if is_v2 and isinstance(command, ResumeCommand):
+                            aggregated_results = await self._aggregate_task_group(
+                                group_key=group_key,
+                                results_key=results_key,
+                                task_group_id=header.task_group_id,
+                                total=int(total_str),
+                            )
                             command.reply_data = aggregated_results
+                            # reply_data is the single aggregation channel for
+                            # a Task Group resume. Leaving content as whichever
+                            # sibling happened to reply last would give the
+                            # caller two channels that disagree.
+                            command.content = ""
 
                 # await context.emit_state(
                 #     StateChangeEvent(state=AgentState.RESUMED.value)
                 # )
             process_result = await self.process_command(command, context)
+            # Only reached when process_command returned normally. If it
+            # raised, call_agents has already marked the Task Group aborted
+            # and these replies must NOT be sent — the caller execution they
+            # would resume is the one that just failed.
+            await self._flush_pending_group_replies(context)
             task_result = normalize_process_result(process_result)
 
             # Determine the execution status to return

--- a/src/by_framework/worker/worker.py
+++ b/src/by_framework/worker/worker.py
@@ -26,7 +26,6 @@ from by_framework.common.constants import (
     TASK_GROUP_FIELD_ABORTED,
     TASK_GROUP_FIELD_COMPLETED,
     TASK_GROUP_FIELD_PROTOCOL_VERSION,
-    TASK_GROUP_FIELD_TASK_ORDER,
     TASK_GROUP_FIELD_TOTAL,
     TASK_GROUP_PROTOCOL_V2,
     TASK_GROUP_TTL_SECONDS,
@@ -57,6 +56,12 @@ from by_framework.core.runtime.filestore.base import FileStorage
 from by_framework.trace.span_recorder import TraceSpan, str_to_uint64
 from by_framework.worker.context import AgentContext, current_agent_context_var
 from by_framework.worker.heartbeat import WorkerHeartbeat
+from by_framework.worker.task_group import (
+    TASK_GROUP_JOIN_PENDING_STATUS,
+    TASK_GROUP_JOINED_STATUS,
+    TaskGroupJoinState,
+    TaskGroupStore,
+)
 
 from .sandbox.hook_sandbox import active_workspace
 
@@ -304,68 +309,6 @@ class GatewayWorker(ABC):
             self._heartbeat = None
             logger.info("[%s] Heartbeat stopped", self.worker_id)
 
-    async def _aggregate_task_group(
-        self,
-        *,
-        group_key: str,
-        results_key: str,
-        task_group_id: str,
-        total: int,
-    ) -> list[dict[str, Any]]:
-        """Collect a completed Task Group's results in dispatch order.
-
-        Order comes from the group's `task_order` field rather than from
-        `hgetall`, whose order is unspecified — callers fanning out to N
-        agents need to know which result is which without matching by hand.
-
-        Results present in Redis but absent from `task_order` are appended
-        rather than dropped, and a short result set is logged loudly. Silently
-        returning fewer results than the caller dispatched is the failure mode
-        this repo's North Star rules out.
-        """
-        raw_results = await self.redis.hgetall(results_key)  # type: ignore
-        raw_order = await self.redis.hget(  # type: ignore
-            group_key, TASK_GROUP_FIELD_TASK_ORDER
-        )
-        try:
-            order = json.loads(raw_order) if raw_order else []
-        except (TypeError, ValueError):
-            logger.error(
-                "[%s] TaskGroup %s has an unreadable %s field (%r); falling "
-                "back to Redis hash order",
-                self.worker_id,
-                task_group_id,
-                TASK_GROUP_FIELD_TASK_ORDER,
-                raw_order,
-            )
-            order = []
-
-        aggregated: list[dict[str, Any]] = []
-        seen: set[str] = set()
-        for msg_id in order:
-            if msg_id in raw_results:
-                aggregated.append(
-                    {"message_id": msg_id, **json.loads(raw_results[msg_id])}
-                )
-                seen.add(msg_id)
-        for msg_id, data in raw_results.items():
-            if msg_id not in seen:
-                aggregated.append({"message_id": msg_id, **json.loads(data)})
-
-        if len(aggregated) != total:
-            missing = [msg_id for msg_id in order if msg_id not in raw_results]
-            logger.error(
-                "[%s] TaskGroup %s aggregated %d result(s) but expected %d; "
-                "missing sub-task message_ids=%s. Resuming the caller with an "
-                "incomplete result set.",
-                self.worker_id,
-                task_group_id,
-                len(aggregated),
-                total,
-                missing or "unknown",
-            )
-        return aggregated
-
     async def _flush_pending_group_replies(self, context: AgentContext) -> None:
         """Deliver replies for Task Group sub-tasks that never reached a worker.
 
@@ -380,11 +323,7 @@ class GatewayWorker(ABC):
         about a dispatch failure will time out, whereas raising here would
         also destroy the caller's own result.
         """
-        pending = getattr(context, "_pending_group_replies", None)
-        if not pending:
-            return
-        replies = list(pending)
-        pending.clear()
+        replies = context.drain_pending_group_replies()
         for reply in replies:
             try:
                 await self.redis.xadd(
@@ -687,6 +626,10 @@ class GatewayWorker(ABC):
         if execution:
             execution.context = context
         process_result: Any = None
+        joined_task_group_id = ""
+        join_claim_token = ""
+        join_process_started = False
+        join_marked = False
 
         logger.info(
             "[%s] Received message: %s (Trace: %s)",
@@ -782,45 +725,82 @@ class GatewayWorker(ABC):
                         )
                         is_v2 = protocol_version == TASK_GROUP_PROTOCOL_V2
 
-                        # Store result in Redis Hash for distributed access
-                        if isinstance(raw_command, ResumeCommand):
-                            result_data = {
-                                "status": raw_command.status,
-                                "reply_data": raw_command.reply_data,
-                                "content": raw_command.content,
-                                # This ResumeCommand flows FROM the sub-agent
-                                # back TO the caller, so its header's
-                                # source_agent_type is the sub-agent that
-                                # produced this result — i.e. the original
-                                # dispatch's target_agent_type.
-                                "target_agent_type": header.source_agent_type,
-                                "metadata": raw_command.header.metadata,
-                                "extra_payload": raw_command.extra_payload,
-                            }
-                            # _enqueue_agent_return sets a reply's header.
-                            # message_id to the ORIGINAL dispatch's
-                            # parent_message_id (the caller's own message
-                            # id) — identical across every sibling in this
-                            # Task Group. Keying results by that would let
-                            # siblings overwrite each other; header.
-                            # parent_message_id on the reply is the
-                            # sub-task's own dispatch-time message_id
-                            # instead, which is unique per task. Pre-v2
-                            # groups keep the old (colliding) key so their
-                            # readers see what they were written to expect.
-                            result_field = (
-                                header.parent_message_id if is_v2 else header.message_id
+                        assert isinstance(raw_command, ResumeCommand)
+                        result_data = TaskGroupStore.build_result(
+                            status=raw_command.status,
+                            reply_data=raw_command.reply_data,
+                            content=raw_command.content,
+                            # This ResumeCommand flows FROM the sub-agent
+                            # back TO the caller, so its header's
+                            # source_agent_type is the sub-agent that
+                            # produced this result — i.e. the original
+                            # dispatch's target_agent_type.
+                            target_agent_type=header.source_agent_type,
+                            metadata=raw_command.header.metadata,
+                            extra_payload=raw_command.extra_payload,
+                        )
+
+                        # Store and count a v2 result atomically. Redis Streams
+                        # may redeliver before XACK; a sibling must count once.
+                        if is_v2:
+                            task_group_store = TaskGroupStore(
+                                self.redis, worker_id=self.worker_id
                             )
+                            decision = await task_group_store.record_reply(
+                                header.task_group_id,
+                                task_message_id=header.parent_message_id,
+                                result=result_data,
+                            )
+                            if decision.state == TaskGroupJoinState.ABORTED:
+                                logger.warning(
+                                    "[%s] TaskGroup %s is aborted, discarding late "
+                                    "reply from sub-task message_id=%s",
+                                    self.worker_id,
+                                    header.task_group_id,
+                                    header.parent_message_id,
+                                )
+                                return AgentTaskResult(
+                                    status=(
+                                        f"{AgentState.CANCELLED.value}: "
+                                        "group_aborted"
+                                    )
+                                )
+                            if decision.state == TaskGroupJoinState.CLAIMED:
+                                # WorkerRunner recognizes this internal status
+                                # and deliberately leaves the stream entry
+                                # pending for lease recovery.
+                                return AgentTaskResult(
+                                    status=TASK_GROUP_JOIN_PENDING_STATUS
+                                )
+                            if decision.state == TaskGroupJoinState.JOINED:
+                                # ACK-only in WorkerRunner: do not mutate the
+                                # already terminal caller execution.
+                                return AgentTaskResult(status=TASK_GROUP_JOINED_STATUS)
+                            if decision.state == TaskGroupJoinState.WAITING:
+                                return AgentTaskResult(
+                                    status=(
+                                        f"{AgentState.QUEUED.value}: "
+                                        "waiting_for_group"
+                                    )
+                                )
+                            if decision.state == TaskGroupJoinState.NOT_FOUND:
+                                raise RuntimeError(
+                                    f"TaskGroup {header.task_group_id} disappeared "
+                                    "during Group Join"
+                                )
+                            completed = decision.completed
+                            join_claim_token = decision.claim_token
+                            joined_task_group_id = header.task_group_id
+                        else:
                             await self.redis.hset(  # type: ignore
                                 results_key,
-                                result_field,
+                                header.message_id,
                                 json.dumps(result_data),
                             )
                             await self.redis.expire(results_key, TASK_GROUP_TTL_SECONDS)
-
-                        completed = await self.redis.hincrby(  # type: ignore
-                            group_key, TASK_GROUP_FIELD_COMPLETED, 1
-                        )
+                            completed = await self.redis.hincrby(  # type: ignore
+                                group_key, TASK_GROUP_FIELD_COMPLETED, 1
+                            )
                         if completed < int(total_str):
                             logger.info(
                                 "[%s] TaskGroup %s completed %d/%s, waiting...",
@@ -839,10 +819,10 @@ class GatewayWorker(ABC):
                             total_str,
                         )
                         if is_v2 and isinstance(command, ResumeCommand):
-                            aggregated_results = await self._aggregate_task_group(
-                                group_key=group_key,
-                                results_key=results_key,
-                                task_group_id=header.task_group_id,
+                            aggregated_results = await TaskGroupStore(
+                                self.redis, worker_id=self.worker_id
+                            ).aggregate(
+                                header.task_group_id,
                                 total=int(total_str),
                             )
                             command.reply_data = aggregated_results
@@ -855,7 +835,17 @@ class GatewayWorker(ABC):
                 # await context.emit_state(
                 #     StateChangeEvent(state=AgentState.RESUMED.value)
                 # )
+            join_process_started = bool(joined_task_group_id)
             process_result = await self.process_command(command, context)
+            if joined_task_group_id:
+                joined = await TaskGroupStore(self.redis).mark_joined(
+                    joined_task_group_id, join_claim_token
+                )
+                if not joined:
+                    raise RuntimeError(
+                        f"TaskGroup {joined_task_group_id} lost its Group Join claim"
+                    )
+                join_marked = True
             # Only reached when process_command returned normally. If it
             # raised, call_agents has already marked the Task Group aborted
             # and these replies must NOT be sent — the caller execution they
@@ -975,6 +965,26 @@ class GatewayWorker(ABC):
             return AgentTaskResult(status=AgentState.CANCELLED.value)
 
         except Exception as e:  # pylint: disable=broad-exception-caught
+            if joined_task_group_id and not join_marked:
+                if not join_process_started:
+                    logger.exception(
+                        "TaskGroup %s failed before caller resume",
+                        joined_task_group_id,
+                    )
+                    return AgentTaskResult(status=TASK_GROUP_JOIN_PENDING_STATUS)
+                # process_command exceptions are terminally handled below and
+                # ACKed by WorkerRunner, so commit the join before returning
+                # FAILED. Otherwise a later duplicate could resume it again.
+                joined = await TaskGroupStore(self.redis).mark_joined(
+                    joined_task_group_id, join_claim_token
+                )
+                if not joined:
+                    logger.error(
+                        "TaskGroup %s could not commit Group Join",
+                        joined_task_group_id,
+                    )
+                    return AgentTaskResult(status=TASK_GROUP_JOIN_PENDING_STATUS)
+                join_marked = True
             error_msg = f"[{self.worker_id}] Task failed: {str(e)}"
             logger.error(error_msg)
             if has_source_agent:

--- a/tests/integration/test_scatter_gather.py
+++ b/tests/integration/test_scatter_gather.py
@@ -190,14 +190,21 @@ async def test_group_join_delivers_aggregated_results_on_resume(tmp_path):
     task_group_id = dispatch_result["task_group_id"]
     msg_b, msg_c = (t["message_id"] for t in dispatch_result["dispatched_tasks"])
 
+    # _enqueue_agent_return sets a reply's header.message_id to the caller's
+    # own message_id (shared by every sibling reply in this Task Group) and
+    # header.parent_message_id to the sub-task's own dispatch-time message_id
+    # (msg_b/msg_c here, distinct per task) — mirror that real relationship,
+    # not a hand-picked distinct message_id per reply, or this test can't
+    # catch a Group Join bug that only shows up when siblings' replies
+    # collide on the shared header.message_id.
     reply_b = ResumeCommand(
         header=MessageHeader(
-            message_id=msg_b,
+            message_id="parent-msg",
             session_id="s1",
             trace_id="t1",
             source_agent_type="agent-b",
             target_agent_type="caller_agent",
-            parent_message_id="parent-msg",
+            parent_message_id=msg_b,
             task_group_id=task_group_id,
         ),
         status="COMPLETED",
@@ -209,12 +216,12 @@ async def test_group_join_delivers_aggregated_results_on_resume(tmp_path):
 
     reply_c = ResumeCommand(
         header=MessageHeader(
-            message_id=msg_c,
+            message_id="parent-msg",
             session_id="s1",
             trace_id="t1",
             source_agent_type="agent-c",
             target_agent_type="caller_agent",
-            parent_message_id="parent-msg",
+            parent_message_id=msg_c,
             task_group_id=task_group_id,
         ),
         status="COMPLETED",
@@ -274,12 +281,12 @@ async def test_group_join_delivers_aggregate_even_with_partial_failure(tmp_path)
     await worker._handle_message(
         ResumeCommand(
             header=MessageHeader(
-                message_id=msg_b,
+                message_id="parent-msg",
                 session_id="s1",
                 trace_id="t1",
                 source_agent_type="agent-b",
                 target_agent_type="caller_agent",
-                parent_message_id="parent-msg",
+                parent_message_id=msg_b,
                 task_group_id=task_group_id,
             ),
             status="FAILED",
@@ -289,12 +296,12 @@ async def test_group_join_delivers_aggregate_even_with_partial_failure(tmp_path)
     await worker._handle_message(
         ResumeCommand(
             header=MessageHeader(
-                message_id=msg_c,
+                message_id="parent-msg",
                 session_id="s1",
                 trace_id="t1",
                 source_agent_type="agent-c",
                 target_agent_type="caller_agent",
-                parent_message_id="parent-msg",
+                parent_message_id=msg_c,
                 task_group_id=task_group_id,
             ),
             status="COMPLETED",
@@ -341,12 +348,12 @@ async def test_collect_group_results_still_works_outside_process_command(tmp_pat
     await worker._handle_message(
         ResumeCommand(
             header=MessageHeader(
-                message_id=msg_b,
+                message_id="parent-msg",
                 session_id="s1",
                 trace_id="t1",
                 source_agent_type="agent-b",
                 target_agent_type="caller_agent",
-                parent_message_id="parent-msg",
+                parent_message_id=msg_b,
                 task_group_id=task_group_id,
             ),
             status="COMPLETED",
@@ -396,12 +403,12 @@ async def test_collect_group_results_times_out_with_partial_results(tmp_path):
     await worker._handle_message(
         ResumeCommand(
             header=MessageHeader(
-                message_id=msg_b,
+                message_id="parent-msg",
                 session_id="s1",
                 trace_id="t1",
                 source_agent_type="agent-b",
                 target_agent_type="caller_agent",
-                parent_message_id="parent-msg",
+                parent_message_id=msg_b,
                 task_group_id=task_group_id,
             ),
             status="COMPLETED",
@@ -451,12 +458,12 @@ async def test_group_join_discards_reply_for_aborted_task_group(tmp_path):
     await worker._handle_message(
         ResumeCommand(
             header=MessageHeader(
-                message_id=msg_b,
+                message_id="parent-msg",
                 session_id="s1",
                 trace_id="t1",
                 source_agent_type="agent-b",
                 target_agent_type="caller_agent",
-                parent_message_id="parent-msg",
+                parent_message_id=msg_b,
                 task_group_id=task_group_id,
             ),
             status="COMPLETED",

--- a/tests/integration/test_scatter_gather.py
+++ b/tests/integration/test_scatter_gather.py
@@ -1,9 +1,16 @@
 from typing import List
+from unittest.mock import AsyncMock
 
 import pytest
 
+from by_framework.common.constants import (
+    TASK_GROUP_FIELD_ABORTED,
+    TASK_GROUP_FIELD_COMPLETED,
+    RedisKeys,
+)
 from by_framework.core.protocol.commands import ResumeCommand
 from by_framework.core.protocol.message_header import MessageHeader
+from by_framework.worker.context import AgentContext
 from by_framework.worker.worker import GatewayWorker
 
 
@@ -13,6 +20,87 @@ class DummyWorker(GatewayWorker):
         return ["dummy"]
 
     async def process_command(self, command, context):
+        return {"status": "ok"}
+
+
+class MockRedis:
+    """Minimal in-memory Redis hash store for scatter-gather join tests."""
+
+    def __init__(self):
+        self.data = {}
+
+    async def hset(self, name, key=None, value=None, mapping=None):
+        bucket = self.data.setdefault(name, {})
+        if mapping:
+            bucket.update(mapping)
+        else:
+            bucket[key] = value
+
+    async def hget(self, name, key):
+        return self.data.get(name, {}).get(key)
+
+    async def hgetall(self, name):
+        return dict(self.data.get(name, {}))
+
+    async def hincrby(self, name, key, amount=1):
+        bucket = self.data.setdefault(name, {})
+        value = int(bucket.get(key, 0)) + amount
+        bucket[key] = value
+        return value
+
+    async def expire(self, name, ttl):
+        return 1
+
+    async def xadd(self, name, fields):
+        return "0-1"
+
+    async def smembers(self, name):
+        # Every agent type is treated as having one online worker, so
+        # dispatch-time availability checks always pass in these tests.
+        return {b"worker-1"}
+
+    async def get(self, name):
+        return b"1"
+
+    def pipeline(self):
+        return _MockPipeline(self)
+
+
+class _MockPipeline:
+    """Minimal pipeline shim: queues (method, args) and applies them on execute()."""
+
+    def __init__(self, redis):
+        self._redis = redis
+        self._ops = []
+
+    def __getattr__(self, name):
+
+        def queue(*args, **kwargs):
+            self._ops.append((name, args, kwargs))
+            return self
+
+        return queue
+
+    async def execute(self):
+        results = []
+        for name, args, kwargs in self._ops:
+            results.append(await getattr(self._redis, name)(*args, **kwargs))
+        self._ops = []
+        return results
+
+
+class RecordingProcessCommandWorker(GatewayWorker):
+    """Worker that records every command handed to process_command."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.received_commands = []
+
+    def get_agent_types(self) -> List[str]:
+        return ["caller_agent"]
+
+    async def process_command(self, command, context):
+        self.received_commands.append(command)
         return {"status": "ok"}
 
 
@@ -66,3 +154,316 @@ async def test_persist_agent_return_state_scatter_gather(tmp_path):
     assert "B result" in content_b
     content_c = (returns_dir / "msg-c.json").read_text()
     assert "C result" in content_c
+
+
+@pytest.mark.asyncio
+async def test_group_join_delivers_aggregated_results_on_resume(tmp_path):
+    """process_command is resumed with every sub-task's result once the
+    Task Group completes, not with whichever reply happened to arrive last."""
+    redis = MockRedis()
+    workspace_manager = AsyncMock()
+    workspace_manager.setup_workspace.return_value = {
+        "private": str(tmp_path),
+        "public": str(tmp_path),
+    }
+
+    worker = RecordingProcessCommandWorker(
+        worker_id="test-join",
+        redis_client=redis,
+        registry=AsyncMock(),
+        workspace_manager=workspace_manager,
+    )
+
+    caller_context = AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=redis,
+        current_agent_id="caller_agent",
+        message_id="parent-msg",
+    )
+    dispatch_result = await caller_context.dispatch_group(
+        tasks=[
+            {"target_agent_type": "agent-b", "content": "task one"},
+            {"target_agent_type": "agent-c", "content": "task two"},
+        ],
+    )
+    task_group_id = dispatch_result["task_group_id"]
+    msg_b, msg_c = (t["message_id"] for t in dispatch_result["dispatched_tasks"])
+
+    reply_b = ResumeCommand(
+        header=MessageHeader(
+            message_id=msg_b,
+            session_id="s1",
+            trace_id="t1",
+            source_agent_type="agent-b",
+            target_agent_type="caller_agent",
+            parent_message_id="parent-msg",
+            task_group_id=task_group_id,
+        ),
+        status="COMPLETED",
+        content="B result",
+        reply_data={"value": "b"},
+    )
+    await worker._handle_message(reply_b)
+    assert worker.received_commands == []
+
+    reply_c = ResumeCommand(
+        header=MessageHeader(
+            message_id=msg_c,
+            session_id="s1",
+            trace_id="t1",
+            source_agent_type="agent-c",
+            target_agent_type="caller_agent",
+            parent_message_id="parent-msg",
+            task_group_id=task_group_id,
+        ),
+        status="COMPLETED",
+        content="C result",
+        reply_data={"value": "c"},
+    )
+    await worker._handle_message(reply_c)
+
+    assert len(worker.received_commands) == 1
+    resumed = worker.received_commands[0]
+    aggregate = resumed.reply_data
+    assert isinstance(aggregate, list)
+    assert len(aggregate) == 2
+
+    by_message_id = {item["message_id"]: item for item in aggregate}
+    assert by_message_id[msg_b]["target_agent_type"] == "agent-b"
+    assert by_message_id[msg_b]["reply_data"] == {"value": "b"}
+    assert by_message_id[msg_b]["status"] == "COMPLETED"
+    assert by_message_id[msg_c]["target_agent_type"] == "agent-c"
+    assert by_message_id[msg_c]["reply_data"] == {"value": "c"}
+
+
+@pytest.mark.asyncio
+async def test_group_join_delivers_aggregate_even_with_partial_failure(tmp_path):
+    """A failed sub-task still completes the group; the caller sees both
+    outcomes in the aggregate instead of the group hanging or erroring."""
+    redis = MockRedis()
+    workspace_manager = AsyncMock()
+    workspace_manager.setup_workspace.return_value = {
+        "private": str(tmp_path),
+        "public": str(tmp_path),
+    }
+
+    worker = RecordingProcessCommandWorker(
+        worker_id="test-join-partial",
+        redis_client=redis,
+        registry=AsyncMock(),
+        workspace_manager=workspace_manager,
+    )
+
+    caller_context = AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=redis,
+        current_agent_id="caller_agent",
+        message_id="parent-msg",
+    )
+    dispatch_result = await caller_context.dispatch_group(
+        tasks=[
+            {"target_agent_type": "agent-b", "content": "task one"},
+            {"target_agent_type": "agent-c", "content": "task two"},
+        ],
+    )
+    task_group_id = dispatch_result["task_group_id"]
+    msg_b, msg_c = (t["message_id"] for t in dispatch_result["dispatched_tasks"])
+
+    await worker._handle_message(
+        ResumeCommand(
+            header=MessageHeader(
+                message_id=msg_b,
+                session_id="s1",
+                trace_id="t1",
+                source_agent_type="agent-b",
+                target_agent_type="caller_agent",
+                parent_message_id="parent-msg",
+                task_group_id=task_group_id,
+            ),
+            status="FAILED",
+            reply_data={"error": "boom"},
+        )
+    )
+    await worker._handle_message(
+        ResumeCommand(
+            header=MessageHeader(
+                message_id=msg_c,
+                session_id="s1",
+                trace_id="t1",
+                source_agent_type="agent-c",
+                target_agent_type="caller_agent",
+                parent_message_id="parent-msg",
+                task_group_id=task_group_id,
+            ),
+            status="COMPLETED",
+            reply_data={"value": "c"},
+        )
+    )
+
+    assert len(worker.received_commands) == 1
+    aggregate = worker.received_commands[0].reply_data
+    by_message_id = {item["message_id"]: item for item in aggregate}
+    assert by_message_id[msg_b]["status"] == "FAILED"
+    assert by_message_id[msg_c]["status"] == "COMPLETED"
+
+
+@pytest.mark.asyncio
+async def test_collect_group_results_still_works_outside_process_command(tmp_path):
+    """collect_group_results remains a valid manual-polling path, unchanged
+    by the automatic aggregation delivered through resume."""
+    redis = MockRedis()
+    caller_context = AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=redis,
+        current_agent_id="caller_agent",
+        message_id="parent-msg",
+    )
+    dispatch_result = await caller_context.dispatch_group(
+        tasks=[{"target_agent_type": "agent-b", "content": "task one"}],
+    )
+    task_group_id = dispatch_result["task_group_id"]
+    msg_b = dispatch_result["dispatched_tasks"][0]["message_id"]
+
+    workspace_manager = AsyncMock()
+    workspace_manager.setup_workspace.return_value = {
+        "private": str(tmp_path),
+        "public": str(tmp_path),
+    }
+    worker = RecordingProcessCommandWorker(
+        worker_id="test-manual-poll",
+        redis_client=redis,
+        registry=AsyncMock(),
+        workspace_manager=workspace_manager,
+    )
+    await worker._handle_message(
+        ResumeCommand(
+            header=MessageHeader(
+                message_id=msg_b,
+                session_id="s1",
+                trace_id="t1",
+                source_agent_type="agent-b",
+                target_agent_type="caller_agent",
+                parent_message_id="parent-msg",
+                task_group_id=task_group_id,
+            ),
+            status="COMPLETED",
+            reply_data={"value": "b"},
+        )
+    )
+
+    results = await caller_context.collect_group_results(task_group_id, timeout=1.0)
+    assert len(results) == 1
+    assert results[0]["message_id"] == msg_b
+    assert results[0]["reply_data"] == {"value": "b"}
+
+
+@pytest.mark.asyncio
+async def test_collect_group_results_times_out_with_partial_results(tmp_path):
+    """A sub-task that never replies still lets manual polling time out
+    and return whatever partial results were collected."""
+    redis = MockRedis()
+    caller_context = AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=redis,
+        current_agent_id="caller_agent",
+        message_id="parent-msg",
+    )
+    dispatch_result = await caller_context.dispatch_group(
+        tasks=[
+            {"target_agent_type": "agent-b", "content": "task one"},
+            {"target_agent_type": "agent-c", "content": "task two"},
+        ],
+    )
+    task_group_id = dispatch_result["task_group_id"]
+    msg_b = dispatch_result["dispatched_tasks"][0]["message_id"]
+
+    workspace_manager = AsyncMock()
+    workspace_manager.setup_workspace.return_value = {
+        "private": str(tmp_path),
+        "public": str(tmp_path),
+    }
+    worker = RecordingProcessCommandWorker(
+        worker_id="test-timeout",
+        redis_client=redis,
+        registry=AsyncMock(),
+        workspace_manager=workspace_manager,
+    )
+    # Only agent-b ever replies; agent-c never does.
+    await worker._handle_message(
+        ResumeCommand(
+            header=MessageHeader(
+                message_id=msg_b,
+                session_id="s1",
+                trace_id="t1",
+                source_agent_type="agent-b",
+                target_agent_type="caller_agent",
+                parent_message_id="parent-msg",
+                task_group_id=task_group_id,
+            ),
+            status="COMPLETED",
+            reply_data={"value": "b"},
+        )
+    )
+
+    results = await caller_context.collect_group_results(task_group_id, timeout=0.3)
+    assert len(results) == 1
+    assert results[0]["message_id"] == msg_b
+
+
+@pytest.mark.asyncio
+async def test_group_join_discards_reply_for_aborted_task_group(tmp_path):
+    """A reply for a Task Group that was aborted mid-dispatch is dropped,
+    never counted, and never used to resume the (already-failed) caller."""
+    redis = MockRedis()
+    workspace_manager = AsyncMock()
+    workspace_manager.setup_workspace.return_value = {
+        "private": str(tmp_path),
+        "public": str(tmp_path),
+    }
+    worker = RecordingProcessCommandWorker(
+        worker_id="test-abort",
+        redis_client=redis,
+        registry=AsyncMock(),
+        workspace_manager=workspace_manager,
+    )
+
+    caller_context = AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=redis,
+        current_agent_id="caller_agent",
+        message_id="parent-msg",
+    )
+    dispatch_result = await caller_context.dispatch_group(
+        tasks=[{"target_agent_type": "agent-b", "content": "one"}],
+    )
+    task_group_id = dispatch_result["task_group_id"]
+    msg_b = dispatch_result["dispatched_tasks"][0]["message_id"]
+
+    # Simulate a mid-dispatch failure (e.g. a later sibling's xadd raised)
+    # that marked this group aborted after agent-b had already been sent.
+    await redis.hset(RedisKeys.task_group(task_group_id), TASK_GROUP_FIELD_ABORTED, "1")
+
+    await worker._handle_message(
+        ResumeCommand(
+            header=MessageHeader(
+                message_id=msg_b,
+                session_id="s1",
+                trace_id="t1",
+                source_agent_type="agent-b",
+                target_agent_type="caller_agent",
+                parent_message_id="parent-msg",
+                task_group_id=task_group_id,
+            ),
+            status="COMPLETED",
+            reply_data={"value": "b"},
+        )
+    )
+
+    assert worker.received_commands == []
+    group_hash = redis.data[RedisKeys.task_group(task_group_id)]
+    assert group_hash.get(TASK_GROUP_FIELD_COMPLETED, "0") == "0"

--- a/tests/integration/test_scatter_gather.py
+++ b/tests/integration/test_scatter_gather.py
@@ -7,12 +7,21 @@ import pytest
 from by_framework.common.constants import (
     TASK_GROUP_FIELD_ABORTED,
     TASK_GROUP_FIELD_COMPLETED,
+    TASK_GROUP_FIELD_JOIN_CLAIM_EXPIRES_AT,
+    TASK_GROUP_FIELD_JOINED,
     TASK_GROUP_FIELD_TOTAL,
+    TASK_GROUP_JOIN_CLAIM_TTL_MS,
     RedisKeys,
 )
 from by_framework.core.protocol.commands import (ResumeCommand, command_from_dict)
 from by_framework.core.protocol.message_header import MessageHeader
 from by_framework.worker.context import AgentContext
+from by_framework.worker.task_group import (
+    TASK_GROUP_JOIN_PENDING_STATUS,
+    TASK_GROUP_JOINED_STATUS,
+    TaskGroupJoinState,
+    TaskGroupStore,
+)
 from by_framework.worker.worker import GatewayWorker
 
 
@@ -57,9 +66,62 @@ class MockRedis:
     async def expire(self, name, ttl):
         return 1
 
-    async def xadd(self, name, fields):
+    async def xadd(self, name, fields, **_kwargs):
         self.streams.setdefault(name, []).append(fields)
         return "0-1"
+
+    async def eval(self, script, numkeys, *keys_and_args):
+        if numkeys == 1:
+            group_key, claim_field, claim_token, joined_field, expires_field = (
+                keys_and_args
+            )
+            group = self.data.setdefault(group_key, {})
+            if group.get(claim_field) != claim_token:
+                return 0
+            group[joined_field] = "1"
+            group.pop(claim_field, None)
+            group.pop(expires_field, None)
+            return 1
+
+        group_key, results_key, *args = keys_and_args
+        (
+            total_field,
+            completed_field,
+            aborted_field,
+            result_field,
+            result_json,
+            ttl,
+            joined_field,
+            claim_field,
+            expires_field,
+            now_ms,
+            claim_token,
+            claim_ttl_ms,
+        ) = args
+        assert "HSETNX" in script
+        assert int(ttl) > 0
+        group = self.data.setdefault(group_key, {})
+        total = int(group.get(total_field, 0))
+        completed = int(group.get(completed_field, 0))
+        if not total:
+            return [0, completed, total]
+        if group.get(aborted_field):
+            return [1, completed, total]
+
+        results = self.data.setdefault(results_key, {})
+        if result_field not in results:
+            results[result_field] = result_json
+            completed += 1
+            group[completed_field] = completed
+        if completed < total:
+            return [2, completed, total]
+        if group.get(joined_field) == "1":
+            return [5, completed, total]
+        if group.get(claim_field) and int(group.get(expires_field, 0)) > int(now_ms):
+            return [4, completed, total]
+        group[claim_field] = claim_token
+        group[expires_field] = int(now_ms) + int(claim_ttl_ms)
+        return [3, completed, total]
 
     async def smembers(self, name):
         # Every agent type is treated as having one online worker unless the
@@ -324,6 +386,8 @@ async def test_group_join_delivers_aggregate_even_with_partial_failure(tmp_path)
     aggregate = worker.received_commands[0].reply_data
     by_message_id = {item["message_id"]: item for item in aggregate}
     assert by_message_id[msg_b]["status"] == "FAILED"
+    assert by_message_id[msg_b]["error"] == "boom"
+    assert by_message_id[msg_b]["error_code"] is None
     assert by_message_id[msg_c]["status"] == "COMPLETED"
 
 
@@ -568,6 +632,8 @@ async def test_group_with_every_target_offline_still_resumes_caller(tmp_path):
     assert aggregate[0]["status"] == "FAILED"
     assert aggregate[0]["target_agent_type"] == "agent-b"
     assert aggregate[0]["reply_data"]["error_code"] == "AGENT_TYPE_UNAVAILABLE"
+    assert aggregate[0]["error_code"] == "AGENT_TYPE_UNAVAILABLE"
+    assert aggregate[0]["error"] == aggregate[0]["reply_data"]["error"]
 
 
 @pytest.mark.asyncio
@@ -663,6 +729,199 @@ async def test_group_aggregate_follows_dispatch_order_not_completion_order(tmp_p
 
 
 @pytest.mark.asyncio
+async def test_group_join_counts_each_subtask_once_under_redelivery(tmp_path):
+    redis = MockRedis()
+    worker = _make_join_worker(redis, tmp_path, "test-redelivery")
+    caller_context = _make_caller_context(redis)
+
+    dispatch_result = await caller_context.call_agents(
+        tasks=[
+            {"target_agent_type": "agent-b", "content": "one"},
+            {"target_agent_type": "agent-c", "content": "two"},
+        ]
+    )
+    task_group_id = dispatch_result["task_group_id"]
+    msg_b, msg_c = (task["message_id"] for task in dispatch_result["dispatched_tasks"])
+    reply_b = _reply(
+        task_group_id=task_group_id,
+        task_message_id=msg_b,
+        source_agent_type="agent-b",
+        status="COMPLETED",
+        reply_data={"value": "b"},
+    )
+
+    await worker._handle_message(reply_b)
+    await worker._handle_message(reply_b)
+
+    assert worker.received_commands == []
+    assert (
+        redis.data[RedisKeys.task_group(task_group_id)][TASK_GROUP_FIELD_COMPLETED] == 1
+    )
+
+    reply_c = _reply(
+        task_group_id=task_group_id,
+        task_message_id=msg_c,
+        source_agent_type="agent-c",
+        status="COMPLETED",
+        reply_data={"value": "c"},
+    )
+    await worker._handle_message(reply_c)
+    await worker._handle_message(reply_c)
+
+    assert len(worker.received_commands) == 1
+    assert [item["message_id"] for item in worker.received_commands[0].reply_data] == [
+        msg_b,
+        msg_c,
+    ]
+    assert (
+        redis.data[RedisKeys.task_group(task_group_id)][TASK_GROUP_FIELD_COMPLETED] == 2
+    )
+
+
+@pytest.mark.asyncio
+async def test_group_join_claim_can_be_recovered_after_owner_crash():
+    redis = MockRedis()
+    store = TaskGroupStore(redis)
+    task_group_id = "tg-claim-recovery"
+    await store.create(
+        task_group_id,
+        message_ids=["msg-b", "msg-c"],
+        source_agent_type="caller-agent",
+    )
+
+    waiting = await store.record_reply(
+        task_group_id,
+        task_message_id="msg-b",
+        result={"status": "COMPLETED"},
+        now_ms=100,
+        claim_token="worker-one",
+    )
+    ready = await store.record_reply(
+        task_group_id,
+        task_message_id="msg-c",
+        result={"status": "COMPLETED"},
+        now_ms=100,
+        claim_token="worker-one",
+    )
+    still_claimed = await store.record_reply(
+        task_group_id,
+        task_message_id="msg-c",
+        result={"status": "COMPLETED"},
+        now_ms=100 + TASK_GROUP_JOIN_CLAIM_TTL_MS - 1,
+        claim_token="worker-two",
+    )
+    recovered = await store.record_reply(
+        task_group_id,
+        task_message_id="msg-c",
+        result={"status": "COMPLETED"},
+        now_ms=100 + TASK_GROUP_JOIN_CLAIM_TTL_MS + 1,
+        claim_token="worker-two",
+    )
+
+    assert waiting.state == TaskGroupJoinState.WAITING
+    assert ready.state == TaskGroupJoinState.READY
+    assert still_claimed.state == TaskGroupJoinState.CLAIMED
+    assert recovered.state == TaskGroupJoinState.READY
+    assert await store.mark_joined(task_group_id, recovered.claim_token) is True
+
+    joined = await store.record_reply(
+        task_group_id,
+        task_message_id="msg-c",
+        result={"status": "COMPLETED"},
+        now_ms=100 + TASK_GROUP_JOIN_CLAIM_TTL_MS + 2,
+        claim_token="worker-three",
+    )
+    assert joined.state == TaskGroupJoinState.JOINED
+
+
+@pytest.mark.asyncio
+async def test_group_join_does_not_ack_while_another_owner_holds_claim(tmp_path):
+    redis = MockRedis()
+    worker = _make_join_worker(redis, tmp_path, "test-claimed-redelivery")
+    caller_context = _make_caller_context(redis)
+    dispatch_result = await caller_context.call_agents(
+        tasks=[
+            {"target_agent_type": "agent-b", "content": "one"},
+            {"target_agent_type": "agent-c", "content": "two"},
+        ]
+    )
+    task_group_id = dispatch_result["task_group_id"]
+    msg_b, msg_c = (task["message_id"] for task in dispatch_result["dispatched_tasks"])
+    store = TaskGroupStore(redis)
+    await store.record_reply(
+        task_group_id,
+        task_message_id=msg_b,
+        result={"status": "COMPLETED"},
+        claim_token="crashed-worker",
+    )
+    claimed = await store.record_reply(
+        task_group_id,
+        task_message_id=msg_c,
+        result={"status": "COMPLETED"},
+        claim_token="crashed-worker",
+    )
+    assert claimed.state == TaskGroupJoinState.READY
+
+    reply_c = _reply(
+        task_group_id=task_group_id,
+        task_message_id=msg_c,
+        source_agent_type="agent-c",
+        status="COMPLETED",
+    )
+    pending = await worker._handle_message(reply_c)
+    assert pending.status == TASK_GROUP_JOIN_PENDING_STATUS
+    assert worker.received_commands == []
+
+    # Simulate lease expiry after the original owner died. The same pending
+    # Redis Stream entry can now be reclaimed and completes the caller once.
+    redis.data[RedisKeys.task_group(task_group_id)][
+        TASK_GROUP_FIELD_JOIN_CLAIM_EXPIRES_AT
+    ] = 0
+    await worker._handle_message(reply_c)
+    assert len(worker.received_commands) == 1
+
+
+@pytest.mark.asyncio
+async def test_group_join_commits_terminal_caller_failure(tmp_path):
+    redis = MockRedis()
+    worker = _make_join_worker(redis, tmp_path, "test-terminal-failure")
+    worker.process_command = AsyncMock(side_effect=ValueError("caller failed"))
+    caller_context = _make_caller_context(redis)
+    dispatch_result = await caller_context.call_agents(
+        tasks=[
+            {"target_agent_type": "agent-b", "content": "one"},
+            {"target_agent_type": "agent-c", "content": "two"},
+        ]
+    )
+    task_group_id = dispatch_result["task_group_id"]
+    msg_b, msg_c = (task["message_id"] for task in dispatch_result["dispatched_tasks"])
+    await worker._handle_message(
+        _reply(
+            task_group_id=task_group_id,
+            task_message_id=msg_b,
+            source_agent_type="agent-b",
+            status="COMPLETED",
+        )
+    )
+    reply_c = _reply(
+        task_group_id=task_group_id,
+        task_message_id=msg_c,
+        source_agent_type="agent-c",
+        status="COMPLETED",
+    )
+
+    failed = await worker._handle_message(reply_c)
+    assert failed.status == "FAILED"
+    assert (
+        redis.data[RedisKeys.task_group(task_group_id)][TASK_GROUP_FIELD_JOINED] == "1"
+    )
+
+    duplicate = await worker._handle_message(reply_c)
+    assert duplicate.status == TASK_GROUP_JOINED_STATUS
+    assert worker.process_command.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_group_without_protocol_stamp_keeps_legacy_join(tmp_path):
     """A group created by a pre-v2 dispatcher — an old worker still running
     during a rolling upgrade — must be joined the old way: results keyed by
@@ -733,11 +992,9 @@ async def test_group_join_logs_loudly_when_a_result_never_arrived(tmp_path):
     await redis.hincrby(RedisKeys.task_group(task_group_id), TASK_GROUP_FIELD_COMPLETED)
     # by-framework's logger sets propagate=False, so caplog's root handler
     # never sees these records; assert on the module logger directly.
-    with patch("by_framework.worker.worker.logger.error") as mock_error:
-        aggregate = await worker._aggregate_task_group(
-            group_key=RedisKeys.task_group(task_group_id),
-            results_key=RedisKeys.task_group_results(task_group_id),
-            task_group_id=task_group_id,
+    with patch("by_framework.worker.task_group.logger.error") as mock_error:
+        aggregate = await TaskGroupStore(redis, worker_id=worker.worker_id).aggregate(
+            task_group_id,
             total=2,
         )
 
@@ -775,14 +1032,12 @@ async def test_flush_is_skipped_when_process_command_raises(tmp_path):
 
     # agent-b's synthetic failure reply was built but never handed to the
     # context, so there is nothing for the worker to flush.
-    assert caller_context._pending_group_replies == []
+    assert caller_context.drain_pending_group_replies() == []
 
     # The group itself is marked aborted, so even the sibling that WAS sent
     # cannot resume the caller when its reply lands.
     group_hashes = [
-        bucket
-        for key, bucket in redis.data.items()
-        if TASK_GROUP_FIELD_TOTAL in bucket
+        bucket for key, bucket in redis.data.items() if TASK_GROUP_FIELD_TOTAL in bucket
     ]
     assert len(group_hashes) == 1
     assert group_hashes[0][TASK_GROUP_FIELD_ABORTED] == "1"

--- a/tests/integration/test_scatter_gather.py
+++ b/tests/integration/test_scatter_gather.py
@@ -1,14 +1,16 @@
+import json
 from typing import List
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from by_framework.common.constants import (
     TASK_GROUP_FIELD_ABORTED,
     TASK_GROUP_FIELD_COMPLETED,
+    TASK_GROUP_FIELD_TOTAL,
     RedisKeys,
 )
-from by_framework.core.protocol.commands import ResumeCommand
+from by_framework.core.protocol.commands import (ResumeCommand, command_from_dict)
 from by_framework.core.protocol.message_header import MessageHeader
 from by_framework.worker.context import AgentContext
 from by_framework.worker.worker import GatewayWorker
@@ -26,8 +28,12 @@ class DummyWorker(GatewayWorker):
 class MockRedis:
     """Minimal in-memory Redis hash store for scatter-gather join tests."""
 
-    def __init__(self):
+    def __init__(self, offline_agent_types=None):
         self.data = {}
+        # Agent types with no online worker, so dispatch-time availability
+        # checks reject them the way they would in a real deployment.
+        self.offline_agent_types = set(offline_agent_types or ())
+        self.streams = {}
 
     async def hset(self, name, key=None, value=None, mapping=None):
         bucket = self.data.setdefault(name, {})
@@ -52,11 +58,16 @@ class MockRedis:
         return 1
 
     async def xadd(self, name, fields):
+        self.streams.setdefault(name, []).append(fields)
         return "0-1"
 
     async def smembers(self, name):
-        # Every agent type is treated as having one online worker, so
-        # dispatch-time availability checks always pass in these tests.
+        # Every agent type is treated as having one online worker unless the
+        # test declared it offline, so dispatch-time availability checks pass
+        # by default and can be made to fail on demand.
+        for agent_type in self.offline_agent_types:
+            if name == RedisKeys.agent_type_members(agent_type):
+                return set()
         return {b"worker-1"}
 
     async def get(self, name):
@@ -474,3 +485,304 @@ async def test_group_join_discards_reply_for_aborted_task_group(tmp_path):
     assert worker.received_commands == []
     group_hash = redis.data[RedisKeys.task_group(task_group_id)]
     assert group_hash.get(TASK_GROUP_FIELD_COMPLETED, "0") == "0"
+
+
+def _make_join_worker(redis, tmp_path, worker_id):
+    workspace_manager = AsyncMock()
+    workspace_manager.setup_workspace.return_value = {
+        "private": str(tmp_path),
+        "public": str(tmp_path),
+    }
+    return RecordingProcessCommandWorker(
+        worker_id=worker_id,
+        redis_client=redis,
+        registry=AsyncMock(),
+        workspace_manager=workspace_manager,
+    )
+
+
+def _make_caller_context(redis):
+    return AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=redis,
+        current_agent_id="caller_agent",
+        message_id="parent-msg",
+    )
+
+
+def _reply(*, task_group_id, task_message_id, source_agent_type, **kwargs):
+    """A sub-agent's reply, shaped the way _enqueue_agent_return shapes it."""
+    return ResumeCommand(
+        header=MessageHeader(
+            message_id="parent-msg",
+            session_id="s1",
+            trace_id="t1",
+            source_agent_type=source_agent_type,
+            target_agent_type="caller_agent",
+            parent_message_id=task_message_id,
+            task_group_id=task_group_id,
+        ),
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_group_with_every_target_offline_still_resumes_caller(tmp_path):
+    """A group whose only target is offline must resume the caller, not hang.
+
+    Regression for the deadlock where the dispatcher itself counted the
+    failure: `completed` reached `total` inside call_agents, where nothing
+    knows how to resume anyone, so no reply was ever left to trigger Group
+    Join and the caller stayed suspended forever.
+    """
+    redis = MockRedis(offline_agent_types={"agent-b"})
+    worker = _make_join_worker(redis, tmp_path, "test-all-offline")
+    caller_context = _make_caller_context(redis)
+
+    dispatch_result = await caller_context.call_agents(
+        tasks=[{"target_agent_type": "agent-b", "content": "one"}],
+    )
+    task_group_id = dispatch_result["task_group_id"]
+    msg_b = dispatch_result["dispatched_tasks"][0]["message_id"]
+
+    # Nothing was dispatched and the group is untouched until the worker
+    # flushes the synthetic reply.
+    assert dispatch_result["dispatched_tasks"][0]["status"] == "FAILED"
+    group_hash = redis.data[RedisKeys.task_group(task_group_id)]
+    assert group_hash.get(TASK_GROUP_FIELD_COMPLETED) == "0"
+
+    await worker._flush_pending_group_replies(caller_context)
+
+    # The flushed reply lands on the caller's own control stream, exactly
+    # where a real sub-agent's return would have gone.
+    caller_stream = redis.streams[RedisKeys.ctrl_stream("caller_agent")]
+    assert len(caller_stream) == 1
+    flushed = command_from_dict(json.loads(caller_stream[0]["data"]))
+    await worker._handle_message(flushed)
+
+    assert len(worker.received_commands) == 1
+    aggregate = worker.received_commands[0].reply_data
+    assert len(aggregate) == 1
+    assert aggregate[0]["message_id"] == msg_b
+    assert aggregate[0]["status"] == "FAILED"
+    assert aggregate[0]["target_agent_type"] == "agent-b"
+    assert aggregate[0]["reply_data"]["error_code"] == "AGENT_TYPE_UNAVAILABLE"
+
+
+@pytest.mark.asyncio
+async def test_group_resumes_once_when_fast_reply_precedes_offline_sibling(tmp_path):
+    """The second deadlock shape: a sibling replies before a later sibling
+    fails its availability check, so the dispatcher's own counting would have
+    been the one to complete the group."""
+    redis = MockRedis(offline_agent_types={"agent-c"})
+    worker = _make_join_worker(redis, tmp_path, "test-fast-then-offline")
+    caller_context = _make_caller_context(redis)
+
+    dispatch_result = await caller_context.call_agents(
+        tasks=[
+            {"target_agent_type": "agent-b", "content": "one"},
+            {"target_agent_type": "agent-c", "content": "two"},
+        ],
+    )
+    task_group_id = dispatch_result["task_group_id"]
+    msg_b, msg_c = (t["message_id"] for t in dispatch_result["dispatched_tasks"])
+
+    # agent-b's reply arrives first: 1/2, caller not resumed yet.
+    await worker._handle_message(
+        _reply(
+            task_group_id=task_group_id,
+            task_message_id=msg_b,
+            source_agent_type="agent-b",
+            status="COMPLETED",
+            content="B result",
+            reply_data={"value": "b"},
+        )
+    )
+    assert worker.received_commands == []
+
+    # Then the offline sibling's synthetic reply completes the group.
+    await worker._flush_pending_group_replies(caller_context)
+    flushed = command_from_dict(
+        json.loads(redis.streams[RedisKeys.ctrl_stream("caller_agent")][0]["data"])
+    )
+    await worker._handle_message(flushed)
+
+    assert len(worker.received_commands) == 1
+    aggregate = worker.received_commands[0].reply_data
+    assert [item["message_id"] for item in aggregate] == [msg_b, msg_c]
+    assert aggregate[0]["status"] == "COMPLETED"
+    assert aggregate[1]["status"] == "FAILED"
+
+
+@pytest.mark.asyncio
+async def test_group_aggregate_follows_dispatch_order_not_completion_order(tmp_path):
+    """Aggregation order is the tasks' dispatch order, so callers can index
+    results positionally instead of matching by hand."""
+    redis = MockRedis()
+    worker = _make_join_worker(redis, tmp_path, "test-order")
+    caller_context = _make_caller_context(redis)
+
+    dispatch_result = await caller_context.call_agents(
+        tasks=[
+            {"target_agent_type": "agent-b", "content": "one"},
+            {"target_agent_type": "agent-c", "content": "two"},
+            {"target_agent_type": "agent-d", "content": "three"},
+        ],
+    )
+    task_group_id = dispatch_result["task_group_id"]
+    msg_b, msg_c, msg_d = (t["message_id"] for t in dispatch_result["dispatched_tasks"])
+
+    # Complete in reverse order.
+    for msg_id, agent_type in (
+        (msg_d, "agent-d"),
+        (msg_c, "agent-c"),
+        (msg_b, "agent-b"),
+    ):
+        await worker._handle_message(
+            _reply(
+                task_group_id=task_group_id,
+                task_message_id=msg_id,
+                source_agent_type=agent_type,
+                status="COMPLETED",
+                content=f"{agent_type} result",
+            )
+        )
+
+    assert len(worker.received_commands) == 1
+    resumed = worker.received_commands[0]
+    assert [item["message_id"] for item in resumed.reply_data] == [msg_b, msg_c, msg_d]
+    assert [item["target_agent_type"] for item in resumed.reply_data] == [
+        "agent-b",
+        "agent-c",
+        "agent-d",
+    ]
+    # reply_data is the single aggregation channel; content must not also
+    # carry whichever sibling replied last.
+    assert resumed.content == ""
+
+
+@pytest.mark.asyncio
+async def test_group_without_protocol_stamp_keeps_legacy_join(tmp_path):
+    """A group created by a pre-v2 dispatcher — an old worker still running
+    during a rolling upgrade — must be joined the old way: results keyed by
+    the caller's own message_id, no aggregation, content left alone."""
+    redis = MockRedis()
+    worker = _make_join_worker(redis, tmp_path, "test-legacy")
+
+    task_group_id = "tg-legacy01"
+    group_key = RedisKeys.task_group(task_group_id)
+    # Exactly what a pre-v2 dispatcher wrote: no protocol_version, no
+    # task_order.
+    await redis.hset(
+        group_key,
+        mapping={
+            TASK_GROUP_FIELD_TOTAL: "1",
+            TASK_GROUP_FIELD_COMPLETED: "0",
+        },
+    )
+
+    await worker._handle_message(
+        _reply(
+            task_group_id=task_group_id,
+            task_message_id="msg-b",
+            source_agent_type="agent-b",
+            status="COMPLETED",
+            content="B result",
+            reply_data={"value": "b"},
+        )
+    )
+
+    assert len(worker.received_commands) == 1
+    resumed = worker.received_commands[0]
+    # Legacy behavior: the caller sees the single reply as-is.
+    assert resumed.reply_data == {"value": "b"}
+    assert resumed.content == "B result"
+    # And the result was stored under the legacy (caller message_id) key.
+    results = redis.data[RedisKeys.task_group_results(task_group_id)]
+    assert set(results) == {"parent-msg"}
+
+
+@pytest.mark.asyncio
+async def test_group_join_logs_loudly_when_a_result_never_arrived(tmp_path):
+    """A short result set resumes the caller but must never do so silently."""
+    redis = MockRedis()
+    worker = _make_join_worker(redis, tmp_path, "test-incomplete")
+    caller_context = _make_caller_context(redis)
+
+    dispatch_result = await caller_context.call_agents(
+        tasks=[
+            {"target_agent_type": "agent-b", "content": "one"},
+            {"target_agent_type": "agent-c", "content": "two"},
+        ],
+    )
+    task_group_id = dispatch_result["task_group_id"]
+    msg_b, msg_c = (t["message_id"] for t in dispatch_result["dispatched_tasks"])
+
+    # agent-c's result is lost (expired hash field, failed write, ...) but the
+    # completion counter still reaches total.
+    await worker._handle_message(
+        _reply(
+            task_group_id=task_group_id,
+            task_message_id=msg_b,
+            source_agent_type="agent-b",
+            status="COMPLETED",
+            content="B result",
+        )
+    )
+    await redis.hincrby(RedisKeys.task_group(task_group_id), TASK_GROUP_FIELD_COMPLETED)
+    # by-framework's logger sets propagate=False, so caplog's root handler
+    # never sees these records; assert on the module logger directly.
+    with patch("by_framework.worker.worker.logger.error") as mock_error:
+        aggregate = await worker._aggregate_task_group(
+            group_key=RedisKeys.task_group(task_group_id),
+            results_key=RedisKeys.task_group_results(task_group_id),
+            task_group_id=task_group_id,
+            total=2,
+        )
+
+    assert [item["message_id"] for item in aggregate] == [msg_b]
+    assert mock_error.call_count == 1
+    logged = mock_error.call_args.args
+    assert "expected %d" in logged[0]
+    assert msg_c in logged[-1]
+
+
+@pytest.mark.asyncio
+async def test_flush_is_skipped_when_process_command_raises(tmp_path):
+    """A dispatch-time infrastructure failure aborts the group; the synthetic
+    replies queued before it must never be delivered, or a late reply would
+    resume a caller execution that already failed."""
+    redis = MockRedis(offline_agent_types={"agent-b"})
+    caller_context = _make_caller_context(redis)
+
+    original_xadd = redis.xadd
+
+    async def failing_xadd(name, fields):
+        if name == RedisKeys.ctrl_stream("agent-c"):
+            raise RuntimeError("stream unavailable")
+        return await original_xadd(name, fields)
+
+    redis.xadd = failing_xadd
+
+    with pytest.raises(RuntimeError):
+        await caller_context.call_agents(
+            tasks=[
+                {"target_agent_type": "agent-b", "content": "one"},
+                {"target_agent_type": "agent-c", "content": "two"},
+            ],
+        )
+
+    # agent-b's synthetic failure reply was built but never handed to the
+    # context, so there is nothing for the worker to flush.
+    assert caller_context._pending_group_replies == []
+
+    # The group itself is marked aborted, so even the sibling that WAS sent
+    # cannot resume the caller when its reply lands.
+    group_hashes = [
+        bucket
+        for key, bucket in redis.data.items()
+        if TASK_GROUP_FIELD_TOTAL in bucket
+    ]
+    assert len(group_hashes) == 1
+    assert group_hashes[0][TASK_GROUP_FIELD_ABORTED] == "1"

--- a/tests/worker/test_context.py
+++ b/tests/worker/test_context.py
@@ -8,8 +8,10 @@ import pytest
 
 import by_framework.worker.context as context_module
 from by_framework import AgentContext
+from by_framework.common.constants import TASK_GROUP_FIELD_ABORTED, RedisKeys
 from by_framework.core.extensions.plugin import Plugin, PluginManifest
 from by_framework.core.extensions.registry import PluginRegistry
+from by_framework.core.protocol.agent_state import AgentState
 from by_framework.core.protocol.byai_codec import ByaiContentCodec
 from by_framework.core.protocol.commands import (AskAgentCommand, command_from_dict)
 from by_framework.core.protocol.message import (BaiYingMessage, BaiYingMessageRole)
@@ -327,6 +329,8 @@ async def test_context_dispatch_group_propagates_langfuse_observation_id():
     mock_pipe = MagicMock()
     mock_pipe.execute = AsyncMock(return_value=[])
     mock_redis.pipeline.return_value = mock_pipe
+    mock_redis.smembers = AsyncMock(return_value={b"worker-1"})
+    mock_redis.get = AsyncMock(return_value=b"1")
 
     ctx = AgentContext(session_id="s1", trace_id="t1", redis_client=mock_redis)
 
@@ -365,6 +369,8 @@ async def test_context_dispatch_group_prefers_metadata_langfuse_parent():
     mock_pipe = MagicMock()
     mock_pipe.execute = AsyncMock(return_value=[])
     mock_redis.pipeline.return_value = mock_pipe
+    mock_redis.smembers = AsyncMock(return_value={b"worker-1"})
+    mock_redis.get = AsyncMock(return_value=b"1")
 
     ctx = AgentContext(session_id="s1", trace_id="t1", redis_client=mock_redis)
 
@@ -405,6 +411,8 @@ async def test_context_dispatch_group_triggers_plugin_lifecycle_hooks():
     mock_pipe = MagicMock()
     mock_pipe.execute = AsyncMock(return_value=[])
     mock_redis.pipeline.return_value = mock_pipe
+    mock_redis.smembers = AsyncMock(return_value={b"worker-1"})
+    mock_redis.get = AsyncMock(return_value=b"1")
 
     plugin = RecordingCallAgentPlugin()
     registry = PluginRegistry()
@@ -426,7 +434,7 @@ async def test_context_dispatch_group_triggers_plugin_lifecycle_hooks():
         ],
     )
 
-    assert result["status"] == "GROUP_QUEUED"
+    assert result["status"] == AgentState.QUEUED.value
     assert [event[0] for event in plugin.events] == [
         "start",
         "complete",
@@ -437,6 +445,129 @@ async def test_context_dispatch_group_triggers_plugin_lifecycle_hooks():
         "agent-b",
         "agent-c",
     }
+
+
+@pytest.mark.asyncio
+async def test_context_call_agents_dispatches_like_dispatch_group():
+    """call_agents is call_agent's plural: same dispatch, same status vocabulary."""
+    from unittest.mock import MagicMock
+
+    mock_redis = MagicMock()
+    mock_redis.xadd = AsyncMock()
+    mock_redis.hset = AsyncMock()
+    mock_redis.expire = AsyncMock()
+    mock_redis.smembers = AsyncMock(return_value={b"worker-1"})
+    mock_redis.get = AsyncMock(return_value=b"1")
+
+    ctx = AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=mock_redis,
+        current_agent_id="agent-a",
+        message_id="parent-msg",
+    )
+
+    result = await ctx.call_agents(
+        tasks=[
+            {"target_agent_type": "agent-b", "content": "one"},
+            {"target_agent_type": "agent-c", "content": "two"},
+        ],
+    )
+
+    assert result["status"] == AgentState.QUEUED.value
+    assert len(result["dispatched_tasks"]) == 2
+    assert mock_redis.xadd.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_context_call_agents_marks_unavailable_task_failed():
+    """An offline target agent type fails fast as one group member, the
+    rest of the batch still dispatches."""
+    from unittest.mock import MagicMock
+
+    mock_redis = MagicMock()
+    mock_redis.xadd = AsyncMock()
+    mock_redis.hset = AsyncMock()
+    mock_redis.expire = AsyncMock()
+    mock_redis.hincrby = AsyncMock(return_value=1)
+
+    async def smembers_side_effect(name):
+        if name == RedisKeys.agent_type_members("agent-b"):
+            return {b"worker-1"}
+        return set()
+
+    mock_redis.smembers = AsyncMock(side_effect=smembers_side_effect)
+    mock_redis.get = AsyncMock(return_value=b"1")
+
+    plugin = RecordingCallAgentPlugin()
+    registry = PluginRegistry()
+    registry.register_bundle(plugin)
+
+    ctx = AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=mock_redis,
+        current_agent_id="agent-a",
+        message_id="parent-msg",
+        plugin_registry=registry,
+    )
+
+    result = await ctx.call_agents(
+        tasks=[
+            {"target_agent_type": "agent-b", "content": "one"},
+            {"target_agent_type": "agent-c", "content": "two"},
+        ],
+    )
+
+    assert result["status"] == AgentState.QUEUED.value
+    assert len(result["dispatched_tasks"]) == 2
+
+    # Only the available target actually got dispatched.
+    assert mock_redis.xadd.await_count == 1
+    xadd_args, _ = mock_redis.xadd.call_args
+    dispatched_command = command_from_dict(json.loads(xadd_args[1]["data"]))
+    assert dispatched_command.header.target_agent_type == "agent-b"
+
+    # The unavailable task was recorded as FAILED and counted toward completion.
+    assert mock_redis.hincrby.await_count == 1
+    results_writes = [c for c in mock_redis.hset.await_args_list if len(c.args) >= 3]
+    assert len(results_writes) == 1
+    failure_payload = json.loads(results_writes[0].args[2])
+    assert failure_payload["status"] == AgentState.FAILED.value
+    assert failure_payload["target_agent_type"] == "agent-c"
+    assert failure_payload["error_code"] == "AGENT_TYPE_UNAVAILABLE"
+
+    # Same plugin hooks call_agent's own availability failure fires: a
+    # "start"/"error" pair for the unavailable agent-c, alongside the
+    # normal "start"/"complete" pair for the dispatched agent-b.
+    assert [event[0] for event in plugin.events] == [
+        "start",
+        "complete",
+        "start",
+        "error",
+    ]
+    assert {e[1] for e in plugin.events if e[0] == "start"} == {"agent-b", "agent-c"}
+    error_event = next(e for e in plugin.events if e[0] == "error")
+    assert failure_payload["error"] in error_event[1]
+
+
+@pytest.mark.asyncio
+async def test_context_dispatch_group_rejects_empty_task_list():
+    """An empty task list is a caller bug, not a valid no-op group."""
+    from unittest.mock import MagicMock
+
+    mock_redis = MagicMock()
+    mock_redis.hset = AsyncMock()
+    mock_redis.expire = AsyncMock()
+    mock_redis.xadd = AsyncMock()
+
+    ctx = AgentContext(session_id="s1", trace_id="t1", redis_client=mock_redis)
+
+    with pytest.raises(ValueError):
+        await ctx.dispatch_group(tasks=[])
+
+    mock_redis.hset.assert_not_called()
+    mock_redis.xadd.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -451,6 +582,8 @@ async def test_context_dispatch_group_triggers_error_hook_on_dispatch_failure():
     mock_pipe = MagicMock()
     mock_pipe.execute = AsyncMock(return_value=[])
     mock_redis.pipeline.return_value = mock_pipe
+    mock_redis.smembers = AsyncMock(return_value={b"worker-1"})
+    mock_redis.get = AsyncMock(return_value=b"1")
 
     plugin = RecordingCallAgentPlugin()
     registry = PluginRegistry()
@@ -473,6 +606,49 @@ async def test_context_dispatch_group_triggers_error_hook_on_dispatch_failure():
     assert [event[0] for event in plugin.events] == ["start", "error"]
     assert plugin.events[0][1] == "agent-b"
     assert "redis down" in plugin.events[1][1]
+
+
+@pytest.mark.asyncio
+async def test_context_call_agents_marks_group_aborted_on_mid_dispatch_failure():
+    """A dispatch-time infra error stops the batch and marks the Task Group
+    aborted, so already-sent siblings' replies won't later resume a caller
+    execution that already ended in failure."""
+    from unittest.mock import MagicMock
+
+    mock_redis = MagicMock()
+    mock_redis.xadd = AsyncMock(side_effect=[None, RuntimeError("redis down")])
+    mock_redis.hset = AsyncMock()
+    mock_redis.expire = AsyncMock()
+    mock_redis.smembers = AsyncMock(return_value={b"worker-1"})
+    mock_redis.get = AsyncMock(return_value=b"1")
+
+    ctx = AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=mock_redis,
+        current_agent_id="agent-a",
+        message_id="parent-msg",
+    )
+
+    with pytest.raises(RuntimeError, match="redis down"):
+        await ctx.call_agents(
+            tasks=[
+                {"target_agent_type": "agent-b", "content": "one"},
+                {"target_agent_type": "agent-c", "content": "two"},
+                {"target_agent_type": "agent-d", "content": "three"},
+            ],
+        )
+
+    # Only the two tasks up to (and including) the failing one were attempted.
+    assert mock_redis.xadd.await_count == 2
+
+    abort_writes = [
+        c
+        for c in mock_redis.hset.await_args_list
+        if len(c.args) >= 2 and c.args[1] == TASK_GROUP_FIELD_ABORTED
+    ]
+    assert len(abort_writes) == 1
+    assert abort_writes[0].args[2] == "1"
 
 
 @pytest.mark.asyncio
@@ -637,6 +813,8 @@ async def test_context_dispatch_group_serializes_baiying_message_with_codec():
     mock_pipe = MagicMock()
     mock_pipe.execute = AsyncMock(return_value=[])
     mock_redis.pipeline.return_value = mock_pipe
+    mock_redis.smembers = AsyncMock(return_value={b"worker-1"})
+    mock_redis.get = AsyncMock(return_value=b"1")
 
     ctx = AgentContext(
         session_id="s1",
@@ -682,6 +860,8 @@ async def test_context_dispatch_group_records_dispatch_spans():
     mock_pipe = MagicMock()
     mock_pipe.execute = AsyncMock(return_value=[])
     mock_redis.pipeline.return_value = mock_pipe
+    mock_redis.smembers = AsyncMock(return_value={b"worker-1"})
+    mock_redis.get = AsyncMock(return_value=b"1")
     span_recorder = AsyncMock()
 
     ctx = AgentContext(

--- a/tests/worker/test_context.py
+++ b/tests/worker/test_context.py
@@ -8,7 +8,11 @@ import pytest
 
 import by_framework.worker.context as context_module
 from by_framework import AgentContext
-from by_framework.common.constants import TASK_GROUP_FIELD_ABORTED, RedisKeys
+from by_framework.common.constants import (
+    TASK_GROUP_FIELD_ABORTED,
+    TASK_GROUP_FIELD_TASK_ORDER,
+    RedisKeys,
+)
 from by_framework.core.extensions.plugin import Plugin, PluginManifest
 from by_framework.core.extensions.registry import PluginRegistry
 from by_framework.core.protocol.agent_state import AgentState
@@ -528,18 +532,45 @@ async def test_context_call_agents_marks_unavailable_task_failed():
     dispatched_command = command_from_dict(json.loads(xadd_args[1]["data"]))
     assert dispatched_command.header.target_agent_type == "agent-b"
 
-    # The unavailable task was recorded as FAILED and counted toward completion.
-    assert mock_redis.hincrby.await_count == 1
-    results_writes = [c for c in mock_redis.hset.await_args_list if len(c.args) >= 3]
-    assert len(results_writes) == 1
-    failure_payload = json.loads(results_writes[0].args[2])
-    assert failure_payload["status"] == AgentState.FAILED.value
-    assert failure_payload["target_agent_type"] == "agent-c"
-    assert failure_payload["error_code"] == "AGENT_TYPE_UNAVAILABLE"
+    # The dispatcher does NOT book-keep the group itself. Storing the result
+    # and counting completion belong to GatewayWorker's Group Join, and a
+    # second implementation here is what could push `completed` to `total`
+    # with no reply left to resume the caller.
+    assert mock_redis.hincrby.await_count == 0
+
+    # Instead the unavailable task is queued as the reply a sub-agent would
+    # have sent had it started and failed; the worker flushes it after
+    # process_command returns.
+    assert len(ctx._pending_group_replies) == 1
+    failure_reply = ctx._pending_group_replies[0]
+    assert failure_reply.status == AgentState.FAILED.value
+    assert failure_reply.content == ""
+    assert failure_reply.reply_data["error_code"] == "AGENT_TYPE_UNAVAILABLE"
+    # Addressed back at the caller: message_id is what WorkerRunner uses to
+    # reattach the suspended execution, parent_message_id is the sub-task's
+    # own id that Group Join keys the result hash by.
+    assert failure_reply.header.message_id == "parent-msg"
+    assert failure_reply.header.target_agent_type == "agent-a"
+    assert failure_reply.header.source_agent_type == "agent-c"
+    assert failure_reply.header.parent_message_id == (
+        result["dispatched_tasks"][1]["message_id"]
+    )
+    assert failure_reply.header.task_group_id == result["task_group_id"]
+
+    # The failed task is visible in the dispatch result too, in the same shape
+    # a real sub-agent failure arrives in.
+    assert result["dispatched_tasks"][1]["status"] == AgentState.FAILED.value
+    assert (
+        result["dispatched_tasks"][1]["reply_data"]["error_code"]
+        == "AGENT_TYPE_UNAVAILABLE"
+    )
+    assert result["dispatched_tasks"][0]["status"] == AgentState.QUEUED.value
 
     # Same plugin hooks call_agent's own availability failure fires: a
     # "start"/"error" pair for the unavailable agent-c, alongside the
-    # normal "start"/"complete" pair for the dispatched agent-b.
+    # normal "start"/"complete" pair for the dispatched agent-b. The
+    # synthetic reply must not additionally fire agent-return hooks — those
+    # belong to a sub-agent that actually ran.
     assert [event[0] for event in plugin.events] == [
         "start",
         "complete",
@@ -548,7 +579,7 @@ async def test_context_call_agents_marks_unavailable_task_failed():
     ]
     assert {e[1] for e in plugin.events if e[0] == "start"} == {"agent-b", "agent-c"}
     error_event = next(e for e in plugin.events if e[0] == "error")
-    assert failure_payload["error"] in error_event[1]
+    assert failure_reply.reply_data["error"] in error_event[1]
 
 
 @pytest.mark.asyncio
@@ -995,3 +1026,167 @@ async def test_context_injects_custom_file_permission_policy(tmp_path):
 
     assert result["success"] is False
     assert "blocked write" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_context_call_agents_rejects_shared_message_id_across_tasks():
+    """One message_id for a whole batch would make siblings overwrite each
+    other in the Task Group result hash, which is keyed per sub-task."""
+    from unittest.mock import MagicMock
+
+    mock_redis = MagicMock()
+    mock_redis.xadd = AsyncMock()
+    mock_redis.hset = AsyncMock()
+    mock_redis.expire = AsyncMock()
+    mock_redis.smembers = AsyncMock(return_value={b"worker-1"})
+    mock_redis.get = AsyncMock(return_value=b"1")
+
+    ctx = AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=mock_redis,
+        current_agent_id="agent-a",
+        message_id="parent-msg",
+    )
+
+    with pytest.raises(ValueError, match="message_id"):
+        await ctx.call_agents(
+            tasks=[
+                {"target_agent_type": "agent-b", "content": "one"},
+                {"target_agent_type": "agent-c", "content": "two"},
+            ],
+            message_id="shared-msg",
+        )
+
+    # Still allowed for a single task, where nothing can collide.
+    result = await ctx.call_agents(
+        tasks=[{"target_agent_type": "agent-b", "content": "one"}],
+        message_id="single-msg",
+    )
+    assert result["dispatched_tasks"][0]["message_id"] == "single-msg"
+
+
+@pytest.mark.asyncio
+async def test_context_call_agents_honours_per_task_message_id():
+    from unittest.mock import MagicMock
+
+    mock_redis = MagicMock()
+    mock_redis.xadd = AsyncMock()
+    mock_redis.hset = AsyncMock()
+    mock_redis.expire = AsyncMock()
+    mock_redis.smembers = AsyncMock(return_value={b"worker-1"})
+    mock_redis.get = AsyncMock(return_value=b"1")
+
+    ctx = AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=mock_redis,
+        current_agent_id="agent-a",
+        message_id="parent-msg",
+    )
+
+    result = await ctx.call_agents(
+        tasks=[
+            {"target_agent_type": "agent-b", "content": "one", "message_id": "mid-b"},
+            {"target_agent_type": "agent-c", "content": "two", "message_id": "mid-c"},
+        ],
+    )
+
+    assert [t["message_id"] for t in result["dispatched_tasks"]] == ["mid-b", "mid-c"]
+    order_writes = [
+        c
+        for c in mock_redis.hset.await_args_list
+        if len(c.args) >= 3 and c.args[1] == TASK_GROUP_FIELD_TASK_ORDER
+    ]
+    assert len(order_writes) == 1
+    assert json.loads(order_writes[0].args[2]) == ["mid-b", "mid-c"]
+
+
+@pytest.mark.asyncio
+async def test_context_call_agents_per_task_route_policy_reaches_offline_target():
+    """SEND_ANYWAY per task restores the pre-unification ability to queue a
+    task for an agent type whose workers have not started yet — consumer
+    groups are created with id="0", so the message is delivered on start."""
+    from unittest.mock import MagicMock
+
+    mock_redis = MagicMock()
+    mock_redis.xadd = AsyncMock()
+    mock_redis.hset = AsyncMock()
+    mock_redis.expire = AsyncMock()
+    # No agent type has an online worker.
+    mock_redis.smembers = AsyncMock(return_value=set())
+    mock_redis.get = AsyncMock(return_value=b"1")
+
+    ctx = AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=mock_redis,
+        current_agent_id="agent-a",
+        message_id="parent-msg",
+    )
+
+    result = await ctx.call_agents(
+        tasks=[
+            {"target_agent_type": "agent-b", "content": "one"},
+            {
+                "target_agent_type": "agent-c",
+                "content": "two",
+                "route_policy": "SEND_ANYWAY",
+            },
+        ],
+    )
+
+    # Default FAIL_FAST rejects agent-b; SEND_ANYWAY dispatches agent-c anyway.
+    assert result["dispatched_tasks"][0]["status"] == AgentState.FAILED.value
+    assert result["dispatched_tasks"][1]["status"] == AgentState.QUEUED.value
+    assert mock_redis.xadd.await_count == 1
+    xadd_args, _ = mock_redis.xadd.call_args
+    assert (
+        command_from_dict(json.loads(xadd_args[1]["data"])).header.target_agent_type
+        == "agent-c"
+    )
+
+
+@pytest.mark.asyncio
+async def test_byai_context_call_agents_accepts_typed_tasks():
+    """call_agents is the primary batch entry point, so the typed facade must
+    override it — not only dispatch_group, or a ByaiAgentTask would be
+    subscripted as a dict by the base implementation."""
+    from unittest.mock import MagicMock
+
+    from by_framework.worker.byai_context import (ByaiAgentContext, ByaiAgentTask)
+
+    mock_redis = MagicMock()
+    mock_redis.xadd = AsyncMock()
+    mock_redis.hset = AsyncMock()
+    mock_redis.expire = AsyncMock()
+    mock_redis.smembers = AsyncMock(return_value={b"worker-1"})
+    mock_redis.get = AsyncMock(return_value=b"1")
+
+    ctx = ByaiAgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=mock_redis,
+        current_agent_id="agent-a",
+        message_id="parent-msg",
+    )
+
+    result = await ctx.call_agents(
+        tasks=[
+            ByaiAgentTask(target_agent_type="agent-b", content="one"),
+            ByaiAgentTask(
+                target_agent_type="agent-c", content="two", message_id="mid-c"
+            ),
+        ],
+    )
+
+    assert result["status"] == AgentState.QUEUED.value
+    assert len(result["dispatched_tasks"]) == 2
+    assert result["dispatched_tasks"][1]["message_id"] == "mid-c"
+    assert mock_redis.xadd.await_count == 2
+
+    # dispatch_group stays source-compatible and routes through call_agents.
+    alias_result = await ctx.dispatch_group(
+        tasks=[ByaiAgentTask(target_agent_type="agent-b", content="one")],
+    )
+    assert alias_result["status"] == AgentState.QUEUED.value

--- a/tests/worker/test_context.py
+++ b/tests/worker/test_context.py
@@ -541,8 +541,9 @@ async def test_context_call_agents_marks_unavailable_task_failed():
     # Instead the unavailable task is queued as the reply a sub-agent would
     # have sent had it started and failed; the worker flushes it after
     # process_command returns.
-    assert len(ctx._pending_group_replies) == 1
-    failure_reply = ctx._pending_group_replies[0]
+    pending_replies = ctx.drain_pending_group_replies()
+    assert len(pending_replies) == 1
+    failure_reply = pending_replies[0]
     assert failure_reply.status == AgentState.FAILED.value
     assert failure_reply.content == ""
     assert failure_reply.reply_data["error_code"] == "AGENT_TYPE_UNAVAILABLE"
@@ -1029,45 +1030,9 @@ async def test_context_injects_custom_file_permission_policy(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_context_call_agents_rejects_shared_message_id_across_tasks():
-    """One message_id for a whole batch would make siblings overwrite each
-    other in the Task Group result hash, which is keyed per sub-task."""
-    from unittest.mock import MagicMock
-
-    mock_redis = MagicMock()
-    mock_redis.xadd = AsyncMock()
-    mock_redis.hset = AsyncMock()
-    mock_redis.expire = AsyncMock()
-    mock_redis.smembers = AsyncMock(return_value={b"worker-1"})
-    mock_redis.get = AsyncMock(return_value=b"1")
-
-    ctx = AgentContext(
-        session_id="s1",
-        trace_id="t1",
-        redis_client=mock_redis,
-        current_agent_id="agent-a",
-        message_id="parent-msg",
-    )
-
-    with pytest.raises(ValueError, match="message_id"):
-        await ctx.call_agents(
-            tasks=[
-                {"target_agent_type": "agent-b", "content": "one"},
-                {"target_agent_type": "agent-c", "content": "two"},
-            ],
-            message_id="shared-msg",
-        )
-
-    # Still allowed for a single task, where nothing can collide.
-    result = await ctx.call_agents(
-        tasks=[{"target_agent_type": "agent-b", "content": "one"}],
-        message_id="single-msg",
-    )
-    assert result["dispatched_tasks"][0]["message_id"] == "single-msg"
-
-
-@pytest.mark.asyncio
-async def test_context_call_agents_honours_per_task_message_id():
+async def test_context_call_agents_derives_unique_ids_from_shared_message_id():
+    """The legacy batch-level argument remains source-compatible without
+    allowing sibling results to collide."""
     from unittest.mock import MagicMock
 
     mock_redis = MagicMock()
@@ -1087,6 +1052,89 @@ async def test_context_call_agents_honours_per_task_message_id():
 
     result = await ctx.call_agents(
         tasks=[
+            {"target_agent_type": "agent-b", "content": "one"},
+            {"target_agent_type": "agent-c", "content": "two"},
+        ],
+        message_id="shared-msg",
+    )
+    assert [task["message_id"] for task in result["dispatched_tasks"]] == [
+        "shared-msg:0",
+        "shared-msg:1",
+    ]
+
+    # Still allowed for a single task, where nothing can collide.
+    result = await ctx.call_agents(
+        tasks=[{"target_agent_type": "agent-b", "content": "one"}],
+        message_id="single-msg",
+    )
+    assert result["dispatched_tasks"][0]["message_id"] == "single-msg"
+
+
+@pytest.mark.asyncio
+async def test_context_call_agents_rejects_duplicate_per_task_ids_before_writes():
+    from unittest.mock import MagicMock
+
+    mock_redis = MagicMock()
+    mock_redis.hset = AsyncMock()
+    mock_redis.expire = AsyncMock()
+    mock_redis.xadd = AsyncMock()
+
+    ctx = AgentContext(session_id="s1", trace_id="t1", redis_client=mock_redis)
+
+    with pytest.raises(ValueError, match="message_ids must be unique"):
+        await ctx.call_agents(
+            tasks=[
+                {
+                    "target_agent_type": "agent-b",
+                    "content": "one",
+                    "message_id": "duplicate-id",
+                },
+                {
+                    "target_agent_type": "agent-c",
+                    "content": "two",
+                    "message_id": "duplicate-id",
+                },
+            ]
+        )
+
+    mock_redis.hset.assert_not_awaited()
+    mock_redis.expire.assert_not_awaited()
+    mock_redis.xadd.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_context_call_agents_honours_per_task_message_id():
+    from unittest.mock import MagicMock
+
+    mock_redis = MagicMock()
+    mock_redis.hset = AsyncMock()
+    mock_redis.expire = AsyncMock()
+    mock_redis.smembers = AsyncMock(return_value={b"worker-1"})
+    mock_redis.get = AsyncMock(return_value=b"1")
+
+    async def assert_task_order_exists_before_dispatch(*_args, **_kwargs):
+        order_writes = [
+            call
+            for call in mock_redis.hset.await_args_list
+            if call.kwargs.get("mapping", {}).get(TASK_GROUP_FIELD_TASK_ORDER)
+        ]
+        assert len(order_writes) == 1
+        assert json.loads(
+            order_writes[0].kwargs["mapping"][TASK_GROUP_FIELD_TASK_ORDER]
+        ) == ["mid-b", "mid-c"]
+
+    mock_redis.xadd = AsyncMock(side_effect=assert_task_order_exists_before_dispatch)
+
+    ctx = AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=mock_redis,
+        current_agent_id="agent-a",
+        message_id="parent-msg",
+    )
+
+    result = await ctx.call_agents(
+        tasks=[
             {"target_agent_type": "agent-b", "content": "one", "message_id": "mid-b"},
             {"target_agent_type": "agent-c", "content": "two", "message_id": "mid-c"},
         ],
@@ -1094,12 +1142,14 @@ async def test_context_call_agents_honours_per_task_message_id():
 
     assert [t["message_id"] for t in result["dispatched_tasks"]] == ["mid-b", "mid-c"]
     order_writes = [
-        c
-        for c in mock_redis.hset.await_args_list
-        if len(c.args) >= 3 and c.args[1] == TASK_GROUP_FIELD_TASK_ORDER
+        call
+        for call in mock_redis.hset.await_args_list
+        if call.kwargs.get("mapping", {}).get(TASK_GROUP_FIELD_TASK_ORDER)
     ]
     assert len(order_writes) == 1
-    assert json.loads(order_writes[0].args[2]) == ["mid-b", "mid-c"]
+    assert json.loads(
+        order_writes[0].kwargs["mapping"][TASK_GROUP_FIELD_TASK_ORDER]
+    ) == ["mid-b", "mid-c"]
 
 
 @pytest.mark.asyncio

--- a/tests/worker/test_fetch_messages.py
+++ b/tests/worker/test_fetch_messages.py
@@ -56,6 +56,31 @@ class ScriptedXreadgroupRedis:
         pass
 
 
+class ReclaimingRedis(ScriptedXreadgroupRedis):
+    def __init__(self, claimed_message):
+        super().__init__()
+        self.claimed_message = claimed_message
+        self.claim_calls = []
+
+    async def xautoclaim(
+        self,
+        name,
+        groupname,
+        consumername,
+        min_idle_time,
+        start_id="0-0",
+        count=None,
+    ):
+        self.claim_calls.append(
+            (name, groupname, consumername, min_idle_time, start_id, count)
+        )
+        if self.claimed_message is None:
+            return [b"0-0", [], []]
+        message = self.claimed_message
+        self.claimed_message = None
+        return [b"0-0", [message], []]
+
+
 @pytest.mark.asyncio
 async def test_fetch_messages_phase_one_returns_immediately_without_blocking():
     """If any active stream has a message, fetch_messages returns it via the
@@ -85,6 +110,27 @@ async def test_fetch_messages_phase_one_returns_immediately_without_blocking():
     for call in redis_mock.calls:
         assert len(call["streams"]) == 1
         assert call["block"] is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_messages_reclaims_stale_pending_entry_before_new_messages():
+    stream_name = RedisKeys.ctrl_stream("agent-a")
+    redis_mock = ReclaimingRedis(
+        (b"9-0", {b"data": b'{"header": {"message_id": "pending"}}'})
+    )
+    runner = WorkerRunner(
+        redis_client=redis_mock,
+        worker=_FixedAgentTypesWorker(["agent-a"]),
+        group_name="test_group",
+    )
+
+    messages = await runner.fetch_messages()
+
+    assert messages == [
+        (stream_name, "9-0", {"header": {"message_id": "pending"}})
+    ]
+    assert len(redis_mock.claim_calls) == 1
+    assert redis_mock.calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/worker/test_runner.py
+++ b/tests/worker/test_runner.py
@@ -13,6 +13,7 @@ from by_framework import (
     WorkerRunner,
 )
 from by_framework.common.config import WorkerConfig
+from by_framework.common.constants import TASK_GROUP_FIELD_JOINED
 from by_framework.core.protocol.agent_state import AgentState
 from by_framework.core.protocol.commands import (
     AskAgentCommand,
@@ -23,6 +24,7 @@ from by_framework.core.protocol.commands import (
     SuspendWorkerCommand,
 )
 from by_framework.core.protocol.message_header import MessageHeader
+from by_framework.worker.task_group import TASK_GROUP_JOIN_PENDING_STATUS
 
 
 def _request_readyz(port: int):
@@ -62,6 +64,7 @@ class MockRedisRunner:
         self.acked = False
         self.ack_calls = []
         self.group_create_calls = []
+        self.hashes = {}
 
     async def xgroup_create(self, name, groupname, id="0", mkstream=False):
         self.group_create_calls.append((name, groupname, id, mkstream))
@@ -77,6 +80,9 @@ class MockRedisRunner:
     async def xack(self, name, groupname, *ids):
         self.acked = True
         self.ack_calls.append((name, groupname, ids))
+
+    async def hget(self, name, key):
+        return self.hashes.get(name, {}).get(key)
 
 
 class DummyWorker(GatewayWorker):
@@ -331,6 +337,72 @@ class TestWorkerRunner(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(worker.registry.save_execution.await_count == 1)
         worker.registry.mark_execution_finished.assert_awaited()
         self.assertTrue(redis_mock.acked)
+
+    async def test_runner_leaves_join_claim_contention_pending_without_failure(self):
+        redis_mock = MockRedisRunner(message_to_return=[])
+        worker = DummyWorker()
+        worker._handle_message = AsyncMock(
+            return_value=AgentTaskResult(status=TASK_GROUP_JOIN_PENDING_STATUS)
+        )
+        worker.registry = AsyncMock()
+        worker.registry.get_execution_by_message_id.return_value = {
+            "execution_id": "exec-join",
+            "message_id": "caller-msg",
+            "session_id": "sess-1",
+            "status": "RUNNING",
+        }
+        runner = WorkerRunner(
+            redis_client=redis_mock, worker=worker, group_name="test_group"
+        )
+        payload = ResumeCommand(
+            header=MessageHeader(
+                message_id="caller-msg",
+                session_id="sess-1",
+                trace_id="trace-1",
+                target_agent_type="dummy_agent",
+                parent_message_id="subtask-msg",
+                task_group_id="tg-pending",
+            ),
+            status="COMPLETED",
+        ).to_dict()
+
+        await runner._process_message_from_dict(
+            RedisKeys.ctrl_stream("dummy_agent"), "2-0", payload
+        )
+
+        self.assertFalse(redis_mock.acked)
+        worker.registry.mark_execution_finished.assert_not_awaited()
+
+    async def test_runner_acks_joined_replay_without_registry_mutation(self):
+        redis_mock = MockRedisRunner(message_to_return=[])
+        redis_mock.hashes[RedisKeys.task_group("tg-joined")] = {
+            TASK_GROUP_FIELD_JOINED: "1"
+        }
+        worker = DummyWorker()
+        worker.registry = AsyncMock()
+        runner = WorkerRunner(
+            redis_client=redis_mock, worker=worker, group_name="test_group"
+        )
+        payload = ResumeCommand(
+            header=MessageHeader(
+                message_id="caller-msg",
+                session_id="sess-1",
+                trace_id="trace-1",
+                target_agent_type="dummy_agent",
+                parent_message_id="subtask-msg",
+                task_group_id="tg-joined",
+            ),
+            status="COMPLETED",
+        ).to_dict()
+
+        await runner._process_message_from_dict(
+            RedisKeys.ctrl_stream("dummy_agent"), "3-0", payload
+        )
+
+        self.assertTrue(redis_mock.acked)
+        worker.registry.get_execution_by_message_id.assert_not_awaited()
+        worker.registry.update_execution_status.assert_not_awaited()
+        worker.registry.mark_execution_finished.assert_not_awaited()
 
     async def test_runner_records_worker_execute_span(self):
         """Processed worker commands write an execution span for trace drilldown."""

--- a/tests/worker/test_task_group.py
+++ b/tests/worker/test_task_group.py
@@ -1,0 +1,101 @@
+"""Unit tests for TaskGroupStore's local invariants and result views."""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from by_framework.common.constants import (
+    TASK_GROUP_FIELD_TASK_ORDER,
+    TASK_GROUP_FIELD_TOTAL,
+    RedisKeys,
+)
+from by_framework.worker.task_group import TaskGroupStore
+
+
+def test_resolve_message_ids_preserves_legacy_shared_id_without_collisions():
+    generated = iter(["generated-a", "generated-b"])
+
+    assert TaskGroupStore.resolve_message_ids(
+        [None],
+        shared_message_id="shared",
+        generate_message_id=lambda: next(generated),
+    ) == ["shared"]
+    assert TaskGroupStore.resolve_message_ids(
+        [None, "explicit"],
+        shared_message_id="shared",
+        generate_message_id=lambda: next(generated),
+    ) == ["shared:0", "explicit"]
+
+
+def test_resolve_message_ids_rejects_duplicate_explicit_and_derived_ids():
+    with pytest.raises(ValueError, match="must be unique"):
+        TaskGroupStore.resolve_message_ids(
+            [None, "shared:0"],
+            shared_message_id="shared",
+            generate_message_id=lambda: "unused",
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_invalid_ids_before_redis_writes():
+    redis = AsyncMock()
+    store = TaskGroupStore(redis)
+
+    with pytest.raises(ValueError, match="at least one"):
+        await store.create("tg-empty", message_ids=[], source_agent_type="caller")
+    with pytest.raises(ValueError, match="must be unique"):
+        await store.create(
+            "tg-duplicate",
+            message_ids=["same", "same"],
+            source_agent_type="caller",
+        )
+
+    redis.hset.assert_not_awaited()
+    redis.expire.assert_not_awaited()
+
+
+def test_build_result_repeats_failed_error_fields_at_top_level():
+    result = TaskGroupStore.build_result(
+        status="FAILED",
+        reply_data={"error": "boom", "error_code": "E_BOOM"},
+        content="",
+        target_agent_type="agent-b",
+        metadata={},
+        extra_payload={},
+    )
+
+    assert result["error"] == "boom"
+    assert result["error_code"] == "E_BOOM"
+    assert result["reply_data"] == {"error": "boom", "error_code": "E_BOOM"}
+
+
+@pytest.mark.asyncio
+async def test_aggregate_uses_dispatch_order_and_appends_unknown_results():
+    redis = AsyncMock()
+    task_group_id = "tg-order"
+    group_key = RedisKeys.task_group(task_group_id)
+    results_key = RedisKeys.task_group_results(task_group_id)
+    redis.hgetall.return_value = {
+        "msg-b": json.dumps({"status": "COMPLETED"}),
+        "unexpected": json.dumps({"status": "COMPLETED"}),
+        "msg-a": json.dumps({"status": "COMPLETED"}),
+    }
+
+    async def hget(name, field):
+        if name == group_key and field == TASK_GROUP_FIELD_TASK_ORDER:
+            return json.dumps(["msg-a", "msg-b"])
+        if name == group_key and field == TASK_GROUP_FIELD_TOTAL:
+            return "3"
+        return None
+
+    redis.hget.side_effect = hget
+
+    aggregate = await TaskGroupStore(redis).aggregate(task_group_id)
+
+    assert [item["message_id"] for item in aggregate] == [
+        "msg-a",
+        "msg-b",
+        "unexpected",
+    ]
+    redis.hgetall.assert_awaited_once_with(results_key)


### PR DESCRIPTION
## Summary

Closes #90, #91, #92, #93, #94, #95, #96.

`call_agents` is now `call_agent`'s plural, sharing one dispatch path and one resume/aggregation path instead of being a separately-behaved, easier-to-misuse API:

- Extracted `AgentContext._dispatch_single_task` as the one place that builds, availability-checks, and dispatches an `AskAgentCommand`; both `call_agent` and `call_agents`' batch loop use it now (#91).
- `call_agents` is the primary batch entry point; `dispatch_group`/`collect_group_results` remain permanent, source-compatible aliases (see `docs/adr/0001-unify-call-agent-and-call-agents-behavior.md`). Successful dispatch now returns `AgentState.QUEUED` instead of the ad hoc `"GROUP_QUEUED"` string (#92).
- Group Join (`GatewayWorker._handle_message`) now resumes the caller with every sub-task's aggregated result instead of forwarding whichever reply happened to complete the group last. Each aggregated item carries `target_agent_type` so its shape matches `call_agent`'s own return/failure dict (#93).
- Each task in a batch is now availability-checked the same way `call_agent`'s single dispatch is: an offline target is recorded `FAILED` immediately instead of hanging the whole group to a 30s timeout, and siblings keep dispatching (#94).
- `call_agents([])` raises `ValueError` instead of silently returning a no-op `EMPTY` status (#95).
- A dispatch-time infrastructure failure partway through a batch now marks the Task Group aborted before re-raising; Group Join checks that marker before counting a reply, so a late sibling reply can no longer resume a caller execution that already failed — protecting the execution-identity invariant this SDK's design guards elsewhere (#96).

Also extends the deploy smoke test (`examples/echo_worker.py`'s new `"fanout"` agent type + `examples/send_and_verify.py`) to exercise `call_agents` against a real, separate-process Redis Streams deployment — the unit/integration tests all run against in-memory fakes, so this is the only place a real-Redis-only Group Join bug would surface.

### Review follow-up hardening

- Added `TaskGroupStore` as the single persistence/accounting module. It validates sibling IDs before writes, preserves legacy batch-level `message_id` calls by deriving unique IDs, and writes the complete ordered group contract before dispatch.
- Group Join now records replies atomically with `HSETNX`, counts each sibling once under Redis redelivery, and uses a recoverable lease/commit so the caller resumes once. `WorkerRunner` reclaims lease-expired pending entries with per-stream `XAUTOCLAIM`; joined replays are ACK-only and do not rewrite execution state.
- Failed aggregate entries retain `reply_data` and also expose top-level `error`/`error_code`. Per-task routing parameters are explicitly approved in #90 and the ADR.
- Added Runner-level reclaim/ACK-only tests and a mirrored `tests/worker/test_task_group.py` suite.

## Test plan

- [x] `make test` (668 main-package tests passed; every subpackage suite passed)
- [x] `make lint` clean (10.00/10) and `scripts/verify.sh` 3/3 green
- [x] New tests at two seams per the PRD's plan: `AgentContext` directly for dispatch-time behavior (`tests/worker/test_context.py`), and `GatewayWorker._handle_message` end-to-end for Group Join with a real in-memory Redis hash fake so completion counters and aggregation are exercised for real (`tests/integration/test_scatter_gather.py`)
- [x] `/matt-code-review` (Standards + Spec axes) run against the diff; findings applied (removed now-dead `check_availability=False` branch, fixed a `target_agent_type` inconsistency under fallback rerouting, fixed a docstring that contradicted the "permanent alias" decision, added a plugin-hook-parity test)
- [x] `echo_worker.py`'s new fanout handler verified in-process via the same fake-Redis harness (no Docker/real Redis available in the authoring sandbox); the deploy-smoke-test workflow itself will exercise it against real Redis Streams on this PR's CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
