### PR TITLE
Native Agent Harness: NativeAgentWorker core loop (litellm, tool calling, agent-as-tool, distributed suspend/resume)

### DIFF
--- a/libs/by-framework-agent/README.md
+++ b/libs/by-framework-agent/README.md
@@ -7,3 +7,46 @@ Native agent harness for `by-framework`: a `litellm`-backed reasoning loop
 
 See [beyonai/by-framework-python#98](https://github.com/beyonai/by-framework-python/issues/98)
 for the design PRD and #99-#104 for the vertical-slice breakdown.
+
+## Quick Start
+
+```python
+from by_framework_agent import NativeAgentWorker, ToolSpec
+from by_framework.core.extensions.agent_config import AgentConfig
+from by_framework.core.extensions.registry import PluginRegistry
+
+
+async def get_weather(context, arguments) -> str:
+    return f"It's sunny in {arguments['city']}."
+
+
+class AssistantWorker(NativeAgentWorker):
+    def get_agent_types(self) -> list[str]:
+        return ["assistant"]
+
+
+registry = PluginRegistry()
+registry._set_agent_configs([
+    AgentConfig(
+        agent_id="assistant",
+        prompts={"system": "You are a helpful assistant."},
+        tools={"get_weather": ToolSpec(name="get_weather", handler=get_weather)},
+        sub_agents=["researcher"],  # auto-exposed as a callable tool too
+        extra={"model": "gpt-4o-mini"},  # any litellm-supported model string
+    ),
+])
+
+worker = AssistantWorker(
+    worker_id="assistant-1",
+    plugin_registry=registry,
+    # model_client defaults to LiteLLMModelClient — omit it to call a real
+    # provider; pass a by_framework_agent.testing.StubModelClient in tests.
+)
+```
+
+No hand-written `process_command()` needed — declaring the `AgentConfig` is
+enough to get a working tool-calling, delegating, suspend/resume-capable
+agent. See [`examples/`](examples/) for four runnable, progressively more
+complete demos (tools, `ask_user`, single-agent delegation, and multi-agent
+`call_agents` Task Group fan-out), and [`tests/`](tests/) for the full
+behavioral spec.

--- a/libs/by-framework-agent/README.md
+++ b/libs/by-framework-agent/README.md
@@ -79,8 +79,34 @@ AgentConfig(
   (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, ...). litellm
   reads it automatically; nothing to pass explicitly.
 - **`extra["model_params"]`** (optional) — a dict forwarded as-is to every
-  `ModelClient.complete()` call: `temperature`, `max_tokens`, `api_base`
-  (for self-hosted/proxy endpoints), etc.
+  `ModelClient.complete()` call, i.e. straight into `litellm.acompletion(...)`.
+  Anything litellm's `completion`/`acompletion` accepts as a kwarg works:
+  `temperature`, `max_tokens`, `api_key` (overrides the env var for just
+  this agent), `api_base` (point at a self-hosted/proxy/OpenAI-compatible
+  endpoint, e.g. vLLM or a local gateway), `api_version`, etc.
+
+`extra` lives on `AgentConfig`, not the worker — so **different agents can
+each use a completely different provider, model, and credentials** in the
+same process. An orchestrator calling OpenAI and a `sub_agents` delegate
+pointed at a self-hosted model behind a different key both "just work":
+
+```python
+AgentConfig(
+    agent_id="orchestrator",
+    sub_agents=["local_specialist"],
+    extra={"model": "gpt-4o-mini", "model_params": {"api_key": "sk-..."}},
+)
+AgentConfig(
+    agent_id="local_specialist",
+    extra={
+        "model": "openai/local-llama",  # litellm's OpenAI-compatible provider
+        "model_params": {
+            "api_key": "sk-local-anything",
+            "api_base": "http://localhost:8000/v1",
+        },
+    },
+)
+```
 
 See [`examples/05_real_model_react.py`](examples/05_real_model_react.py) for
 a complete runnable version of the snippet above, with a `calculate` tool to

--- a/libs/by-framework-agent/README.md
+++ b/libs/by-framework-agent/README.md
@@ -1,0 +1,9 @@
+# by-framework-agent
+
+Native agent harness for `by-framework`: a `litellm`-backed reasoning loop
+(`NativeAgentWorker`) that ships as a first-party alternative to hand-written
+`process_command()` implementations and to the `by-framework-langgraph` /
+`by-framework-adk` external-framework adapters.
+
+See [beyonai/by-framework-python#98](https://github.com/beyonai/by-framework-python/issues/98)
+for the design PRD and #99-#104 for the vertical-slice breakdown.

--- a/libs/by-framework-agent/README.md
+++ b/libs/by-framework-agent/README.md
@@ -46,7 +46,48 @@ worker = AssistantWorker(
 
 No hand-written `process_command()` needed — declaring the `AgentConfig` is
 enough to get a working tool-calling, delegating, suspend/resume-capable
-agent. See [`examples/`](examples/) for four runnable, progressively more
-complete demos (tools, `ask_user`, single-agent delegation, and multi-agent
-`call_agents` Task Group fan-out), and [`tests/`](tests/) for the full
-behavioral spec.
+agent. See [`examples/`](examples/) for five runnable, progressively more
+complete demos (tools, `ask_user`, single-agent delegation, multi-agent
+`call_agents` Task Group fan-out, and a real-model ReAct loop), and
+[`tests/`](tests/) for the full behavioral spec.
+
+## Connecting a real model (ReAct)
+
+Every example above except one uses `by_framework_agent.testing.StubModelClient`
+so it runs offline. To call a real provider instead, there is nothing extra
+to wire up — just **don't pass `model_client=...`** when constructing your
+worker. `NativeAgentWorker` defaults to `LiteLLMModelClient`, which calls
+whatever provider `AgentConfig.extra["model"]` names via `litellm` — the
+same tool-calling loop then behaves as ReAct (reason → call a tool →
+observe the result → repeat) against a real model, with no code changes.
+
+```python
+AgentConfig(
+    agent_id="assistant",
+    tools={"calculate": ...},
+    extra={
+        "model": "gpt-4o-mini",              # any litellm model string
+        "model_params": {"temperature": 0.2},  # forwarded to every model call
+    },
+)
+```
+
+- **`extra["model"]`** — any [litellm-supported](https://docs.litellm.ai/docs/providers)
+  model string: `"gpt-4o-mini"`, `"anthropic/claude-3-5-sonnet-20241022"`,
+  `"gemini/gemini-2.0-flash"`, `"azure/<deployment-name>"`, etc.
+- **The matching API key** — set as an env var the way litellm expects
+  (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, ...). litellm
+  reads it automatically; nothing to pass explicitly.
+- **`extra["model_params"]`** (optional) — a dict forwarded as-is to every
+  `ModelClient.complete()` call: `temperature`, `max_tokens`, `api_base`
+  (for self-hosted/proxy endpoints), etc.
+
+See [`examples/05_real_model_react.py`](examples/05_real_model_react.py) for
+a complete runnable version of the snippet above, with a `calculate` tool to
+demonstrate the reasoning loop:
+
+```bash
+export OPENAI_API_KEY=sk-...
+cd libs/by-framework-agent
+uv run python examples/05_real_model_react.py "What is 12 * (7 + 5)?"
+```

--- a/libs/by-framework-agent/examples/01_basic_chat.py
+++ b/libs/by-framework-agent/examples/01_basic_chat.py
@@ -1,0 +1,96 @@
+"""Example 1: the smallest possible NativeAgentWorker.
+
+No tools, no sub_agents — just an AgentConfig and a model turn. Run:
+
+    uv run python examples/01_basic_chat.py
+"""
+
+# pylint: disable=invalid-name  # numbered filename for tutorial ordering
+
+import asyncio
+
+from _infra import Dispatcher, InMemoryRedis
+from by_framework.core.extensions.agent_config import AgentConfig
+from by_framework.core.extensions.registry import PluginRegistry
+from by_framework.core.protocol.commands import AskAgentCommand
+from by_framework.core.protocol.message_header import MessageHeader
+from by_framework.core.workspace import WorkspaceManager
+
+from by_framework_agent import NativeAgentWorker
+from by_framework_agent.model_client import ModelChunk
+from by_framework_agent.testing import StubModelClient
+
+
+class AssistantWorker(NativeAgentWorker):
+
+    def get_agent_types(self) -> list[str]:
+        return ["assistant"]
+
+
+def build_registry() -> PluginRegistry:
+    registry = PluginRegistry()
+    registry._set_agent_configs(  # pylint: disable=protected-access
+        [
+            AgentConfig(
+                agent_id="assistant",
+                name="Assistant",
+                prompts={"system": "You are a concise, friendly assistant."},
+                # NativeAgentWorker reads the model from AgentConfig.extra["model"] —
+                # any litellm-supported model string works with the real
+                # LiteLLMModelClient. This example scripts the model call instead.
+                extra={"model": "gpt-4o-mini"},
+            )
+        ]
+    )
+    return registry
+
+
+async def main() -> None:
+    redis = InMemoryRedis()
+    dispatcher = Dispatcher(redis=redis)
+    dispatcher.register(
+        "assistant",
+        lambda: AssistantWorker(
+            worker_id="assistant-worker",
+            redis_client=redis,
+            workspace_manager=WorkspaceManager(),
+            plugin_registry=build_registry(),
+            # A real deployment omits model_client entirely and gets the
+            # default LiteLLMModelClient, which calls a real provider. This
+            # example scripts the reply so it runs with no API key.
+            model_client=StubModelClient(
+                turns=[
+                    [
+                        ModelChunk(content="Hi there"),
+                        ModelChunk(content="! How can I help today?"),
+                        ModelChunk(
+                            is_final=True,
+                            finish_reason="stop",
+                            usage={"prompt_tokens": 18, "completion_tokens": 9},
+                            model="gpt-4o-mini",
+                        ),
+                    ]
+                ]
+            ),
+        ),
+    )
+
+    command = AskAgentCommand(
+        header=MessageHeader(
+            message_id="msg-1",
+            session_id="session-1",
+            trace_id="trace-1",
+            user_code="user-1",
+            user_name="Alice",
+            target_agent_type="assistant",
+        ),
+        content="Hello!",
+    )
+
+    result = await dispatcher.dispatch_root(command)
+    print(f"status:  {result.status}")
+    print(f"content: {result.content}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/libs/by-framework-agent/examples/02_tools_and_ask_user.py
+++ b/libs/by-framework-agent/examples/02_tools_and_ask_user.py
@@ -1,0 +1,172 @@
+"""Example 2: a local tool, plus the built-in ask_user tool.
+
+Shows the harness's suspend/resume cycle: the model calls ask_user, the
+worker returns WAITING_USER, and — on a *separate* worker instance,
+demonstrating this doesn't depend on process affinity — a ResumeCommand with
+the user's reply continues the same loop to completion. Run:
+
+    uv run python examples/02_tools_and_ask_user.py
+"""
+
+# pylint: disable=invalid-name  # numbered filename for tutorial ordering
+
+import asyncio
+import datetime
+import json
+
+from _infra import Dispatcher, InMemoryRedis
+from by_framework.core.extensions.agent_config import AgentConfig
+from by_framework.core.extensions.registry import PluginRegistry
+from by_framework.core.protocol.commands import AskAgentCommand, ResumeCommand
+from by_framework.core.protocol.message_header import MessageHeader
+from by_framework.core.workspace import WorkspaceManager
+
+from by_framework_agent import NativeAgentWorker, ToolSpec
+from by_framework_agent.model_client import ModelChunk
+from by_framework_agent.testing import StubModelClient
+
+
+async def get_current_time(context, arguments) -> str:
+    del context, arguments
+    # A real tool would do real work; this one's deterministic for the demo.
+    return datetime.datetime(2026, 1, 1, 9, 30).isoformat()
+
+
+def build_registry() -> PluginRegistry:
+    registry = PluginRegistry()
+    registry._set_agent_configs(  # pylint: disable=protected-access
+        [
+            AgentConfig(
+                agent_id="assistant",
+                name="Assistant",
+                prompts={"system": "You are a friendly scheduling assistant."},
+                tools={
+                    "get_current_time": ToolSpec(
+                        name="get_current_time",
+                        handler=get_current_time,
+                        description="Return the current date and time.",
+                    )
+                },
+                extra={"model": "gpt-4o-mini"},
+            )
+        ]
+    )
+    return registry
+
+
+class AssistantWorker(NativeAgentWorker):
+
+    def get_agent_types(self) -> list[str]:
+        return ["assistant"]
+
+
+async def main() -> None:
+    redis = InMemoryRedis()
+    dispatcher = Dispatcher(redis=redis)
+
+    # Turn 1: call the local tool. Turn 2: ask the user a question — this
+    # suspends the loop instead of producing a final answer. Turn 3 (scripted
+    # on a *different* worker instance below): the final answer, once the
+    # user's reply is available as a tool result.
+    first_worker_model_client = StubModelClient(
+        turns=[
+            [
+                ModelChunk(
+                    tool_call_deltas=[
+                        {
+                            "index": 0,
+                            "id": "call_time",
+                            "function": {"name": "get_current_time", "arguments": "{}"},
+                        }
+                    ],
+                    is_final=True,
+                    finish_reason="tool_calls",
+                )
+            ],
+            [
+                ModelChunk(
+                    tool_call_deltas=[
+                        {
+                            "index": 0,
+                            "id": "call_ask",
+                            "function": {
+                                "name": "ask_user",
+                                "arguments": json.dumps(
+                                    {"prompt": "What's your name?"}
+                                ),
+                            },
+                        }
+                    ],
+                    is_final=True,
+                    finish_reason="tool_calls",
+                )
+            ],
+        ]
+    )
+    dispatcher.register(
+        "assistant",
+        lambda: AssistantWorker(
+            worker_id="assistant-worker-a",
+            redis_client=redis,
+            workspace_manager=WorkspaceManager(),
+            plugin_registry=build_registry(),
+            model_client=first_worker_model_client,
+        ),
+    )
+
+    command = AskAgentCommand(
+        header=MessageHeader(
+            message_id="msg-1",
+            session_id="session-1",
+            trace_id="trace-1",
+            user_code="user-1",
+            user_name="Alice",
+            target_agent_type="assistant",
+        ),
+        content="What time is it, and can you greet me by name?",
+    )
+
+    execution_id = "exec-demo-1"
+    suspend_result = await dispatcher.dispatch_root(command, execution_id=execution_id)
+    print(f"after ask_user:  status={suspend_result.status}")
+    assert suspend_result.status == "WAITING_USER"
+
+    # A fresh worker instance — same execution_id, no shared Python state —
+    # picks up the user's reply and finishes the conversation.
+    dispatcher.register(
+        "assistant",
+        lambda: AssistantWorker(
+            worker_id="assistant-worker-b",
+            redis_client=redis,
+            workspace_manager=WorkspaceManager(),
+            plugin_registry=build_registry(),
+            model_client=StubModelClient(
+                turns=[
+                    [
+                        ModelChunk(content="Nice to meet you, Bob"),
+                        ModelChunk(content="! It's 09:30 on 2026-01-01."),
+                        ModelChunk(is_final=True, finish_reason="stop"),
+                    ]
+                ]
+            ),
+        ),
+    )
+    reply = ResumeCommand(
+        header=MessageHeader(
+            message_id="msg-2",
+            session_id="session-1",
+            trace_id="trace-1",
+            parent_message_id="msg-1",
+            user_code="user-1",
+            user_name="Alice",
+            target_agent_type="assistant",
+        ),
+        content="Bob",
+    )
+    final_result = await dispatcher.dispatch_root(reply, execution_id=execution_id)
+    print(f"after resume:    status={final_result.status}")
+    print(f"final content:   {final_result.content}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/libs/by-framework-agent/examples/03_agent_delegation.py
+++ b/libs/by-framework-agent/examples/03_agent_delegation.py
@@ -1,0 +1,168 @@
+"""Example 3: agent-as-tool — delegating to one sub-agent via `call_agent`.
+
+`AgentConfig.sub_agents` entries are auto-registered as callable tools, with
+no separate AgentConfig.tools entry needed. When the model calls one, the
+harness dispatches a *real* AskAgentCommand — here, `Dispatcher.drain()`
+plays the role a real Redis Streams cluster would: it picks up the dispatched
+command, hands it to the sub-agent's own worker, and relays that worker's
+reply back as a ResumeCommand, which the orchestrator's suspended loop then
+resumes from. Run:
+
+    uv run python examples/03_agent_delegation.py
+"""
+
+# pylint: disable=invalid-name  # numbered filename for tutorial ordering
+
+import asyncio
+import json
+
+from _infra import Dispatcher, InMemoryRedis
+from by_framework.core.extensions.agent_config import AgentConfig
+from by_framework.core.extensions.registry import PluginRegistry
+from by_framework.core.protocol.commands import AskAgentCommand
+from by_framework.core.protocol.message_header import MessageHeader
+from by_framework.core.workspace import WorkspaceManager
+
+from by_framework_agent import NativeAgentWorker
+from by_framework_agent.model_client import ModelChunk
+from by_framework_agent.testing import StubModelClient
+
+
+class OrchestratorWorker(NativeAgentWorker):
+
+    def get_agent_types(self) -> list[str]:
+        return ["orchestrator"]
+
+
+class ResearcherWorker(NativeAgentWorker):
+
+    def get_agent_types(self) -> list[str]:
+        return ["researcher"]
+
+
+def orchestrator_registry() -> PluginRegistry:
+    registry = PluginRegistry()
+    registry._set_agent_configs(  # pylint: disable=protected-access
+        [
+            AgentConfig(
+                agent_id="orchestrator",
+                name="Orchestrator",
+                description="Delegates research questions to a specialist.",
+                prompts={"system": "You delegate research questions to 'researcher'."},
+                sub_agents=["researcher"],
+                extra={"model": "gpt-4o-mini"},
+            ),
+            # The orchestrator's config manager needs to resolve "researcher"
+            # too, so it can read its description for the auto-generated
+            # tool schema — see HarnessLoop._sub_agent_tool_schemas.
+            AgentConfig(
+                agent_id="researcher",
+                name="Researcher",
+                description="Answers focused research questions.",
+                extra={"model": "gpt-4o-mini"},
+            ),
+        ]
+    )
+    return registry
+
+
+def researcher_registry() -> PluginRegistry:
+    registry = PluginRegistry()
+    registry._set_agent_configs(  # pylint: disable=protected-access
+        [
+            AgentConfig(
+                agent_id="researcher",
+                name="Researcher",
+                prompts={"system": "You answer focused research questions concisely."},
+                extra={"model": "gpt-4o-mini"},
+            )
+        ]
+    )
+    return registry
+
+
+async def main() -> None:
+    redis = InMemoryRedis()
+    dispatcher = Dispatcher(redis=redis)
+    redis.mark_agent_type_online("researcher", worker_id="researcher-worker")
+
+    orchestrator_model_client = StubModelClient(
+        turns=[
+            [
+                ModelChunk(
+                    tool_call_deltas=[
+                        {
+                            "index": 0,
+                            "id": "call_research",
+                            "function": {
+                                "name": "researcher",
+                                "arguments": json.dumps(
+                                    {"content": "What year was Redis released?"}
+                                ),
+                            },
+                        }
+                    ],
+                    is_final=True,
+                    finish_reason="tool_calls",
+                )
+            ],
+            [
+                ModelChunk(content="Redis was first released in 2009."),
+                ModelChunk(is_final=True, finish_reason="stop"),
+            ],
+        ]
+    )
+    dispatcher.register(
+        "orchestrator",
+        lambda: OrchestratorWorker(
+            worker_id="orchestrator-worker",
+            redis_client=redis,
+            workspace_manager=WorkspaceManager(),
+            plugin_registry=orchestrator_registry(),
+            model_client=orchestrator_model_client,
+        ),
+    )
+    dispatcher.register(
+        "researcher",
+        lambda: ResearcherWorker(
+            worker_id="researcher-worker",
+            redis_client=redis,
+            workspace_manager=WorkspaceManager(),
+            plugin_registry=researcher_registry(),
+            model_client=StubModelClient(
+                turns=[
+                    [
+                        ModelChunk(content="Redis was released in 2009."),
+                        ModelChunk(is_final=True, finish_reason="stop"),
+                    ]
+                ]
+            ),
+        ),
+    )
+
+    command = AskAgentCommand(
+        header=MessageHeader(
+            message_id="msg-1",
+            session_id="session-1",
+            trace_id="trace-1",
+            user_code="user-1",
+            user_name="Alice",
+            target_agent_type="orchestrator",
+        ),
+        content="What year was Redis released?",
+    )
+
+    suspend_result = await dispatcher.dispatch_root(command)
+    print(f"after delegation: status={suspend_result.status}")
+    assert suspend_result.status == "QUEUED"
+
+    # Drain routes the dispatched call_agent command to the researcher
+    # worker, then relays its reply back to the orchestrator — the same
+    # Group Join / ResumeCommand machinery a real Redis deployment uses.
+    processed = await dispatcher.drain()
+    for agent_type, result in processed:
+        print(f"[{agent_type}] status={result.status} content={result.content!r}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/libs/by-framework-agent/examples/04_task_group.py
+++ b/libs/by-framework-agent/examples/04_task_group.py
@@ -1,0 +1,223 @@
+"""Example 4: agent-as-tool with *two* sub-agents in one turn — Task Group.
+
+Per ADR-0001, a turn that delegates to more than one distinct sub-agent
+fans out as a single `call_agents` (Task Group) dispatch instead of
+sequential `call_agent` hops. Group Join then resumes the orchestrator's
+loop exactly once, only after *both* siblings have replied, with each
+reply correlated back to its own tool_call_id. Run:
+
+    uv run python examples/04_task_group.py
+"""
+
+# pylint: disable=invalid-name  # numbered filename for tutorial ordering
+
+import asyncio
+import json
+
+from _infra import Dispatcher, InMemoryRedis
+from by_framework.core.extensions.agent_config import AgentConfig
+from by_framework.core.extensions.registry import PluginRegistry
+from by_framework.core.protocol.commands import AskAgentCommand
+from by_framework.core.protocol.message_header import MessageHeader
+from by_framework.core.workspace import WorkspaceManager
+
+from by_framework_agent import NativeAgentWorker
+from by_framework_agent.model_client import ModelChunk
+from by_framework_agent.testing import StubModelClient
+
+
+class OrchestratorWorker(NativeAgentWorker):
+
+    def get_agent_types(self) -> list[str]:
+        return ["orchestrator"]
+
+
+class SpecialistWorker(NativeAgentWorker):
+    """Reused for both `pricing_specialist` and `availability_specialist` —
+    only the AgentConfig/model_client passed in differs per instance."""
+
+    def get_agent_types(self) -> list[str]:
+        return [self._agent_type]
+
+    def __init__(self, *args, agent_type: str, **kwargs) -> None:
+        self._agent_type = agent_type
+        super().__init__(*args, **kwargs)
+
+
+def orchestrator_registry() -> PluginRegistry:
+    registry = PluginRegistry()
+    registry._set_agent_configs(  # pylint: disable=protected-access
+        [
+            AgentConfig(
+                agent_id="orchestrator",
+                name="Orchestrator",
+                prompts={
+                    "system": (
+                        "You plan a trip by asking pricing_specialist and "
+                        "availability_specialist, then combine their answers."
+                    )
+                },
+                sub_agents=["pricing_specialist", "availability_specialist"],
+                extra={"model": "gpt-4o-mini"},
+            ),
+            # Needed so the orchestrator's auto-generated tool schemas can
+            # read each sub-agent's description (see _sub_agent_tool_schemas).
+            AgentConfig(
+                agent_id="pricing_specialist",
+                name="Pricing Specialist",
+                description="Quotes prices for a destination.",
+                extra={"model": "gpt-4o-mini"},
+            ),
+            AgentConfig(
+                agent_id="availability_specialist",
+                name="Availability Specialist",
+                description="Checks date availability for a destination.",
+                extra={"model": "gpt-4o-mini"},
+            ),
+        ]
+    )
+    return registry
+
+
+def specialist_registry(agent_id: str, system_prompt: str) -> PluginRegistry:
+    registry = PluginRegistry()
+    registry._set_agent_configs(  # pylint: disable=protected-access
+        [
+            AgentConfig(
+                agent_id=agent_id,
+                prompts={"system": system_prompt},
+                extra={"model": "gpt-4o-mini"},
+            )
+        ]
+    )
+    return registry
+
+
+async def main() -> None:
+    redis = InMemoryRedis()
+    dispatcher = Dispatcher(redis=redis)
+    redis.mark_agent_type_online("pricing_specialist", worker_id="pricing-worker")
+    redis.mark_agent_type_online(
+        "availability_specialist", worker_id="availability-worker"
+    )
+
+    # One turn, two distinct sub-agent tool calls — this is what triggers
+    # Task Group batching (HarnessLoop._dispatch_sub_agent_task_group)
+    # instead of the single-target call_agent path.
+    orchestrator_model_client = StubModelClient(
+        turns=[
+            [
+                ModelChunk(
+                    tool_call_deltas=[
+                        {
+                            "index": 0,
+                            "id": "call_pricing",
+                            "function": {
+                                "name": "pricing_specialist",
+                                "arguments": json.dumps(
+                                    {"content": "Quote a price for Tokyo."}
+                                ),
+                            },
+                        },
+                        {
+                            "index": 1,
+                            "id": "call_availability",
+                            "function": {
+                                "name": "availability_specialist",
+                                "arguments": json.dumps(
+                                    {"content": "Check availability for Tokyo."}
+                                ),
+                            },
+                        },
+                    ],
+                    is_final=True,
+                    finish_reason="tool_calls",
+                )
+            ],
+            [
+                ModelChunk(
+                    content=(
+                        "Tokyo: $1,200 round trip, and dates in March are " "available."
+                    )
+                ),
+                ModelChunk(is_final=True, finish_reason="stop"),
+            ],
+        ]
+    )
+    dispatcher.register(
+        "orchestrator",
+        lambda: OrchestratorWorker(
+            worker_id="orchestrator-worker",
+            redis_client=redis,
+            workspace_manager=WorkspaceManager(),
+            plugin_registry=orchestrator_registry(),
+            model_client=orchestrator_model_client,
+        ),
+    )
+    dispatcher.register(
+        "pricing_specialist",
+        lambda: SpecialistWorker(
+            worker_id="pricing-worker",
+            agent_type="pricing_specialist",
+            redis_client=redis,
+            workspace_manager=WorkspaceManager(),
+            plugin_registry=specialist_registry(
+                "pricing_specialist", "You quote a round-trip price in USD."
+            ),
+            model_client=StubModelClient(
+                turns=[
+                    [
+                        ModelChunk(content="$1,200 round trip to Tokyo."),
+                        ModelChunk(is_final=True, finish_reason="stop"),
+                    ]
+                ]
+            ),
+        ),
+    )
+    dispatcher.register(
+        "availability_specialist",
+        lambda: SpecialistWorker(
+            worker_id="availability-worker",
+            agent_type="availability_specialist",
+            redis_client=redis,
+            workspace_manager=WorkspaceManager(),
+            plugin_registry=specialist_registry(
+                "availability_specialist", "You check date availability."
+            ),
+            model_client=StubModelClient(
+                turns=[
+                    [
+                        ModelChunk(content="Tokyo is available in March."),
+                        ModelChunk(is_final=True, finish_reason="stop"),
+                    ]
+                ]
+            ),
+        ),
+    )
+
+    command = AskAgentCommand(
+        header=MessageHeader(
+            message_id="msg-1",
+            session_id="session-1",
+            trace_id="trace-1",
+            user_code="user-1",
+            user_name="Alice",
+            target_agent_type="orchestrator",
+        ),
+        content="Plan a trip to Tokyo — price and availability, please.",
+    )
+
+    suspend_result = await dispatcher.dispatch_root(command)
+    print(f"after fan-out:   status={suspend_result.status}")
+    assert suspend_result.status == "QUEUED"
+
+    # Exactly one Task Group dispatch went out for both specialists — drain
+    # routes each to its own worker and relays both replies back, and Group
+    # Join only resumes the orchestrator once BOTH have answered.
+    processed = await dispatcher.drain()
+    for agent_type, result in processed:
+        print(f"[{agent_type}] status={result.status} content={result.content!r}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/libs/by-framework-agent/examples/05_real_model_react.py
+++ b/libs/by-framework-agent/examples/05_real_model_react.py
@@ -19,6 +19,30 @@ var — litellm reads it automatically:
     MODEL=gemini/gemini-2.0-flash                GEMINI_API_KEY=...
     MODEL=azure/<deployment-name>                AZURE_API_KEY=..., AZURE_API_BASE=...
 
+Every AgentConfig.extra["model_params"] key litellm accepts is configurable
+via its own env var, so you don't have to edit this file to try one:
+
+    MODEL_TEMPERATURE=0.2   # float, forwarded as model_params["temperature"]
+    MODEL_MAX_TOKENS=500    # int,   forwarded as model_params["max_tokens"]
+    MODEL_API_BASE=...      # str,   for a self-hosted/proxy/OpenAI-compatible
+                             #        endpoint (e.g. vLLM) instead of the
+                             #        provider's default
+    MODEL_API_KEY=...       # str,   overrides the provider's usual env var
+                             #        just for this agent (e.g. a self-hosted
+                             #        model's own key)
+    MODEL_API_VERSION=...   # str,   e.g. for Azure OpenAI deployments
+    MODEL_PARAMS_JSON='{"seed": 7, "top_p": 0.9}'
+                             # any other litellm kwarg not covered above —
+                             # merged in last, so it wins on overlapping keys
+
+Example — point at a local vLLM/OpenAI-compatible server instead of a real
+provider:
+
+    MODEL=openai/local-llama \
+    MODEL_API_BASE=http://localhost:8000/v1 \
+    MODEL_API_KEY=sk-local-anything \
+    uv run python examples/05_real_model_react.py "What is 9 * 6?"
+
 Redis is still faked (InMemoryRedis, see _infra.py) — only the model call is
 real. A production deployment additionally runs this behind WorkerRunner
 against a real Redis Streams cluster instead of Dispatcher.
@@ -27,8 +51,10 @@ against a real Redis Streams cluster instead of Dispatcher.
 # pylint: disable=invalid-name  # numbered filename for tutorial ordering
 
 import asyncio
+import json
 import os
 import sys
+from typing import Any
 
 from _infra import Dispatcher, InMemoryRedis
 from by_framework.core.extensions.agent_config import AgentConfig
@@ -42,6 +68,36 @@ from by_framework_agent import NativeAgentWorker, ToolSpec
 # Restricted to a handful of safe operators — a real calculator tool would
 # use a proper expression parser instead of eval().
 _ALLOWED_CALC_CHARS = set("0123456789+-*/(). ")
+
+
+def _model_params_from_env() -> dict[str, Any]:
+    """Build AgentConfig.extra["model_params"] from env vars — see the
+    module docstring for the full list. Every value here is forwarded
+    as-is to litellm.acompletion(), so names match litellm's own kwargs
+    (temperature, max_tokens, api_base, api_key, api_version, ...)."""
+    params: dict[str, Any] = {}
+
+    if "MODEL_TEMPERATURE" in os.environ:
+        params["temperature"] = float(os.environ["MODEL_TEMPERATURE"])
+    if "MODEL_MAX_TOKENS" in os.environ:
+        params["max_tokens"] = int(os.environ["MODEL_MAX_TOKENS"])
+    if "MODEL_API_BASE" in os.environ:
+        params["api_base"] = os.environ["MODEL_API_BASE"]
+    if "MODEL_API_KEY" in os.environ:
+        params["api_key"] = os.environ["MODEL_API_KEY"]
+    if "MODEL_API_VERSION" in os.environ:
+        params["api_version"] = os.environ["MODEL_API_VERSION"]
+
+    raw_extra = os.environ.get("MODEL_PARAMS_JSON")
+    if raw_extra:
+        extra = json.loads(raw_extra)
+        if not isinstance(extra, dict):
+            raise ValueError(
+                f"MODEL_PARAMS_JSON must decode to a JSON object, got {extra!r}"
+            )
+        params.update(extra)  # wins on any key also set via a named var above
+
+    return params
 
 
 async def calculate(context, arguments) -> str:
@@ -95,9 +151,12 @@ def build_registry() -> PluginRegistry:
                 # - extra["model"]: any litellm model string
                 # - extra["model_params"]: forwarded to every ModelClient.
                 #   complete() call (temperature, max_tokens, api_base, ...)
+                # Both are sourced from env vars here — see the module
+                # docstring for the full list — so trying a different
+                # model/provider/endpoint never requires editing this file.
                 extra={
                     "model": os.environ.get("MODEL", "gpt-4o-mini"),
-                    "model_params": {"temperature": 0.2},
+                    "model_params": _model_params_from_env(),
                 },
             )
         ]
@@ -116,6 +175,12 @@ class AssistantWorker(NativeAgentWorker):
 
 async def main() -> None:
     question = " ".join(sys.argv[1:]) or "What is 12 * (7 + 5)?"
+
+    model = os.environ.get("MODEL", "gpt-4o-mini")
+    model_params = _model_params_from_env()
+    params_label = model_params or "(none set)"
+    print(f"model:    {model}")
+    print(f"params:   {params_label}")
 
     redis = InMemoryRedis()
     dispatcher = Dispatcher(redis=redis)

--- a/libs/by-framework-agent/examples/05_real_model_react.py
+++ b/libs/by-framework-agent/examples/05_real_model_react.py
@@ -1,0 +1,151 @@
+"""Example 5: a real model doing ReAct (reason, call a tool, observe, repeat).
+
+Every other example scripts the model's replies with StubModelClient so they
+run offline. This one calls a real provider through litellm's
+LiteLLMModelClient — the harness's *default* ModelClient, so this is really
+just examples/02's tool-calling loop with `model_client=...` removed.
+
+Setup:
+
+    export OPENAI_API_KEY=sk-...        # or ANTHROPIC_API_KEY, etc.
+    export MODEL=gpt-4o-mini            # any litellm model string; see below
+    cd libs/by-framework-agent
+    uv run python examples/05_real_model_react.py "What is 12 * (7 + 5)?"
+
+Switching providers is just the `MODEL` string plus the matching API key env
+var — litellm reads it automatically:
+
+    MODEL=anthropic/claude-3-5-sonnet-20241022   ANTHROPIC_API_KEY=...
+    MODEL=gemini/gemini-2.0-flash                GEMINI_API_KEY=...
+    MODEL=azure/<deployment-name>                AZURE_API_KEY=..., AZURE_API_BASE=...
+
+Redis is still faked (InMemoryRedis, see _infra.py) — only the model call is
+real. A production deployment additionally runs this behind WorkerRunner
+against a real Redis Streams cluster instead of Dispatcher.
+"""
+
+# pylint: disable=invalid-name  # numbered filename for tutorial ordering
+
+import asyncio
+import os
+import sys
+
+from _infra import Dispatcher, InMemoryRedis
+from by_framework.core.extensions.agent_config import AgentConfig
+from by_framework.core.extensions.registry import PluginRegistry
+from by_framework.core.protocol.commands import AskAgentCommand
+from by_framework.core.protocol.message_header import MessageHeader
+from by_framework.core.workspace import WorkspaceManager
+
+from by_framework_agent import NativeAgentWorker, ToolSpec
+
+# Restricted to a handful of safe operators — a real calculator tool would
+# use a proper expression parser instead of eval().
+_ALLOWED_CALC_CHARS = set("0123456789+-*/(). ")
+
+
+async def calculate(context, arguments) -> str:
+    del context
+    expression = str(arguments.get("expression", ""))
+    if not expression or not set(expression) <= _ALLOWED_CALC_CHARS:
+        return "error: expression must be a simple arithmetic expression"
+    try:
+        # Safe here specifically because _ALLOWED_CALC_CHARS above already
+        # rejected anything but digits/operators/parens/spaces — no
+        # identifier characters means no attribute-chain sandbox escape.
+        return str(
+            eval(expression, {"__builtins__": {}}, {})  # pylint: disable=eval-used
+        )
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        return f"error: {exc}"
+
+
+def build_registry() -> PluginRegistry:
+    registry = PluginRegistry()
+    registry._set_agent_configs(  # pylint: disable=protected-access
+        [
+            AgentConfig(
+                agent_id="assistant",
+                name="Assistant",
+                prompts={
+                    "system": (
+                        "You are a careful assistant. For any arithmetic, "
+                        "call the calculate tool instead of computing it "
+                        "yourself, then answer using its result."
+                    )
+                },
+                tools={
+                    "calculate": ToolSpec(
+                        name="calculate",
+                        handler=calculate,
+                        description="Evaluate a simple arithmetic expression.",
+                        parameters={
+                            "type": "object",
+                            "properties": {
+                                "expression": {
+                                    "type": "string",
+                                    "description": "e.g. '12 * (7 + 5)'",
+                                }
+                            },
+                            "required": ["expression"],
+                        },
+                    )
+                },
+                # This is the whole configuration surface for a real model:
+                # - extra["model"]: any litellm model string
+                # - extra["model_params"]: forwarded to every ModelClient.
+                #   complete() call (temperature, max_tokens, api_base, ...)
+                extra={
+                    "model": os.environ.get("MODEL", "gpt-4o-mini"),
+                    "model_params": {"temperature": 0.2},
+                },
+            )
+        ]
+    )
+    return registry
+
+
+class AssistantWorker(NativeAgentWorker):
+
+    def get_agent_types(self) -> list[str]:
+        return ["assistant"]
+
+    # No model_client override here — omitting it entirely (as this worker
+    # does) is what makes NativeAgentWorker default to LiteLLMModelClient.
+
+
+async def main() -> None:
+    question = " ".join(sys.argv[1:]) or "What is 12 * (7 + 5)?"
+
+    redis = InMemoryRedis()
+    dispatcher = Dispatcher(redis=redis)
+    dispatcher.register(
+        "assistant",
+        lambda: AssistantWorker(
+            worker_id="assistant-worker",
+            redis_client=redis,
+            workspace_manager=WorkspaceManager(),
+            plugin_registry=build_registry(),
+        ),
+    )
+
+    command = AskAgentCommand(
+        header=MessageHeader(
+            message_id="msg-1",
+            session_id="session-1",
+            trace_id="trace-1",
+            user_code="user-1",
+            user_name="Alice",
+            target_agent_type="assistant",
+        ),
+        content=question,
+    )
+
+    print(f"question: {question}")
+    result = await dispatcher.dispatch_root(command)
+    print(f"status:   {result.status}")
+    print(f"answer:   {result.content}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/libs/by-framework-agent/examples/05_real_model_react.py
+++ b/libs/by-framework-agent/examples/05_real_model_react.py
@@ -57,7 +57,7 @@ import sys
 from typing import Any
 
 from _infra import Dispatcher, InMemoryRedis
-from by_framework.core.extensions.agent_config import AgentConfig
+from by_framework.core.extensions.agent_config import AgentConfig, CallbackType
 from by_framework.core.extensions.registry import PluginRegistry
 from by_framework.core.protocol.commands import AskAgentCommand
 from by_framework.core.protocol.message_header import MessageHeader
@@ -100,23 +100,50 @@ def _model_params_from_env() -> dict[str, Any]:
     return params
 
 
-async def calculate(context, arguments) -> str:
-    del context
-    expression = str(arguments.get("expression", ""))
-    if not expression or not set(expression) <= _ALLOWED_CALC_CHARS:
-        return "error: expression must be a simple arithmetic expression"
-    try:
-        # Safe here specifically because _ALLOWED_CALC_CHARS above already
-        # rejected anything but digits/operators/parens/spaces — no
-        # identifier characters means no attribute-chain sandbox escape.
-        return str(
-            eval(expression, {"__builtins__": {}}, {})  # pylint: disable=eval-used
-        )
-    except Exception as exc:  # pylint: disable=broad-exception-caught
-        return f"error: {exc}"
+class ReactTelemetry:
+    """Makes it possible to tell "the model computed this itself" apart from
+    "the calculate tool computed this" — the two look identical in the final
+    answer text alone. Wired in as both the tool handler (so a tool
+    invocation is directly observable) and before/after_model_callback (so
+    a second model turn — only reachable after a tool result — is too).
+    """
+
+    def __init__(self) -> None:
+        self.model_turn = 0
+        self.tool_call_count = 0
+
+    async def before_model(self, context, payload) -> None:
+        del context
+        self.model_turn += 1
+        num_messages = len(payload["messages"])
+        print(f"[MODEL TURN {self.model_turn}] sending {num_messages} messages")
+
+    async def after_model(self, context, payload) -> None:
+        del context
+        preview = payload["content"] or "(no text — likely requesting a tool call)"
+        print(f"[MODEL TURN {self.model_turn}] replied: {preview!r}")
+
+    async def calculate(self, context, arguments) -> str:
+        del context
+        expression = str(arguments.get("expression", ""))
+        if not expression or not set(expression) <= _ALLOWED_CALC_CHARS:
+            return "error: expression must be a simple arithmetic expression"
+        try:
+            # Safe here specifically because _ALLOWED_CALC_CHARS above
+            # already rejected anything but digits/operators/parens/spaces —
+            # no identifier characters means no attribute-chain sandbox
+            # escape.
+            result = str(
+                eval(expression, {"__builtins__": {}}, {})  # pylint: disable=eval-used
+            )
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            return f"error: {exc}"
+        self.tool_call_count += 1
+        print(f"[TOOL CALLED] calculate({expression!r}) -> {result}")
+        return result
 
 
-def build_registry() -> PluginRegistry:
+def build_registry(telemetry: ReactTelemetry) -> PluginRegistry:
     registry = PluginRegistry()
     registry._set_agent_configs(  # pylint: disable=protected-access
         [
@@ -133,7 +160,7 @@ def build_registry() -> PluginRegistry:
                 tools={
                     "calculate": ToolSpec(
                         name="calculate",
-                        handler=calculate,
+                        handler=telemetry.calculate,
                         description="Evaluate a simple arithmetic expression.",
                         parameters={
                             "type": "object",
@@ -146,6 +173,10 @@ def build_registry() -> PluginRegistry:
                             "required": ["expression"],
                         },
                     )
+                },
+                callbacks={
+                    CallbackType.before_model_callback: [telemetry.before_model],
+                    CallbackType.after_model_callback: [telemetry.after_model],
                 },
                 # This is the whole configuration surface for a real model:
                 # - extra["model"]: any litellm model string
@@ -182,6 +213,7 @@ async def main() -> None:
     print(f"model:    {model}")
     print(f"params:   {params_label}")
 
+    telemetry = ReactTelemetry()
     redis = InMemoryRedis()
     dispatcher = Dispatcher(redis=redis)
     dispatcher.register(
@@ -190,7 +222,7 @@ async def main() -> None:
             worker_id="assistant-worker",
             redis_client=redis,
             workspace_manager=WorkspaceManager(),
-            plugin_registry=build_registry(),
+            plugin_registry=build_registry(telemetry),
         ),
     )
 
@@ -210,6 +242,22 @@ async def main() -> None:
     result = await dispatcher.dispatch_root(command)
     print(f"status:   {result.status}")
     print(f"answer:   {result.content}")
+    print()
+    print(f"model turns taken:    {telemetry.model_turn}")
+    print(f"calculate tool calls: {telemetry.tool_call_count}")
+    if telemetry.tool_call_count:
+        print(
+            "-> confirmed: the numeric result above came from the calculate "
+            "tool (see the [TOOL CALLED] line above), not the model's own "
+            "arithmetic."
+        )
+    else:
+        print(
+            "-> the calculate tool was never invoked — the model answered "
+            "directly. If the answer is numeric, it computed it itself "
+            "(and may be wrong); try a stricter system prompt or a model "
+            "with better tool-use adherence."
+        )
 
 
 if __name__ == "__main__":

--- a/libs/by-framework-agent/examples/05_real_model_react.py
+++ b/libs/by-framework-agent/examples/05_real_model_react.py
@@ -100,6 +100,26 @@ def _model_params_from_env() -> dict[str, Any]:
     return params
 
 
+_SECRET_PARAM_NAME_MARKERS = ("key", "token", "secret", "password", "authorization")
+
+
+def _redact_secrets(params: dict[str, Any]) -> dict[str, Any]:
+    """Mask any secret-looking param value before it's ever printed/logged —
+    api_key (or anything else from MODEL_PARAMS_JSON with a similarly
+    sensitive name) must never land in plain text in terminal output,
+    shell history, or copy-pasted logs."""
+    redacted: dict[str, Any] = {}
+    for name, value in params.items():
+        looks_secret = any(
+            marker in name.lower() for marker in _SECRET_PARAM_NAME_MARKERS
+        )
+        if looks_secret and isinstance(value, str) and value:
+            redacted[name] = f"{value[:4]}***" if len(value) > 4 else "***"
+        else:
+            redacted[name] = value
+    return redacted
+
+
 class ReactTelemetry:
     """Makes it possible to tell "the model computed this itself" apart from
     "the calculate tool computed this" — the two look identical in the final
@@ -209,7 +229,7 @@ async def main() -> None:
 
     model = os.environ.get("MODEL", "gpt-4o-mini")
     model_params = _model_params_from_env()
-    params_label = model_params or "(none set)"
+    params_label = _redact_secrets(model_params) or "(none set)"
     print(f"model:    {model}")
     print(f"params:   {params_label}")
 

--- a/libs/by-framework-agent/examples/README.md
+++ b/libs/by-framework-agent/examples/README.md
@@ -1,0 +1,37 @@
+# Examples
+
+Four runnable, progressively more complete demos of `NativeAgentWorker`. Each
+is self-contained — no real Redis, no real LLM API key required — using
+`_infra.py`'s `InMemoryRedis` (enough of the Redis surface for
+`AgentContext`/`call_agent`/`call_agents` to work unmodified) and
+`by_framework_agent.testing.StubModelClient` (scripted model turns) in place
+of the real deployment stack.
+
+Run any of them directly:
+
+```bash
+cd libs/by-framework-agent
+uv run python examples/01_basic_chat.py
+```
+
+| File | Demonstrates |
+|---|---|
+| [`01_basic_chat.py`](01_basic_chat.py) | The minimum: an `AgentConfig` with no tools/sub_agents, one model turn. |
+| [`02_tools_and_ask_user.py`](02_tools_and_ask_user.py) | A local `ToolSpec` tool, then the built-in `ask_user` tool suspending the loop — resumed on a **separate** worker instance, proving the suspend/resume state lives in Redis, not process memory. |
+| [`03_agent_delegation.py`](03_agent_delegation.py) | `AgentConfig.sub_agents` auto-registered as a callable tool; a single delegation dispatches via `call_agent`, and `Dispatcher.drain()` plays the role a real Redis Streams cluster would — routing the dispatched command to the sub-agent's own worker and relaying its reply back. |
+| [`04_task_group.py`](04_task_group.py) | One turn delegating to **two** distinct sub-agents at once — per ADR-0001 this batches into a single `call_agents` Task Group dispatch instead of two sequential hops; Group Join resumes the orchestrator exactly once, after both replies are in. |
+
+## What `_infra.py` is (and isn't)
+
+`InMemoryRedis` and `Dispatcher` in [`_infra.py`](_infra.py) are **not** part
+of the `by_framework_agent` public API — they exist purely to make these
+examples runnable in one process with `python examples/NN_*.py`. A real
+deployment runs `NativeAgentWorker` behind `WorkerRunner` against a real
+Redis Streams cluster (see the root `by-framework-python` README/docs for
+`run_worker()`), where competitive consumption across worker processes is
+what `Dispatcher.drain()` stands in for here.
+
+Swapping `StubModelClient` for the default `LiteLLMModelClient` (just omit
+`model_client=...` when constructing your worker) is the only change needed
+to call a real model provider — everything else in these examples is exactly
+how you'd wire a real deployment.

--- a/libs/by-framework-agent/examples/README.md
+++ b/libs/by-framework-agent/examples/README.md
@@ -1,11 +1,14 @@
 # Examples
 
-Four runnable, progressively more complete demos of `NativeAgentWorker`. Each
-is self-contained — no real Redis, no real LLM API key required — using
-`_infra.py`'s `InMemoryRedis` (enough of the Redis surface for
-`AgentContext`/`call_agent`/`call_agents` to work unmodified) and
+Five runnable, progressively more complete demos of `NativeAgentWorker`.
+Examples 1-4 are fully self-contained — no real Redis, no real LLM API key
+required — using `_infra.py`'s `InMemoryRedis` (enough of the Redis surface
+for `AgentContext`/`call_agent`/`call_agents` to work unmodified) and
 `by_framework_agent.testing.StubModelClient` (scripted model turns) in place
-of the real deployment stack.
+of the real deployment stack. Example 5 calls a real model provider (Redis
+is still faked; only the LLM call is real) — see it, or ["Connecting a real
+model"](../README.md#connecting-a-real-model-react) in the package README,
+for how to configure that.
 
 Run any of them directly:
 
@@ -20,6 +23,7 @@ uv run python examples/01_basic_chat.py
 | [`02_tools_and_ask_user.py`](02_tools_and_ask_user.py) | A local `ToolSpec` tool, then the built-in `ask_user` tool suspending the loop — resumed on a **separate** worker instance, proving the suspend/resume state lives in Redis, not process memory. |
 | [`03_agent_delegation.py`](03_agent_delegation.py) | `AgentConfig.sub_agents` auto-registered as a callable tool; a single delegation dispatches via `call_agent`, and `Dispatcher.drain()` plays the role a real Redis Streams cluster would — routing the dispatched command to the sub-agent's own worker and relaying its reply back. |
 | [`04_task_group.py`](04_task_group.py) | One turn delegating to **two** distinct sub-agents at once — per ADR-0001 this batches into a single `call_agents` Task Group dispatch instead of two sequential hops; Group Join resumes the orchestrator exactly once, after both replies are in. |
+| [`05_real_model_react.py`](05_real_model_react.py) | The same tool-calling loop as example 2, but against a **real** model via the default `LiteLLMModelClient` (no `model_client=...` override) — a genuine ReAct loop: reason, call `calculate`, observe, repeat. Needs an API key. |
 
 ## What `_infra.py` is (and isn't)
 

--- a/libs/by-framework-agent/examples/_infra.py
+++ b/libs/by-framework-agent/examples/_infra.py
@@ -1,0 +1,253 @@
+"""Self-contained infra for running these examples with no real Redis and no
+real LLM API key.
+
+Real deployments run `NativeAgentWorker` behind `WorkerRunner` against a real
+Redis Streams cluster, with `LiteLLMModelClient` calling a real provider. To
+keep these examples runnable offline in one process, this module provides:
+
+- `InMemoryRedis` — enough of the Redis surface (`xadd`, `pipeline`, hashes,
+  sets, strings) for `AgentContext`/`call_agent`/`call_agents` to work
+  unmodified, backed by plain Python dicts instead of a real server.
+- `Dispatcher` — a tiny in-process stand-in for the "competitive consume
+  across worker processes" that Redis Streams normally provides: it drains
+  whatever `AskAgentCommand`/`ResumeCommand`s workers dispatched onto control
+  streams and routes each to the right registered worker, tracking which
+  `execution_id` a resume belongs to exactly the way `WorkerRunner` does.
+
+None of this is part of the `by_framework_agent` public API — it exists only
+to make these examples runnable top-to-bottom with `python examples/NN_*.py`.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from by_framework import RunningExecution
+from by_framework.common.constants import RedisKeys
+from by_framework.core.protocol.commands import (
+    GatewayCommand,
+    ResumeCommand,
+    command_from_dict,
+)
+
+
+class _Pipeline:
+
+    def __init__(self, redis: "InMemoryRedis"):
+        self._redis = redis
+        self._ops: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    def xadd(self, stream: str, fields: dict[str, Any], **kwargs: Any) -> "_Pipeline":
+        self._ops.append(("xadd", (stream, fields), kwargs))
+        return self
+
+    def expire(self, key: str, seconds: int) -> "_Pipeline":
+        self._ops.append(("expire", (key, seconds), {}))
+        return self
+
+    def hset(self, key: str, *args: Any, **kwargs: Any) -> "_Pipeline":
+        self._ops.append(("hset", (key, *args), kwargs))
+        return self
+
+    def rpush(self, key: str, value: str) -> "_Pipeline":
+        self._ops.append(("rpush", (key, value), {}))
+        return self
+
+    async def execute(self) -> list[Any]:
+        results = []
+        for name, args, kwargs in self._ops:
+            results.append(await getattr(self._redis, name)(*args, **kwargs))
+        self._ops = []
+        return results
+
+
+class InMemoryRedis:
+    """Just enough Redis to run a NativeAgentWorker without a real server."""
+
+    def __init__(self) -> None:
+        self.strings: dict[str, str] = {}
+        self.hashes: dict[str, dict[str, str]] = {}
+        self.sets: dict[str, set] = {}
+        self.lists: dict[str, list[str]] = {}
+        self.sorted_sets: dict[str, dict[str, float]] = {}
+        self.streams: dict[str, list[dict[str, Any]]] = {}
+
+    async def xadd(self, stream: str, fields: dict[str, Any], **_kwargs: Any) -> str:
+        self.streams.setdefault(stream, []).append(dict(fields))
+        return f"{len(self.streams[stream])}-0"
+
+    async def rpush(self, key: str, value: str) -> int:
+        self.lists.setdefault(key, []).append(value)
+        return len(self.lists[key])
+
+    async def zadd(self, key: str, mapping: dict[str, float]) -> int:
+        self.sorted_sets.setdefault(key, {}).update(mapping)
+        return len(mapping)
+
+    def pipeline(self) -> _Pipeline:
+        return _Pipeline(self)
+
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:
+        del ex
+        self.strings[key] = value
+
+    async def get(self, key: str) -> str | None:
+        return self.strings.get(key)
+
+    async def delete(self, key: str) -> None:
+        self.strings.pop(key, None)
+        self.hashes.pop(key, None)
+        self.sets.pop(key, None)
+
+    async def sadd(self, key: str, *values: str) -> None:
+        self.sets.setdefault(key, set()).update(values)
+
+    async def smembers(self, key: str) -> set:
+        return set(self.sets.get(key, set()))
+
+    async def hset(
+        self,
+        key: str,
+        field: str | None = None,
+        value: Any = None,
+        mapping: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        bucket = self.hashes.setdefault(key, {})
+        if field is not None:
+            bucket[field] = value
+        bucket.update(mapping or kwargs)
+
+    async def hget(self, key: str, field: str) -> str | None:
+        return self.hashes.get(key, {}).get(field)
+
+    async def hgetall(self, key: str) -> dict[str, str]:
+        return dict(self.hashes.get(key, {}))
+
+    async def hincrby(self, key: str, field: str, amount: int = 1) -> int:
+        current = int(self.hashes.get(key, {}).get(field, 0)) + amount
+        self.hashes.setdefault(key, {})[field] = str(current)
+        return current
+
+    async def expire(self, key: str, seconds: int) -> bool:
+        del key, seconds
+        return True
+
+    def mark_agent_type_online(self, agent_type: str, worker_id: str) -> None:
+        """Seed the availability keys AvailabilityRouter checks, so
+        call_agent/call_agents treat `agent_type` as deliverable."""
+        self.sets.setdefault(RedisKeys.agent_type_members(agent_type), set()).add(
+            worker_id
+        )
+        self.strings[RedisKeys.worker_online_lease(worker_id)] = "1"
+
+
+@dataclass
+class Dispatcher:
+    """Routes dispatched commands to registered workers, in-process.
+
+    Stands in for "any of N worker processes might pick this up" — the real
+    property being demonstrated (a suspended loop resumes correctly
+    regardless of which worker instance handles the reply) still holds here:
+    each drained command gets a *fresh* worker instance constructed for it.
+    """
+
+    redis: InMemoryRedis
+    worker_factories: dict[str, "WorkerFactory"] = field(default_factory=dict)
+    _execution_by_message_id: dict[str, str] = field(default_factory=dict)
+
+    def register(self, agent_type: str, factory: "WorkerFactory") -> None:
+        self.worker_factories[agent_type] = factory
+
+    async def dispatch_root(
+        self, command: GatewayCommand, execution_id: str | None = None
+    ) -> Any:
+        """Feed the very first command into its target worker directly."""
+        execution_id = execution_id or f"exec-{uuid.uuid4().hex[:8]}"
+        self._execution_by_message_id[command.header.message_id] = execution_id
+        worker = self.worker_factories[command.header.target_agent_type]()
+        return await worker._handle_message(  # pylint: disable=protected-access
+            command,
+            execution=RunningExecution(
+                execution_id=execution_id,
+                message_id=command.header.message_id,
+                session_id=command.header.session_id,
+                worker_id=f"worker-{uuid.uuid4().hex[:6]}",
+                task=None,  # type: ignore[arg-type]
+                cancel_event=None,  # type: ignore[arg-type]
+            ),
+        )
+
+    async def drain(self) -> list[tuple[str, Any]]:
+        """Process every dispatched command until no new ones remain.
+
+        This is the offline stand-in for N worker processes competitively
+        consuming control streams — here it's just a queue we drain to a
+        fixed point, routing each command to whichever worker owns its
+        target_agent_type and reattaching it to the right execution_id.
+
+        Returns every ``(agent_type, result)`` processed along the way, in
+        order, so a caller can find e.g. the orchestrator's final answer
+        once its Group Join fires.
+        """
+        processed: list[tuple[str, Any]] = []
+        while True:
+            pending = self._pop_all_pending()
+            if not pending:
+                return processed
+            for _, raw in pending:
+                command = command_from_dict(json.loads(raw["data"]))
+                result = await self._route(command)
+                processed.append((command.header.target_agent_type, result))
+
+    _CTRL_STREAM_PREFIX = "byai_gateway:ctrl:"
+
+    def _pop_all_pending(self) -> list[tuple[str, dict[str, Any]]]:
+        """Only control streams carry GatewayCommands — session data streams
+        carry StreamChunkEvent/AskUserEvent wire payloads, not commands."""
+        drained: list[tuple[str, dict[str, Any]]] = []
+        for stream_name, entries in list(self.redis.streams.items()):
+            if not stream_name.startswith(self._CTRL_STREAM_PREFIX):
+                continue
+            while entries:
+                drained.append((stream_name, entries.pop(0)))
+        return drained
+
+    async def _route(self, command: GatewayCommand) -> Any:
+        target_agent_type = command.header.target_agent_type
+        factory = self.worker_factories.get(target_agent_type)
+        if factory is None:
+            raise RuntimeError(f"No worker registered for {target_agent_type!r}")
+
+        if isinstance(command, ResumeCommand):
+            execution_id = self._execution_by_message_id.get(command.header.message_id)
+            if execution_id is None:
+                raise RuntimeError(
+                    "Dispatcher has no execution_id on file for resume "
+                    f"message_id={command.header.message_id!r} — a real "
+                    "WorkerRunner would resolve this via the registry."
+                )
+        else:
+            execution_id = f"exec-{uuid.uuid4().hex[:8]}"
+            self._execution_by_message_id[command.header.message_id] = execution_id
+
+        worker = factory()
+        return await worker._handle_message(  # pylint: disable=protected-access
+            command,
+            execution=RunningExecution(
+                execution_id=execution_id,
+                message_id=command.header.message_id,
+                session_id=command.header.session_id,
+                worker_id=f"worker-{uuid.uuid4().hex[:6]}",
+                task=None,  # type: ignore[arg-type]
+                cancel_event=None,  # type: ignore[arg-type]
+            ),
+        )
+
+
+WorkerFactory = (
+    Any  # Callable[[], GatewayWorker], typed loosely to dodge a generic import cycle
+)

--- a/libs/by-framework-agent/pyproject.toml
+++ b/libs/by-framework-agent/pyproject.toml
@@ -1,0 +1,35 @@
+[project]
+name = "by-framework-agent"
+version = "0.0.1.dev1"
+description = "Native agent harness for by-framework (litellm-backed reasoning loop)"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "by-framework>=0.2.1",
+    "litellm>=1.93.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+    "isort>=5.13.0",
+    "pyink>=24.0.0",
+    "pylint>=3.0.0",
+    "ruff>=0.3.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/by_framework_agent"]
+
+[tool.uv.sources]
+by-framework = { workspace = true }
+
+[tool.pytest.ini_options]
+pythonpath = ["src", "../../src"]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/libs/by-framework-agent/src/by_framework_agent/__init__.py
+++ b/libs/by-framework-agent/src/by_framework_agent/__init__.py
@@ -3,6 +3,7 @@
 from .litellm_client import LiteLLMModelClient
 from .loop import HarnessLoop
 from .model_client import ModelChunk, ModelClient
+from .tool_spec import ToolSpec
 from .worker import NativeAgentWorker
 
 __all__ = [
@@ -11,4 +12,5 @@ __all__ = [
     "ModelChunk",
     "ModelClient",
     "NativeAgentWorker",
+    "ToolSpec",
 ]

--- a/libs/by-framework-agent/src/by_framework_agent/__init__.py
+++ b/libs/by-framework-agent/src/by_framework_agent/__init__.py
@@ -1,0 +1,14 @@
+"""Native agent harness for by-framework."""
+
+from .litellm_client import LiteLLMModelClient
+from .loop import HarnessLoop
+from .model_client import ModelChunk, ModelClient
+from .worker import NativeAgentWorker
+
+__all__ = [
+    "HarnessLoop",
+    "LiteLLMModelClient",
+    "ModelChunk",
+    "ModelClient",
+    "NativeAgentWorker",
+]

--- a/libs/by-framework-agent/src/by_framework_agent/litellm_client.py
+++ b/libs/by-framework-agent/src/by_framework_agent/litellm_client.py
@@ -1,0 +1,85 @@
+"""Default ``ModelClient`` implementation, backed by litellm."""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, cast
+
+import litellm
+from litellm import CustomStreamWrapper
+
+from .model_client import ModelChunk
+
+
+class LiteLLMModelClient:
+    """Wraps ``litellm.acompletion`` behind the harness's ``ModelClient`` seam.
+
+    Any provider litellm supports is usable without new harness code — model
+    selection is entirely a matter of the ``model`` string passed in.
+    """
+
+    async def complete(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        model: str,
+        tools: list[dict[str, Any]] | None = None,
+        **params: Any,
+    ) -> AsyncIterator[ModelChunk]:
+        # litellm's overloads don't discriminate on a runtime `stream=True`
+        # bool, so the return type widens to include the non-streaming
+        # ModelResponse branch; stream=True is passed literally above, so
+        # this is always actually a CustomStreamWrapper at runtime.
+        stream = cast(
+            CustomStreamWrapper,
+            await litellm.acompletion(
+                model=model,
+                messages=messages,
+                tools=tools or None,
+                stream=True,
+                stream_options={"include_usage": True},
+                **params,
+            ),
+        )
+
+        collected_raw_chunks = []
+        async for raw_chunk in stream:
+            collected_raw_chunks.append(raw_chunk)
+            choice = raw_chunk.choices[0] if raw_chunk.choices else None
+            delta = getattr(choice, "delta", None) if choice else None
+            content_delta = getattr(delta, "content", None) if delta else None
+            tool_call_deltas = getattr(delta, "tool_calls", None) if delta else None
+            finish_reason = getattr(choice, "finish_reason", None) if choice else None
+            usage = getattr(raw_chunk, "usage", None)
+
+            yield ModelChunk(
+                content=content_delta or "",
+                tool_call_deltas=[
+                    tool_call.model_dump()
+                    if hasattr(tool_call, "model_dump")
+                    else dict(tool_call)
+                    for tool_call in (tool_call_deltas or [])
+                ],
+                finish_reason=finish_reason or "",
+                is_final=usage is not None,
+                usage={
+                    "prompt_tokens": usage.prompt_tokens,
+                    "completion_tokens": usage.completion_tokens,
+                }
+                if usage
+                else None,
+                model=model,
+            )
+
+        if not collected_raw_chunks:
+            return
+
+        cost = 0.0
+        try:
+            full_response = litellm.stream_chunk_builder(
+                collected_raw_chunks, messages=messages
+            )
+            cost = litellm.completion_cost(completion_response=full_response) or 0.0
+        except Exception:  # pylint: disable=broad-exception-caught
+            cost = 0.0
+
+        yield ModelChunk(is_final=True, cost=cost, model=model)

--- a/libs/by-framework-agent/src/by_framework_agent/loop.py
+++ b/libs/by-framework-agent/src/by_framework_agent/loop.py
@@ -16,8 +16,10 @@ import json
 from dataclasses import dataclass
 from typing import Any
 
+from by_framework.common.constants import HARNESS_STATE_TTL_SECONDS, RedisKeys
 from by_framework.core.extensions.agent_config import AgentConfig, CallbackType
 from by_framework.core.protocol.agent_state import AgentState
+from by_framework.core.protocol.commands import ResumeCommand
 from by_framework.core.protocol.events import StreamChunkEvent
 from by_framework.core.protocol.results import AgentTaskResult
 from by_framework.worker.context import AgentContext
@@ -27,6 +29,25 @@ from .tool_spec import ToolSpec
 
 _HISTORY_LIMIT = 50
 _MESSAGE_ROLES = {"user", "assistant", "system"}
+
+_ASK_USER_TOOL_NAME = "ask_user"
+_ASK_USER_TOOL_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": _ASK_USER_TOOL_NAME,
+        "description": "Ask the human user a question and wait for their reply.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "description": "The question to ask the user.",
+                }
+            },
+            "required": ["prompt"],
+        },
+    },
+}
 
 
 @dataclass
@@ -56,38 +77,164 @@ class HarnessLoop:
 
     async def run(self, context: AgentContext) -> AgentTaskResult:
         tool_specs = self._resolve_tools()
-        tool_schemas = [spec.to_openai_schema() for spec in tool_specs.values()] or None
-        messages = await self._build_messages(context)
+        tool_schemas = [spec.to_openai_schema() for spec in tool_specs.values()]
+        tool_schemas.append(_ASK_USER_TOOL_SCHEMA)
         model = self._resolve_model()
 
-        while True:
-            turn = await self._run_model_turn(context, messages, model, tool_schemas)
+        is_resume = isinstance(context.current_command, ResumeCommand)
+        if is_resume:
+            messages = await self._rehydrate_messages(context)
+        else:
+            messages = await self._build_messages(context)
 
-            if turn.usage or turn.cost:
-                context.record_token_usage(
-                    prompt_tokens=(turn.usage or {}).get("prompt_tokens", 0),
-                    completion_tokens=(turn.usage or {}).get("completion_tokens", 0),
-                    model=turn.model,
-                    cost=turn.cost or None,
+        try:
+            while True:
+                turn = await self._run_model_turn(
+                    context, messages, model, tool_schemas
                 )
 
-            if not turn.tool_calls:
-                return AgentTaskResult(
-                    status=AgentState.COMPLETED.value, content=turn.content
+                if turn.usage or turn.cost:
+                    context.record_token_usage(
+                        prompt_tokens=(turn.usage or {}).get("prompt_tokens", 0),
+                        completion_tokens=(turn.usage or {}).get(
+                            "completion_tokens", 0
+                        ),
+                        model=turn.model,
+                        cost=turn.cost or None,
+                    )
+
+                ask_user_call = next(
+                    (tc for tc in turn.tool_calls if tc.name == _ASK_USER_TOOL_NAME),
+                    None,
+                )
+                if ask_user_call is not None:
+                    await self._suspend_for_ask_user(context, messages, ask_user_call)
+                    return AgentTaskResult(status=AgentState.WAITING_USER.value)
+
+                if not turn.tool_calls:
+                    return AgentTaskResult(
+                        status=AgentState.COMPLETED.value, content=turn.content
+                    )
+
+                messages.append(
+                    self._assistant_tool_call_message(turn.content, turn.tool_calls)
+                )
+                await self._persist_assistant_tool_call_turn(
+                    context, turn.content, turn.tool_calls
                 )
 
-            messages.append(
-                self._assistant_tool_call_message(turn.content, turn.tool_calls)
-            )
-            await self._persist_assistant_tool_call_turn(
-                context, turn.content, turn.tool_calls
+                tool_results = await self._execute_tool_calls(
+                    context, turn.tool_calls, tool_specs
+                )
+                messages.extend(tool_results)
+                await self._persist_tool_result_turns(context, tool_results)
+        except Exception:
+            if context.execution_id:
+                await self._clear_harness_state(context)
+            raise
+
+    async def _suspend_for_ask_user(
+        self,
+        context: AgentContext,
+        messages: list[dict[str, Any]],
+        ask_user_call: _ResolvedToolCall,
+    ) -> None:
+        if not context.execution_id:
+            raise RuntimeError(
+                "NativeAgentWorker requires a tracked execution_id to suspend a "
+                "loop on ask_user — ensure the worker is run via WorkerRunner"
             )
 
-            tool_results = await self._execute_tool_calls(
-                context, turn.tool_calls, tool_specs
+        await self._persist_assistant_tool_call_turn(context, "", [ask_user_call])
+        suspended_messages = messages + [
+            self._assistant_tool_call_message("", [ask_user_call])
+        ]
+        await self._save_harness_state(
+            context,
+            messages=suspended_messages,
+            pending_tool_call_id=ask_user_call.id,
+            pending_tool_name=ask_user_call.name,
+        )
+
+        prompt = ""
+        if isinstance(ask_user_call.arguments, dict):
+            prompt = str(ask_user_call.arguments.get("prompt", ""))
+        await context.ask_user(prompt)
+
+    async def _rehydrate_messages(self, context: AgentContext) -> list[dict[str, Any]]:
+        if not context.execution_id:
+            raise RuntimeError(
+                "NativeAgentWorker requires a tracked execution_id to resume a "
+                "suspended loop — ensure the worker is run via WorkerRunner"
             )
-            messages.extend(tool_results)
-            await self._persist_tool_result_turns(context, tool_results)
+
+        state = await self._load_harness_state(context)
+        if state is None:
+            raise RuntimeError(
+                "Received a resume for execution_id="
+                f"{context.execution_id!r} but no harness loop state was found "
+                "(stray or expired resume)"
+            )
+        await self._clear_harness_state(context)
+
+        messages = state["messages"]
+        tool_result = {
+            "role": "tool",
+            "tool_call_id": state["pending_tool_call_id"],
+            "name": state["pending_tool_name"],
+            "content": self._extract_resume_reply(context.current_command),
+        }
+        messages.append(tool_result)
+        await self._persist_tool_result_turns(context, [tool_result])
+        return messages
+
+    @staticmethod
+    def _extract_resume_reply(command: Any) -> str:
+        content = getattr(command, "content", "") or ""
+        if content:
+            return (
+                content
+                if isinstance(content, str)
+                else json.dumps(content, ensure_ascii=False)
+            )
+        reply_data = getattr(command, "reply_data", None)
+        if reply_data is not None:
+            return (
+                reply_data
+                if isinstance(reply_data, str)
+                else json.dumps(reply_data, ensure_ascii=False)
+            )
+        return ""
+
+    async def _save_harness_state(
+        self,
+        context: AgentContext,
+        *,
+        messages: list[dict[str, Any]],
+        pending_tool_call_id: str,
+        pending_tool_name: str,
+    ) -> None:
+        key = RedisKeys.harness_state(context.execution_id)
+        payload = json.dumps(
+            {
+                "messages": messages,
+                "pending_tool_call_id": pending_tool_call_id,
+                "pending_tool_name": pending_tool_name,
+            },
+            ensure_ascii=False,
+        )
+        await context.redis.set(key, payload, ex=HARNESS_STATE_TTL_SECONDS)
+
+    async def _load_harness_state(self, context: AgentContext) -> dict[str, Any] | None:
+        key = RedisKeys.harness_state(context.execution_id)
+        raw = await context.redis.get(key)
+        if raw is None:
+            return None
+        return json.loads(raw)
+
+    async def _clear_harness_state(self, context: AgentContext) -> None:
+        key = RedisKeys.harness_state(context.execution_id)
+        await context.redis.delete(key)
 
     async def _run_model_turn(
         self,

--- a/libs/by-framework-agent/src/by_framework_agent/loop.py
+++ b/libs/by-framework-agent/src/by_framework_agent/loop.py
@@ -118,27 +118,35 @@ class HarnessLoop:
                         status=AgentState.COMPLETED.value, content=turn.content
                     )
 
-                sub_agent_call = next(
-                    (tc for tc in turn.tool_calls if tc.name in sub_agent_ids), None
-                )
-                local_calls = (
-                    [tc for tc in turn.tool_calls if tc is not sub_agent_call]
-                    if sub_agent_call is not None
-                    else turn.tool_calls
-                )
+                sub_agent_calls = [
+                    tc for tc in turn.tool_calls if tc.name in sub_agent_ids
+                ]
+                local_calls = [
+                    tc for tc in turn.tool_calls if tc not in sub_agent_calls
+                ]
                 tool_results = (
                     await self._execute_tool_calls(context, local_calls, tool_specs)
                     if local_calls
                     else []
                 )
 
-                if sub_agent_call is not None:
-                    dispatch_error = await self._dispatch_sub_agent_call(
-                        context, messages, turn, sub_agent_call, tool_results
+                if len(sub_agent_calls) == 1:
+                    dispatch_errors = await self._dispatch_sub_agent_call(
+                        context, messages, turn, sub_agent_calls[0], tool_results
                     )
-                    if dispatch_error is None:
+                    if dispatch_errors is None:
                         return AgentTaskResult(status=AgentState.QUEUED.value)
-                    tool_results.append(dispatch_error)
+                    tool_results.extend(dispatch_errors)
+                elif len(sub_agent_calls) > 1:
+                    # Per ADR-0001's call_agent/call_agents unification: a turn
+                    # with multiple sub-agent calls fans out as one Task Group
+                    # dispatch rather than sequential call_agent hops.
+                    dispatch_errors = await self._dispatch_sub_agent_task_group(
+                        context, messages, turn, sub_agent_calls, tool_results
+                    )
+                    if dispatch_errors is None:
+                        return AgentTaskResult(status=AgentState.QUEUED.value)
+                    tool_results.extend(dispatch_errors)
 
                 messages.append(
                     self._assistant_tool_call_message(turn.content, turn.tool_calls)
@@ -159,11 +167,7 @@ class HarnessLoop:
         messages: list[dict[str, Any]],
         ask_user_call: _ResolvedToolCall,
     ) -> None:
-        if not context.execution_id:
-            raise RuntimeError(
-                "NativeAgentWorker requires a tracked execution_id to suspend a "
-                "loop on ask_user — ensure the worker is run via WorkerRunner"
-            )
+        self._require_execution_id(context, "ask_user")
 
         await self._persist_assistant_tool_call_turn(context, "", [ask_user_call])
         suspended_messages = messages + [
@@ -172,8 +176,9 @@ class HarnessLoop:
         await self._save_harness_state(
             context,
             messages=suspended_messages,
-            pending_tool_call_id=ask_user_call.id,
-            pending_tool_name=ask_user_call.name,
+            pending=[
+                {"tool_call_id": ask_user_call.id, "tool_name": ask_user_call.name}
+            ],
         )
 
         prompt = ""
@@ -200,25 +205,18 @@ class HarnessLoop:
         turn: _ModelTurn,
         sub_agent_call: _ResolvedToolCall,
         sibling_results: list[dict[str, Any]],
-    ) -> dict[str, Any] | None:
-        """Delegate to a sub-agent via call_agent.
+    ) -> list[dict[str, Any]] | None:
+        """Delegate to a single sub-agent via call_agent.
 
         On success, persists the suspended loop state and returns None — the
         caller returns QUEUED without falling through. On dispatch failure
-        (e.g. the sub-agent type has no online worker), returns a tool-error
-        result for the caller to fold into the normal turn continuation
+        (e.g. the sub-agent type has no online worker), returns tool-error
+        result(s) for the caller to fold into the normal turn continuation
         instead of suspending.
         """
-        if not context.execution_id:
-            raise RuntimeError(
-                "NativeAgentWorker requires a tracked execution_id to suspend "
-                "a loop on an agent-as-tool call — ensure the worker is run "
-                "via WorkerRunner"
-            )
+        self._require_execution_id(context, "an agent-as-tool call")
 
-        content = ""
-        if isinstance(sub_agent_call.arguments, dict):
-            content = str(sub_agent_call.arguments.get("content", ""))
+        content = _tool_call_content_argument(sub_agent_call)
 
         dispatch_result = await context.call_agent(
             target_agent_type=sub_agent_call.name,
@@ -227,29 +225,97 @@ class HarnessLoop:
         )
         if dispatch_result.get("status") != AgentState.QUEUED.value:
             dispatch_error = dispatch_result.get("error") or "unavailable"
-            return _tool_error_message(
-                sub_agent_call,
-                f"Failed to dispatch to sub-agent {sub_agent_call.name!r}: "
-                f"{dispatch_error}",
-            )
+            return [
+                _tool_error_message(
+                    sub_agent_call,
+                    f"Failed to dispatch to sub-agent {sub_agent_call.name!r}: "
+                    f"{dispatch_error}",
+                )
+            ]
 
+        await self._persist_suspended_turn(context, turn, sibling_results)
+        await self._save_harness_state(
+            context,
+            messages=messages
+            + [self._assistant_tool_call_message(turn.content, turn.tool_calls)]
+            + sibling_results,
+            pending=[
+                {"tool_call_id": sub_agent_call.id, "tool_name": sub_agent_call.name}
+            ],
+        )
+        return None
+
+    async def _dispatch_sub_agent_task_group(
+        self,
+        context: AgentContext,
+        messages: list[dict[str, Any]],
+        turn: _ModelTurn,
+        sub_agent_calls: list[_ResolvedToolCall],
+        sibling_results: list[dict[str, Any]],
+    ) -> list[dict[str, Any]] | None:
+        """Delegate to multiple sub-agents at once as a single Task Group.
+
+        On success, persists the suspended loop state (with one pending
+        entry per sub-agent call) and returns None. Group Join — already
+        handled by GatewayWorker — resumes this loop exactly once, with
+        every sub-agent's result available together. On a genuine
+        dispatch-time failure (call_agents raises — an aborted fan-out, not
+        an individual unavailable target, which call_agents already turns
+        into a FAILED per-task result instead of raising), returns
+        tool-error results for every sub-agent call so the loop continues.
+        """
+        self._require_execution_id(context, "a multi-target agent-as-tool call")
+
+        tasks = [
+            {
+                "target_agent_type": call.name,
+                "content": _tool_call_content_argument(call),
+            }
+            for call in sub_agent_calls
+        ]
+
+        try:
+            await context.call_agents(tasks, wait_for_reply=True)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            return [
+                _tool_error_message(
+                    call, f"Failed to dispatch Task Group to sub-agents: {exc}"
+                )
+                for call in sub_agent_calls
+            ]
+
+        await self._persist_suspended_turn(context, turn, sibling_results)
+        await self._save_harness_state(
+            context,
+            messages=messages
+            + [self._assistant_tool_call_message(turn.content, turn.tool_calls)]
+            + sibling_results,
+            pending=[
+                {"tool_call_id": call.id, "tool_name": call.name}
+                for call in sub_agent_calls
+            ],
+        )
+        return None
+
+    async def _persist_suspended_turn(
+        self,
+        context: AgentContext,
+        turn: _ModelTurn,
+        sibling_results: list[dict[str, Any]],
+    ) -> None:
         await self._persist_assistant_tool_call_turn(
             context, turn.content, turn.tool_calls
         )
         if sibling_results:
             await self._persist_tool_result_turns(context, sibling_results)
-        suspended_messages = (
-            messages
-            + [self._assistant_tool_call_message(turn.content, turn.tool_calls)]
-            + sibling_results
-        )
-        await self._save_harness_state(
-            context,
-            messages=suspended_messages,
-            pending_tool_call_id=sub_agent_call.id,
-            pending_tool_name=sub_agent_call.name,
-        )
-        return None
+
+    @staticmethod
+    def _require_execution_id(context: AgentContext, action: str) -> None:
+        if not context.execution_id:
+            raise RuntimeError(
+                f"NativeAgentWorker requires a tracked execution_id to suspend "
+                f"a loop on {action} — ensure the worker is run via WorkerRunner"
+            )
 
     async def _rehydrate_messages(self, context: AgentContext) -> list[dict[str, Any]]:
         if not context.execution_id:
@@ -268,14 +334,27 @@ class HarnessLoop:
         await self._clear_harness_state(context)
 
         messages = state["messages"]
-        tool_result = {
-            "role": "tool",
-            "tool_call_id": state["pending_tool_call_id"],
-            "name": state["pending_tool_name"],
-            "content": self._extract_resume_reply(context.current_command),
-        }
-        messages.append(tool_result)
-        await self._persist_tool_result_turns(context, [tool_result])
+        pending = state["pending"]
+
+        if len(pending) == 1:
+            tool_results = [
+                {
+                    "role": "tool",
+                    "tool_call_id": pending[0]["tool_call_id"],
+                    "name": pending[0]["tool_name"],
+                    "content": self._extract_resume_reply(context.current_command),
+                }
+            ]
+        else:
+            # Only a Task Group dispatch ever saves >1 pending entries, and
+            # GatewayWorker's Group Join only calls process_command once
+            # every sibling has replied, with the aggregate on reply_data.
+            tool_results = _map_group_results_to_tool_calls(
+                context.current_command, pending
+            )
+
+        messages.extend(tool_results)
+        await self._persist_tool_result_turns(context, tool_results)
         return messages
 
     @staticmethod
@@ -301,16 +380,11 @@ class HarnessLoop:
         context: AgentContext,
         *,
         messages: list[dict[str, Any]],
-        pending_tool_call_id: str,
-        pending_tool_name: str,
+        pending: list[dict[str, str]],
     ) -> None:
         key = RedisKeys.harness_state(context.execution_id)
         payload = json.dumps(
-            {
-                "messages": messages,
-                "pending_tool_call_id": pending_tool_call_id,
-                "pending_tool_name": pending_tool_name,
-            },
+            {"messages": messages, "pending": pending},
             ensure_ascii=False,
         )
         await context.redis.set(key, payload, ex=HARNESS_STATE_TTL_SECONDS)
@@ -619,3 +693,83 @@ def _sub_agent_tool_schema(sub_agent_id: str, description: str) -> dict[str, Any
             },
         },
     }
+
+
+def _tool_call_content_argument(call: _ResolvedToolCall) -> str:
+    if isinstance(call.arguments, dict):
+        return str(call.arguments.get("content", ""))
+    return ""
+
+
+def _map_group_results_to_tool_calls(
+    command: Any, pending: list[dict[str, str]]
+) -> list[dict[str, Any]]:
+    """Map a Task Group's aggregated reply_data back to each pending tool_call_id.
+
+    Each aggregate entry carries ``target_agent_type`` — the sub-agent that
+    produced it — which correlates 1:1 with the ``tool_name`` recorded for
+    each pending call at suspend time (a turn dispatches at most one call
+    per distinct sub-agent type).
+    """
+    aggregated = getattr(command, "reply_data", None) or []
+    tool_call_id_by_agent_type = {
+        entry["tool_name"]: entry["tool_call_id"] for entry in pending
+    }
+
+    results: list[dict[str, Any]] = []
+    seen_agent_types: set[str] = set()
+    for result in aggregated:
+        agent_type = result.get("target_agent_type", "")
+        tool_call_id = tool_call_id_by_agent_type.get(agent_type)
+        if tool_call_id is None:
+            continue
+        seen_agent_types.add(agent_type)
+        results.append(
+            {
+                "role": "tool",
+                "tool_call_id": tool_call_id,
+                "name": agent_type,
+                "content": _extract_group_member_reply(result),
+            }
+        )
+
+    # Every pending call should appear in the aggregate once Group Join
+    # fires (it only fires once `completed == total`) — but fail loudly
+    # with a visible error message instead of silently dropping the
+    # tool_call_id from the conversation if one is somehow missing.
+    for entry in pending:
+        if entry["tool_name"] not in seen_agent_types:
+            results.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": entry["tool_call_id"],
+                    "name": entry["tool_name"],
+                    "content": json.dumps(
+                        {"error": "no result received for this sub-agent call"},
+                        ensure_ascii=False,
+                    ),
+                }
+            )
+    return results
+
+
+def _extract_group_member_reply(result: dict[str, Any]) -> str:
+    if result.get("status") == "FAILED":
+        error = result.get("error") or "sub-agent call failed"
+        return json.dumps({"error": error}, ensure_ascii=False)
+
+    content = result.get("content") or ""
+    if content:
+        return (
+            content
+            if isinstance(content, str)
+            else json.dumps(content, ensure_ascii=False)
+        )
+    reply_data = result.get("reply_data")
+    if reply_data is not None:
+        return (
+            reply_data
+            if isinstance(reply_data, str)
+            else json.dumps(reply_data, ensure_ascii=False)
+        )
+    return ""

--- a/libs/by-framework-agent/src/by_framework_agent/loop.py
+++ b/libs/by-framework-agent/src/by_framework_agent/loop.py
@@ -1,15 +1,19 @@
 """The harness's turn-execution loop.
 
-Slice 1 scope: a single model turn (no tool calling yet — that's Slice 2).
-Assembles messages from the existing history backend and ``AgentConfig``
-prompts, streams the model's reply through the existing ``emit_chunk``/
-``StreamChunkEvent`` path, and records token usage/cost through the existing
-``record_token_usage`` accumulator.
+Runs a full tool-calling loop for a given ``AgentConfig``: assemble
+messages from the existing history backend and prompts, stream the model's
+reply through the existing ``emit_chunk``/``StreamChunkEvent`` path, execute
+any local tools the model requests (concurrently, within one turn), append
+their results, and call the model again — repeating until a turn returns no
+tool calls.
 """
 
 from __future__ import annotations
 
+import asyncio
 import inspect
+import json
+from dataclasses import dataclass
 from typing import Any
 
 from by_framework.core.extensions.agent_config import AgentConfig, CallbackType
@@ -19,35 +23,97 @@ from by_framework.core.protocol.results import AgentTaskResult
 from by_framework.worker.context import AgentContext
 
 from .model_client import ModelClient
+from .tool_spec import ToolSpec
 
 _HISTORY_LIMIT = 50
 _MESSAGE_ROLES = {"user", "assistant", "system"}
 
 
+@dataclass
+class _ResolvedToolCall:
+    id: str
+    name: str
+    arguments: dict[str, Any]
+    raw_arguments: str
+    parse_error: str = ""
+
+
+@dataclass
+class _ModelTurn:
+    content: str
+    tool_calls: list[_ResolvedToolCall]
+    usage: dict[str, int] | None
+    cost: float
+    model: str
+
+
 class HarnessLoop:
-    """Runs one native-agent turn for a given ``AgentConfig``."""
+    """Runs one native-agent execution (a tool-calling loop) for an ``AgentConfig``."""
 
     def __init__(self, model_client: ModelClient, agent_config: AgentConfig):
         self._model_client = model_client
         self._agent_config = agent_config
 
     async def run(self, context: AgentContext) -> AgentTaskResult:
+        tool_specs = self._resolve_tools()
+        tool_schemas = [spec.to_openai_schema() for spec in tool_specs.values()] or None
         messages = await self._build_messages(context)
         model = self._resolve_model()
 
+        while True:
+            turn = await self._run_model_turn(context, messages, model, tool_schemas)
+
+            if turn.usage or turn.cost:
+                context.record_token_usage(
+                    prompt_tokens=(turn.usage or {}).get("prompt_tokens", 0),
+                    completion_tokens=(turn.usage or {}).get("completion_tokens", 0),
+                    model=turn.model,
+                    cost=turn.cost or None,
+                )
+
+            if not turn.tool_calls:
+                return AgentTaskResult(
+                    status=AgentState.COMPLETED.value, content=turn.content
+                )
+
+            messages.append(
+                self._assistant_tool_call_message(turn.content, turn.tool_calls)
+            )
+            await self._persist_assistant_tool_call_turn(
+                context, turn.content, turn.tool_calls
+            )
+
+            tool_results = await self._execute_tool_calls(
+                context, turn.tool_calls, tool_specs
+            )
+            messages.extend(tool_results)
+            await self._persist_tool_result_turns(context, tool_results)
+
+    async def _run_model_turn(
+        self,
+        context: AgentContext,
+        messages: list[dict[str, Any]],
+        model: str,
+        tool_schemas: list[dict[str, Any]] | None,
+    ) -> _ModelTurn:
         await self._fire_callbacks(
             CallbackType.before_model_callback, context, {"messages": messages}
         )
 
         content_parts: list[str] = []
+        tool_call_accumulator: dict[int, dict[str, str]] = {}
         usage: dict[str, int] | None = None
         cost = 0.0
         response_model = model
 
-        async for chunk in self._model_client.complete(messages, model=model):
+        async for chunk in self._model_client.complete(
+            messages, model=model, tools=tool_schemas
+        ):
             if chunk.content:
                 content_parts.append(chunk.content)
                 await context.emit_chunk(StreamChunkEvent(content=chunk.content))
+            if chunk.tool_call_deltas:
+                _merge_tool_call_deltas(tool_call_accumulator, chunk.tool_call_deltas)
             if chunk.is_final:
                 usage = chunk.usage or usage
                 response_model = chunk.model or response_model
@@ -55,21 +121,126 @@ class HarnessLoop:
 
         full_content = "".join(content_parts)
 
-        if usage or cost:
-            context.record_token_usage(
-                prompt_tokens=(usage or {}).get("prompt_tokens", 0),
-                completion_tokens=(usage or {}).get("completion_tokens", 0),
-                model=response_model,
-                cost=cost or None,
-            )
-
         await self._fire_callbacks(
             CallbackType.after_model_callback,
             context,
             {"content": full_content, "usage": usage, "cost": cost},
         )
 
-        return AgentTaskResult(status=AgentState.COMPLETED.value, content=full_content)
+        tool_calls = (
+            _finalize_tool_calls(tool_call_accumulator) if tool_call_accumulator else []
+        )
+        return _ModelTurn(
+            content=full_content,
+            tool_calls=tool_calls,
+            usage=usage,
+            cost=cost,
+            model=response_model,
+        )
+
+    async def _execute_tool_calls(
+        self,
+        context: AgentContext,
+        tool_calls: list[_ResolvedToolCall],
+        tool_specs: dict[str, ToolSpec],
+    ) -> list[dict[str, Any]]:
+        return await asyncio.gather(
+            *(
+                self._execute_one_tool_call(context, call, tool_specs)
+                for call in tool_calls
+            )
+        )
+
+    async def _execute_one_tool_call(
+        self,
+        context: AgentContext,
+        call: _ResolvedToolCall,
+        tool_specs: dict[str, ToolSpec],
+    ) -> dict[str, Any]:
+        if call.parse_error:
+            return _tool_error_message(
+                call, f"Invalid JSON arguments: {call.parse_error}"
+            )
+
+        spec = tool_specs.get(call.name)
+        if spec is None:
+            return _tool_error_message(call, f"Unknown tool: {call.name!r}")
+
+        try:
+            await self._fire_callbacks(
+                CallbackType.before_tool_callback, context, {"tool_call": call}
+            )
+            result = await spec.handler(context, call.arguments)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            return _tool_error_message(call, str(exc))
+
+        content = (
+            result
+            if isinstance(result, str)
+            else json.dumps(result, ensure_ascii=False)
+        )
+        await self._fire_callbacks(
+            CallbackType.after_tool_callback,
+            context,
+            {"tool_call": call, "result": content},
+        )
+        return {
+            "role": "tool",
+            "tool_call_id": call.id,
+            "name": call.name,
+            "content": content,
+        }
+
+    async def _persist_assistant_tool_call_turn(
+        self,
+        context: AgentContext,
+        content: str,
+        tool_calls: list[_ResolvedToolCall],
+    ) -> None:
+        history = context.agent_runtime_state.session_manager.history
+        payload_content = content or json.dumps(
+            {
+                "tool_calls": [
+                    {"name": tc.name, "arguments": tc.arguments} for tc in tool_calls
+                ]
+            },
+            ensure_ascii=False,
+        )
+        await history.save_message(
+            role="assistant",
+            content=payload_content,
+            metadata={
+                "tool_calls": [
+                    {"id": tc.id, "name": tc.name, "arguments": tc.arguments}
+                    for tc in tool_calls
+                ]
+            },
+        )
+
+    async def _persist_tool_result_turns(
+        self, context: AgentContext, tool_results: list[dict[str, Any]]
+    ) -> None:
+        history = context.agent_runtime_state.session_manager.history
+        for result in tool_results:
+            await history.save_message(
+                role="tool",
+                content=result["content"],
+                metadata={
+                    "tool_call_id": result["tool_call_id"],
+                    "name": result["name"],
+                },
+            )
+
+    def _resolve_tools(self) -> dict[str, ToolSpec]:
+        resolved: dict[str, ToolSpec] = {}
+        for key, spec in self._agent_config.tools.items():
+            if not isinstance(spec, ToolSpec):
+                raise TypeError(
+                    f"AgentConfig.tools[{key!r}] must be a ToolSpec, "
+                    f"got {type(spec).__name__}"
+                )
+            resolved[spec.name] = spec
+        return resolved
 
     async def _build_messages(self, context: AgentContext) -> list[dict[str, Any]]:
         messages: list[dict[str, Any]] = []
@@ -118,3 +289,75 @@ class HarnessLoop:
             result = callback(context, payload)
             if inspect.isawaitable(result):
                 await result
+
+    @staticmethod
+    def _assistant_tool_call_message(
+        content: str, tool_calls: list[_ResolvedToolCall]
+    ) -> dict[str, Any]:
+        return {
+            "role": "assistant",
+            "content": content or None,
+            "tool_calls": [
+                {
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {"name": tc.name, "arguments": tc.raw_arguments},
+                }
+                for tc in tool_calls
+            ],
+        }
+
+
+def _merge_tool_call_deltas(
+    accumulator: dict[int, dict[str, str]], deltas: list[dict[str, Any]]
+) -> None:
+    """Fold streamed tool-call fragments into per-index accumulators.
+
+    Mirrors OpenAI/litellm's incremental tool-call delta shape: each delta
+    carries an ``index`` plus whichever of ``id``/``function.name``/
+    ``function.arguments`` arrived in this fragment.
+    """
+    for delta in deltas:
+        index = delta.get("index", 0)
+        entry = accumulator.setdefault(index, {"id": "", "name": "", "arguments": ""})
+        if delta.get("id"):
+            entry["id"] = delta["id"]
+        function = delta.get("function") or {}
+        if function.get("name"):
+            entry["name"] += function["name"]
+        if function.get("arguments"):
+            entry["arguments"] += function["arguments"]
+
+
+def _finalize_tool_calls(
+    accumulator: dict[int, dict[str, str]],
+) -> list[_ResolvedToolCall]:
+    resolved: list[_ResolvedToolCall] = []
+    for index in sorted(accumulator):
+        entry = accumulator[index]
+        raw_arguments = entry["arguments"] or "{}"
+        try:
+            arguments = json.loads(raw_arguments) if raw_arguments.strip() else {}
+            parse_error = ""
+        except json.JSONDecodeError as exc:
+            arguments = {}
+            parse_error = str(exc)
+        resolved.append(
+            _ResolvedToolCall(
+                id=entry["id"] or f"call_{index}",
+                name=entry["name"],
+                arguments=arguments,
+                raw_arguments=raw_arguments,
+                parse_error=parse_error,
+            )
+        )
+    return resolved
+
+
+def _tool_error_message(call: _ResolvedToolCall, error: str) -> dict[str, Any]:
+    return {
+        "role": "tool",
+        "tool_call_id": call.id,
+        "name": call.name,
+        "content": json.dumps({"error": error}, ensure_ascii=False),
+    }

--- a/libs/by-framework-agent/src/by_framework_agent/loop.py
+++ b/libs/by-framework-agent/src/by_framework_agent/loop.py
@@ -177,7 +177,11 @@ class HarnessLoop:
             context,
             messages=suspended_messages,
             pending=[
-                {"tool_call_id": ask_user_call.id, "tool_name": ask_user_call.name}
+                {
+                    "tool_call_id": ask_user_call.id,
+                    "tool_name": ask_user_call.name,
+                    "message_id": "",
+                }
             ],
         )
 
@@ -233,14 +237,17 @@ class HarnessLoop:
                 )
             ]
 
-        await self._persist_suspended_turn(context, turn, sibling_results)
-        await self._save_harness_state(
+        await self._suspend_turn(
             context,
-            messages=messages
-            + [self._assistant_tool_call_message(turn.content, turn.tool_calls)]
-            + sibling_results,
+            messages,
+            turn,
+            sibling_results,
             pending=[
-                {"tool_call_id": sub_agent_call.id, "tool_name": sub_agent_call.name}
+                {
+                    "tool_call_id": sub_agent_call.id,
+                    "tool_name": sub_agent_call.name,
+                    "message_id": dispatch_result.get("message_id", ""),
+                }
             ],
         )
         return None
@@ -275,7 +282,7 @@ class HarnessLoop:
         ]
 
         try:
-            await context.call_agents(tasks, wait_for_reply=True)
+            dispatch_result = await context.call_agents(tasks, wait_for_reply=True)
         except Exception as exc:  # pylint: disable=broad-exception-caught
             return [
                 _tool_error_message(
@@ -284,30 +291,54 @@ class HarnessLoop:
                 for call in sub_agent_calls
             ]
 
-        await self._persist_suspended_turn(context, turn, sibling_results)
-        await self._save_harness_state(
+        # dispatched_tasks is ordered identically to `tasks` above, and each
+        # entry's message_id is what Group Join later keys aggregated
+        # results by (see worker.py) — target_agent_type alone would collide
+        # if a turn ever dispatches the same sub-agent type twice.
+        dispatched_tasks = dispatch_result.get("dispatched_tasks", [])
+        await self._suspend_turn(
             context,
-            messages=messages
-            + [self._assistant_tool_call_message(turn.content, turn.tool_calls)]
-            + sibling_results,
+            messages,
+            turn,
+            sibling_results,
             pending=[
-                {"tool_call_id": call.id, "tool_name": call.name}
-                for call in sub_agent_calls
+                {
+                    "tool_call_id": call.id,
+                    "tool_name": call.name,
+                    "message_id": dispatched.get("message_id", ""),
+                }
+                for call, dispatched in zip(sub_agent_calls, dispatched_tasks)
             ],
         )
         return None
 
-    async def _persist_suspended_turn(
+    async def _suspend_turn(
         self,
         context: AgentContext,
+        messages: list[dict[str, Any]],
         turn: _ModelTurn,
         sibling_results: list[dict[str, Any]],
+        *,
+        pending: list[dict[str, str]],
     ) -> None:
+        """Persist a turn's assistant/tool history and harness_state together.
+
+        Shared tail for both single-target and Task Group dispatch: once the
+        dispatch itself has succeeded, both suspend the same way — only
+        ``pending``'s cardinality differs.
+        """
         await self._persist_assistant_tool_call_turn(
             context, turn.content, turn.tool_calls
         )
         if sibling_results:
             await self._persist_tool_result_turns(context, sibling_results)
+        await self._save_harness_state(
+            context,
+            messages=messages
+            + [self._assistant_tool_call_message(turn.content, turn.tool_calls)]
+            + sibling_results,
+            pending=pending,
+        )
 
     @staticmethod
     def _require_execution_id(context: AgentContext, action: str) -> None:
@@ -359,21 +390,10 @@ class HarnessLoop:
 
     @staticmethod
     def _extract_resume_reply(command: Any) -> str:
-        content = getattr(command, "content", "") or ""
-        if content:
-            return (
-                content
-                if isinstance(content, str)
-                else json.dumps(content, ensure_ascii=False)
-            )
-        reply_data = getattr(command, "reply_data", None)
-        if reply_data is not None:
-            return (
-                reply_data
-                if isinstance(reply_data, str)
-                else json.dumps(reply_data, ensure_ascii=False)
-            )
-        return ""
+        return _stringify_reply(
+            getattr(command, "content", "") or "",
+            getattr(command, "reply_data", None),
+        )
 
     async def _save_harness_state(
         self,
@@ -706,29 +726,28 @@ def _map_group_results_to_tool_calls(
 ) -> list[dict[str, Any]]:
     """Map a Task Group's aggregated reply_data back to each pending tool_call_id.
 
-    Each aggregate entry carries ``target_agent_type`` — the sub-agent that
-    produced it — which correlates 1:1 with the ``tool_name`` recorded for
-    each pending call at suspend time (a turn dispatches at most one call
-    per distinct sub-agent type).
+    Correlates by the dispatch-time ``message_id`` recorded on each pending
+    entry — the same unique-per-task key Group Join itself uses to key the
+    results hash (see worker.py) — NOT by ``target_agent_type``, which
+    collides if a single turn ever dispatches the same sub-agent type more
+    than once.
     """
     aggregated = getattr(command, "reply_data", None) or []
-    tool_call_id_by_agent_type = {
-        entry["tool_name"]: entry["tool_call_id"] for entry in pending
-    }
+    pending_by_message_id = {entry["message_id"]: entry for entry in pending}
 
     results: list[dict[str, Any]] = []
-    seen_agent_types: set[str] = set()
+    seen_message_ids: set[str] = set()
     for result in aggregated:
-        agent_type = result.get("target_agent_type", "")
-        tool_call_id = tool_call_id_by_agent_type.get(agent_type)
-        if tool_call_id is None:
+        message_id = result.get("message_id", "")
+        entry = pending_by_message_id.get(message_id)
+        if entry is None:
             continue
-        seen_agent_types.add(agent_type)
+        seen_message_ids.add(message_id)
         results.append(
             {
                 "role": "tool",
-                "tool_call_id": tool_call_id,
-                "name": agent_type,
+                "tool_call_id": entry["tool_call_id"],
+                "name": entry["tool_name"],
                 "content": _extract_group_member_reply(result),
             }
         )
@@ -738,7 +757,7 @@ def _map_group_results_to_tool_calls(
     # with a visible error message instead of silently dropping the
     # tool_call_id from the conversation if one is somehow missing.
     for entry in pending:
-        if entry["tool_name"] not in seen_agent_types:
+        if entry["message_id"] not in seen_message_ids:
             results.append(
                 {
                     "role": "tool",
@@ -758,14 +777,20 @@ def _extract_group_member_reply(result: dict[str, Any]) -> str:
         error = result.get("error") or "sub-agent call failed"
         return json.dumps({"error": error}, ensure_ascii=False)
 
-    content = result.get("content") or ""
+    return _stringify_reply(result.get("content") or "", result.get("reply_data"))
+
+
+def _stringify_reply(content: str, reply_data: Any) -> str:
+    """Prefer ``content``, fall back to ``reply_data``, both JSON-encoded if
+    not already a string. Shared by single-reply and Task Group correlation
+    — both need the same "what did the other side actually say" extraction.
+    """
     if content:
         return (
             content
             if isinstance(content, str)
             else json.dumps(content, ensure_ascii=False)
         )
-    reply_data = result.get("reply_data")
     if reply_data is not None:
         return (
             reply_data

--- a/libs/by-framework-agent/src/by_framework_agent/loop.py
+++ b/libs/by-framework-agent/src/by_framework_agent/loop.py
@@ -77,8 +77,10 @@ class HarnessLoop:
 
     async def run(self, context: AgentContext) -> AgentTaskResult:
         tool_specs = self._resolve_tools()
+        sub_agent_ids = set(self._agent_config.sub_agents)
         tool_schemas = [spec.to_openai_schema() for spec in tool_specs.values()]
         tool_schemas.append(_ASK_USER_TOOL_SCHEMA)
+        tool_schemas.extend(self._sub_agent_tool_schemas(context))
         model = self._resolve_model()
 
         is_resume = isinstance(context.current_command, ResumeCommand)
@@ -116,15 +118,33 @@ class HarnessLoop:
                         status=AgentState.COMPLETED.value, content=turn.content
                     )
 
+                sub_agent_call = next(
+                    (tc for tc in turn.tool_calls if tc.name in sub_agent_ids), None
+                )
+                local_calls = (
+                    [tc for tc in turn.tool_calls if tc is not sub_agent_call]
+                    if sub_agent_call is not None
+                    else turn.tool_calls
+                )
+                tool_results = (
+                    await self._execute_tool_calls(context, local_calls, tool_specs)
+                    if local_calls
+                    else []
+                )
+
+                if sub_agent_call is not None:
+                    dispatch_error = await self._dispatch_sub_agent_call(
+                        context, messages, turn, sub_agent_call, tool_results
+                    )
+                    if dispatch_error is None:
+                        return AgentTaskResult(status=AgentState.QUEUED.value)
+                    tool_results.append(dispatch_error)
+
                 messages.append(
                     self._assistant_tool_call_message(turn.content, turn.tool_calls)
                 )
                 await self._persist_assistant_tool_call_turn(
                     context, turn.content, turn.tool_calls
-                )
-
-                tool_results = await self._execute_tool_calls(
-                    context, turn.tool_calls, tool_specs
                 )
                 messages.extend(tool_results)
                 await self._persist_tool_result_turns(context, tool_results)
@@ -160,6 +180,76 @@ class HarnessLoop:
         if isinstance(ask_user_call.arguments, dict):
             prompt = str(ask_user_call.arguments.get("prompt", ""))
         await context.ask_user(prompt)
+
+    def _sub_agent_tool_schemas(self, context: AgentContext) -> list[dict[str, Any]]:
+        schemas = []
+        for sub_agent_id in self._agent_config.sub_agents:
+            sub_config = context.agent_runtime_state.config_manager.get_config(
+                sub_agent_id
+            )
+            description = (sub_config.description if sub_config else "") or (
+                f"Delegate to sub-agent {sub_agent_id!r}."
+            )
+            schemas.append(_sub_agent_tool_schema(sub_agent_id, description))
+        return schemas
+
+    async def _dispatch_sub_agent_call(
+        self,
+        context: AgentContext,
+        messages: list[dict[str, Any]],
+        turn: _ModelTurn,
+        sub_agent_call: _ResolvedToolCall,
+        sibling_results: list[dict[str, Any]],
+    ) -> dict[str, Any] | None:
+        """Delegate to a sub-agent via call_agent.
+
+        On success, persists the suspended loop state and returns None — the
+        caller returns QUEUED without falling through. On dispatch failure
+        (e.g. the sub-agent type has no online worker), returns a tool-error
+        result for the caller to fold into the normal turn continuation
+        instead of suspending.
+        """
+        if not context.execution_id:
+            raise RuntimeError(
+                "NativeAgentWorker requires a tracked execution_id to suspend "
+                "a loop on an agent-as-tool call — ensure the worker is run "
+                "via WorkerRunner"
+            )
+
+        content = ""
+        if isinstance(sub_agent_call.arguments, dict):
+            content = str(sub_agent_call.arguments.get("content", ""))
+
+        dispatch_result = await context.call_agent(
+            target_agent_type=sub_agent_call.name,
+            content=content,
+            wait_for_reply=True,
+        )
+        if dispatch_result.get("status") != AgentState.QUEUED.value:
+            dispatch_error = dispatch_result.get("error") or "unavailable"
+            return _tool_error_message(
+                sub_agent_call,
+                f"Failed to dispatch to sub-agent {sub_agent_call.name!r}: "
+                f"{dispatch_error}",
+            )
+
+        await self._persist_assistant_tool_call_turn(
+            context, turn.content, turn.tool_calls
+        )
+        if sibling_results:
+            await self._persist_tool_result_turns(context, sibling_results)
+        suspended_messages = (
+            messages
+            + [self._assistant_tool_call_message(turn.content, turn.tool_calls)]
+            + sibling_results
+        )
+        await self._save_harness_state(
+            context,
+            messages=suspended_messages,
+            pending_tool_call_id=sub_agent_call.id,
+            pending_tool_name=sub_agent_call.name,
+        )
+        return None
 
     async def _rehydrate_messages(self, context: AgentContext) -> list[dict[str, Any]]:
         if not context.execution_id:
@@ -507,4 +597,25 @@ def _tool_error_message(call: _ResolvedToolCall, error: str) -> dict[str, Any]:
         "tool_call_id": call.id,
         "name": call.name,
         "content": json.dumps({"error": error}, ensure_ascii=False),
+    }
+
+
+def _sub_agent_tool_schema(sub_agent_id: str, description: str) -> dict[str, Any]:
+    """Auto-generated tool schema for delegating to ``sub_agent_id`` via call_agent."""
+    return {
+        "type": "function",
+        "function": {
+            "name": sub_agent_id,
+            "description": description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "content": {
+                        "type": "string",
+                        "description": "The message/task to send to the sub-agent.",
+                    }
+                },
+                "required": ["content"],
+            },
+        },
     }

--- a/libs/by-framework-agent/src/by_framework_agent/loop.py
+++ b/libs/by-framework-agent/src/by_framework_agent/loop.py
@@ -82,6 +82,7 @@ class HarnessLoop:
         tool_schemas.append(_ASK_USER_TOOL_SCHEMA)
         tool_schemas.extend(self._sub_agent_tool_schemas(context))
         model = self._resolve_model()
+        model_params = self._resolve_model_params()
 
         is_resume = isinstance(context.current_command, ResumeCommand)
         if is_resume:
@@ -92,7 +93,7 @@ class HarnessLoop:
         try:
             while True:
                 turn = await self._run_model_turn(
-                    context, messages, model, tool_schemas
+                    context, messages, model, tool_schemas, model_params
                 )
 
                 if turn.usage or turn.cost:
@@ -426,6 +427,7 @@ class HarnessLoop:
         messages: list[dict[str, Any]],
         model: str,
         tool_schemas: list[dict[str, Any]] | None,
+        model_params: dict[str, Any],
     ) -> _ModelTurn:
         await self._fire_callbacks(
             CallbackType.before_model_callback, context, {"messages": messages}
@@ -438,7 +440,7 @@ class HarnessLoop:
         response_model = model
 
         async for chunk in self._model_client.complete(
-            messages, model=model, tools=tool_schemas
+            messages, model=model, tools=tool_schemas, **model_params
         ):
             if chunk.content:
                 content_parts.append(chunk.content)
@@ -609,6 +611,18 @@ class HarnessLoop:
                 "in extra['model']"
             )
         return str(model)
+
+    def _resolve_model_params(self) -> dict[str, Any]:
+        """Extra kwargs (temperature, max_tokens, api_base, ...) forwarded
+        to ModelClient.complete() on every call, from
+        AgentConfig.extra["model_params"]."""
+        params = self._agent_config.extra.get("model_params", {})
+        if not isinstance(params, dict):
+            raise TypeError(
+                f"AgentConfig '{self._agent_config.agent_id}' extra['model_params'] "
+                f"must be a dict, got {type(params).__name__}"
+            )
+        return dict(params)
 
     async def _fire_callbacks(
         self,

--- a/libs/by-framework-agent/src/by_framework_agent/loop.py
+++ b/libs/by-framework-agent/src/by_framework_agent/loop.py
@@ -1,0 +1,120 @@
+"""The harness's turn-execution loop.
+
+Slice 1 scope: a single model turn (no tool calling yet — that's Slice 2).
+Assembles messages from the existing history backend and ``AgentConfig``
+prompts, streams the model's reply through the existing ``emit_chunk``/
+``StreamChunkEvent`` path, and records token usage/cost through the existing
+``record_token_usage`` accumulator.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+from by_framework.core.extensions.agent_config import AgentConfig, CallbackType
+from by_framework.core.protocol.agent_state import AgentState
+from by_framework.core.protocol.events import StreamChunkEvent
+from by_framework.core.protocol.results import AgentTaskResult
+from by_framework.worker.context import AgentContext
+
+from .model_client import ModelClient
+
+_HISTORY_LIMIT = 50
+_MESSAGE_ROLES = {"user", "assistant", "system"}
+
+
+class HarnessLoop:
+    """Runs one native-agent turn for a given ``AgentConfig``."""
+
+    def __init__(self, model_client: ModelClient, agent_config: AgentConfig):
+        self._model_client = model_client
+        self._agent_config = agent_config
+
+    async def run(self, context: AgentContext) -> AgentTaskResult:
+        messages = await self._build_messages(context)
+        model = self._resolve_model()
+
+        await self._fire_callbacks(
+            CallbackType.before_model_callback, context, {"messages": messages}
+        )
+
+        content_parts: list[str] = []
+        usage: dict[str, int] | None = None
+        cost = 0.0
+        response_model = model
+
+        async for chunk in self._model_client.complete(messages, model=model):
+            if chunk.content:
+                content_parts.append(chunk.content)
+                await context.emit_chunk(StreamChunkEvent(content=chunk.content))
+            if chunk.is_final:
+                usage = chunk.usage or usage
+                response_model = chunk.model or response_model
+                cost = chunk.cost or cost
+
+        full_content = "".join(content_parts)
+
+        if usage or cost:
+            context.record_token_usage(
+                prompt_tokens=(usage or {}).get("prompt_tokens", 0),
+                completion_tokens=(usage or {}).get("completion_tokens", 0),
+                model=response_model,
+                cost=cost or None,
+            )
+
+        await self._fire_callbacks(
+            CallbackType.after_model_callback,
+            context,
+            {"content": full_content, "usage": usage, "cost": cost},
+        )
+
+        return AgentTaskResult(status=AgentState.COMPLETED.value, content=full_content)
+
+    async def _build_messages(self, context: AgentContext) -> list[dict[str, Any]]:
+        messages: list[dict[str, Any]] = []
+        system_prompt = self._render_system_prompt()
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+
+        history = await context.agent_runtime_state.session_manager.history.get_history(
+            limit=_HISTORY_LIMIT
+        )
+        for entry in history:
+            role = entry.get("role", "user")
+            if role not in _MESSAGE_ROLES:
+                continue
+            content = entry.get("content", "")
+            if not isinstance(content, str):
+                content = str(content)
+            messages.append({"role": role, "content": content})
+
+        return messages
+
+    def _render_system_prompt(self) -> str:
+        system_prompt = self._agent_config.prompts.get("system")
+        if system_prompt is None:
+            return ""
+        if hasattr(system_prompt, "render"):
+            return system_prompt.render()
+        return str(system_prompt)
+
+    def _resolve_model(self) -> str:
+        model = self._agent_config.extra.get("model")
+        if not model:
+            raise ValueError(
+                f"AgentConfig '{self._agent_config.agent_id}' has no 'model' set "
+                "in extra['model']"
+            )
+        return str(model)
+
+    async def _fire_callbacks(
+        self,
+        callback_type: CallbackType,
+        context: AgentContext,
+        payload: dict[str, Any],
+    ) -> None:
+        for callback in self._agent_config.callbacks.get(callback_type, []):
+            result = callback(context, payload)
+            if inspect.isawaitable(result):
+                await result

--- a/libs/by-framework-agent/src/by_framework_agent/model_client.py
+++ b/libs/by-framework-agent/src/by_framework_agent/model_client.py
@@ -1,0 +1,45 @@
+"""Model-calling seam for the native agent harness.
+
+``ModelClient`` is the harness's sole external, non-deterministic dependency
+— every other integration point (tool execution, agent-as-tool dispatch,
+suspend/resume) runs through real ``by_framework`` code. Tests substitute a
+stub implementation here instead of calling a real model provider.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Protocol
+
+
+@dataclass
+class ModelChunk:
+    """One increment of a streamed model turn.
+
+    A turn is a sequence of chunks carrying content/tool-call deltas,
+    terminated by exactly one chunk with ``is_final=True`` carrying the
+    aggregated ``usage``/``cost``/``finish_reason`` for the whole turn.
+    """
+
+    content: str = ""
+    tool_call_deltas: list[dict[str, Any]] = field(default_factory=list)
+    finish_reason: str = ""
+    is_final: bool = False
+    usage: dict[str, int] | None = None
+    cost: float = 0.0
+    model: str = ""
+
+
+class ModelClient(Protocol):
+    """Protocol for the harness's model-calling boundary."""
+
+    def complete(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        model: str,
+        tools: list[dict[str, Any]] | None = None,
+        **params: Any,
+    ) -> AsyncIterator[ModelChunk]:
+        """Stream a single model turn as a sequence of ``ModelChunk``s."""
+        ...  # pylint: disable=unnecessary-ellipsis

--- a/libs/by-framework-agent/src/by_framework_agent/testing.py
+++ b/libs/by-framework-agent/src/by_framework_agent/testing.py
@@ -1,0 +1,37 @@
+"""Test-only ``ModelClient`` double.
+
+Shipped as part of the package (not just the harness's own tests) so agent
+developers building on ``NativeAgentWorker`` can script deterministic model
+turns in their own tests without calling a real provider.
+"""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator
+
+from .model_client import ModelChunk
+
+
+class StubModelClient:
+    """Replays scripted chunk sequences, one sequence per ``complete()`` call."""
+
+    def __init__(self, turns: list[list[ModelChunk]]):
+        self._turns = list(turns)
+        self.calls: list[dict[str, Any]] = []
+
+    async def complete(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        model: str,
+        tools: list[dict[str, Any]] | None = None,
+        **params: Any,
+    ) -> AsyncIterator[ModelChunk]:
+        self.calls.append(
+            {"messages": messages, "model": model, "tools": tools, "params": params}
+        )
+        if not self._turns:
+            raise AssertionError("StubModelClient: no more scripted turns")
+        turn = self._turns.pop(0)
+        for chunk in turn:
+            yield chunk

--- a/libs/by-framework-agent/src/by_framework_agent/tool_spec.py
+++ b/libs/by-framework-agent/src/by_framework_agent/tool_spec.py
@@ -1,0 +1,41 @@
+"""Typed local-tool declarations for the harness's tool-calling loop."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
+
+if TYPE_CHECKING:
+    from by_framework.worker.context import AgentContext
+
+ToolHandler = Callable[["AgentContext", dict[str, Any]], Awaitable[Any]]
+
+
+def _default_parameters() -> dict[str, Any]:
+    return {"type": "object", "properties": {}}
+
+
+@dataclass
+class ToolSpec:
+    """A single locally-executable tool the model can call.
+
+    ``handler`` receives the current ``AgentContext`` and the tool call's
+    parsed JSON arguments, and may return a string (used as-is) or any
+    JSON-serializable value (serialized before being sent back to the model).
+    """
+
+    name: str
+    handler: ToolHandler
+    description: str = ""
+    parameters: dict[str, Any] = field(default_factory=_default_parameters)
+
+    def to_openai_schema(self) -> dict[str, Any]:
+        """Return this tool's definition in OpenAI/litellm function-schema shape."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": self.parameters,
+            },
+        }

--- a/libs/by-framework-agent/src/by_framework_agent/worker.py
+++ b/libs/by-framework-agent/src/by_framework_agent/worker.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from by_framework.common.constants import RedisKeys
 from by_framework.core.protocol.agent_state import AgentState
-from by_framework.core.protocol.commands import GatewayCommand
+from by_framework.core.protocol.commands import (CancelTaskCommand, GatewayCommand)
 from by_framework.core.protocol.results import AgentTaskResult
 from by_framework.worker.byai_worker import ByaiWorker
 from by_framework.worker.context import AgentContext
@@ -53,3 +54,28 @@ class NativeAgentWorker(ByaiWorker):
 
         loop = HarnessLoop(self._model_client, agent_config)
         return await loop.run(context)
+
+    async def on_cancelled_resume(
+        self, command: GatewayCommand, context: AgentContext, reason: str
+    ) -> None:
+        """Clean up a suspended loop's harness_state on a stray, post-cancel resume.
+
+        This is the only hook that fires for an execution cancelled while
+        fully suspended (awaiting ask_user or a sub-agent reply) — it has no
+        live task for CancelTaskCommand's own on_cancel_task hook to catch.
+        """
+        del command, reason
+        if context.execution_id:
+            await context.redis.delete(RedisKeys.harness_state(context.execution_id))
+
+    async def on_cancel_task(self, command: CancelTaskCommand) -> None:
+        """Clean up harness_state for a live (still-running) cancelled task.
+
+        Covers the narrow window where a loop just wrote harness_state and
+        is cancelled before ever reaching a suspended state; harmless no-op
+        otherwise since deleting an absent key is a no-op.
+        """
+        if command.target_execution_id:
+            await self.redis.delete(
+                RedisKeys.harness_state(command.target_execution_id)
+            )

--- a/libs/by-framework-agent/src/by_framework_agent/worker.py
+++ b/libs/by-framework-agent/src/by_framework_agent/worker.py
@@ -1,0 +1,55 @@
+"""``NativeAgentWorker`` — the first-party agent harness worker.
+
+Unlike ``LangGraphWorker``/``AdkWorker``, which require a per-subclass
+``build_graph``/``build_agent`` hook, the reasoning loop here is entirely
+framework-owned. Subclasses only need to declare ``get_agent_types()`` and
+make an ``AgentConfig`` resolvable through the existing
+``PluginRegistry``/``AgentConfigManager`` plumbing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from by_framework.core.protocol.agent_state import AgentState
+from by_framework.core.protocol.commands import GatewayCommand
+from by_framework.core.protocol.results import AgentTaskResult
+from by_framework.worker.byai_worker import ByaiWorker
+from by_framework.worker.context import AgentContext
+
+from .litellm_client import LiteLLMModelClient
+from .loop import HarnessLoop
+from .model_client import ModelClient
+
+
+class NativeAgentWorker(ByaiWorker):
+    """``GatewayWorker`` that runs a native, litellm-backed reasoning loop."""
+
+    def __init__(
+        self,
+        *args: Any,
+        model_client: ModelClient | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._model_client: ModelClient = model_client or LiteLLMModelClient()
+
+    async def process_command(
+        self, command: GatewayCommand, context: AgentContext
+    ) -> AgentTaskResult:
+        agent_config = context.agent_runtime_state.config_manager.get_config(
+            context.current_agent_id
+        )
+        if agent_config is None:
+            return AgentTaskResult(
+                status=AgentState.FAILED.value,
+                reply_data={
+                    "error": (
+                        "No AgentConfig registered for agent_id="
+                        f"{context.current_agent_id!r}"
+                    )
+                },
+            )
+
+        loop = HarnessLoop(self._model_client, agent_config)
+        return await loop.run(context)

--- a/libs/by-framework-agent/tests/conftest.py
+++ b/libs/by-framework-agent/tests/conftest.py
@@ -18,6 +18,7 @@ class FakeRedisStore:
     def __init__(self):
         self.strings: dict[str, str] = {}
         self.hashes: dict[str, dict[str, str]] = {}
+        self.sets: dict[str, set] = {}
 
     async def set(self, key, value, ex=None):  # pylint: disable=unused-argument
         self.strings[key] = value
@@ -28,6 +29,13 @@ class FakeRedisStore:
     async def delete(self, key):
         self.strings.pop(key, None)
         self.hashes.pop(key, None)
+        self.sets.pop(key, None)
+
+    async def sadd(self, key, *values):
+        self.sets.setdefault(key, set()).update(values)
+
+    async def smembers(self, key):
+        return set(self.sets.get(key, set()))
 
     async def hset(self, key, mapping=None, **kwargs):
         self.hashes.setdefault(key, {}).update(mapping or kwargs)
@@ -58,12 +66,25 @@ def mock_redis():
     mock.set = store.set
     mock.get = store.get
     mock.delete = store.delete
+    mock.sadd = store.sadd
+    mock.smembers = store.smembers
     mock.hset = store.hset
     mock.hget = store.hget
     mock.hgetall = store.hgetall
     mock.hincrby = store.hincrby
     mock.expire = store.expire
     return mock
+
+
+async def mark_agent_type_online(
+    mock_redis, agent_type: str, worker_id: str = "worker-online"
+) -> None:
+    """Seed the availability-check keys AvailabilityRouter reads so
+    ``context.call_agent(...)`` treats ``agent_type`` as deliverable."""
+    from by_framework.common.constants import RedisKeys
+
+    await mock_redis.sadd(RedisKeys.agent_type_members(agent_type), worker_id)
+    await mock_redis.set(RedisKeys.worker_online_lease(worker_id), "1")
 
 
 @pytest.fixture

--- a/libs/by-framework-agent/tests/conftest.py
+++ b/libs/by-framework-agent/tests/conftest.py
@@ -6,19 +6,63 @@ from by_framework.core.runtime.history.history_manager import HistoryManager
 from by_framework.core.runtime.history.in_memory import InMemoryHistoryBackend
 
 
+class FakeRedisStore:
+    """Minimal real in-memory backing for the Redis calls the harness makes.
+
+    Shared across multiple worker instances within a test (they're all
+    handed the same ``mock_redis``), so a value written by one "worker
+    process" is readable by another — proving loop state genuinely
+    round-trips through Redis rather than living in Python memory.
+    """
+
+    def __init__(self):
+        self.strings: dict[str, str] = {}
+        self.hashes: dict[str, dict[str, str]] = {}
+
+    async def set(self, key, value, ex=None):  # pylint: disable=unused-argument
+        self.strings[key] = value
+
+    async def get(self, key):
+        return self.strings.get(key)
+
+    async def delete(self, key):
+        self.strings.pop(key, None)
+        self.hashes.pop(key, None)
+
+    async def hset(self, key, mapping=None, **kwargs):
+        self.hashes.setdefault(key, {}).update(mapping or kwargs)
+
+    async def hget(self, key, field):
+        return self.hashes.get(key, {}).get(field)
+
+    async def hgetall(self, key):
+        return dict(self.hashes.get(key, {}))
+
+    async def hincrby(self, key, field, amount=1):
+        current = int(self.hashes.get(key, {}).get(field, 0)) + amount
+        self.hashes.setdefault(key, {})[field] = str(current)
+        return current
+
+    async def expire(self, key, seconds):  # pylint: disable=unused-argument
+        return True
+
+
 @pytest.fixture
 def mock_redis():
+    store = FakeRedisStore()
     mock = MagicMock()
     mock.xadd = AsyncMock()
     mock.pipeline = MagicMock(
         return_value=MagicMock(xadd=MagicMock(), execute=AsyncMock(return_value=[]))
     )
-    mock.hset = AsyncMock()
-    mock.hget = AsyncMock(return_value=None)
-    mock.hgetall = AsyncMock(return_value={})
-    mock.hincrby = AsyncMock(return_value=1)
-    mock.expire = AsyncMock()
-    mock.delete = AsyncMock()
+    mock.set = store.set
+    mock.get = store.get
+    mock.delete = store.delete
+    mock.hset = store.hset
+    mock.hget = store.hget
+    mock.hgetall = store.hgetall
+    mock.hincrby = store.hincrby
+    mock.expire = store.expire
     return mock
 
 

--- a/libs/by-framework-agent/tests/conftest.py
+++ b/libs/by-framework-agent/tests/conftest.py
@@ -1,0 +1,40 @@
+# pylint: disable=redefined-outer-name
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from by_framework.core.runtime.history.history_manager import HistoryManager
+from by_framework.core.runtime.history.in_memory import InMemoryHistoryBackend
+
+
+@pytest.fixture
+def mock_redis():
+    mock = MagicMock()
+    mock.xadd = AsyncMock()
+    mock.pipeline = MagicMock(
+        return_value=MagicMock(xadd=MagicMock(), execute=AsyncMock(return_value=[]))
+    )
+    mock.hset = AsyncMock()
+    mock.hget = AsyncMock(return_value=None)
+    mock.hgetall = AsyncMock(return_value={})
+    mock.hincrby = AsyncMock(return_value=1)
+    mock.expire = AsyncMock()
+    mock.delete = AsyncMock()
+    return mock
+
+
+@pytest.fixture
+def workspace_manager():
+    manager = MagicMock()
+    manager.setup_workspace = AsyncMock(
+        return_value={"private": "/tmp", "public": "/tmp"}
+    )
+    manager.cleanup_task = AsyncMock()
+    return manager
+
+
+@pytest.fixture(autouse=True)
+def _isolated_history_backend():
+    """Each test gets a fresh in-memory history store (default backend is
+    process-global, so cross-test bleed is possible otherwise)."""
+    HistoryManager.set_default_backend(InMemoryHistoryBackend())
+    yield

--- a/libs/by-framework-agent/tests/conftest.py
+++ b/libs/by-framework-agent/tests/conftest.py
@@ -37,8 +37,11 @@ class FakeRedisStore:
     async def smembers(self, key):
         return set(self.sets.get(key, set()))
 
-    async def hset(self, key, mapping=None, **kwargs):
-        self.hashes.setdefault(key, {}).update(mapping or kwargs)
+    async def hset(self, key, field=None, value=None, mapping=None, **kwargs):
+        bucket = self.hashes.setdefault(key, {})
+        if field is not None:
+            bucket[field] = value
+        bucket.update(mapping or kwargs)
 
     async def hget(self, key, field):
         return self.hashes.get(key, {}).get(field)
@@ -73,6 +76,7 @@ def mock_redis():
     mock.hgetall = store.hgetall
     mock.hincrby = store.hincrby
     mock.expire = store.expire
+    mock.store = store
     return mock
 
 

--- a/libs/by-framework-agent/tests/test_agent_as_tool.py
+++ b/libs/by-framework-agent/tests/test_agent_as_tool.py
@@ -200,9 +200,10 @@ async def test_mixed_local_tool_and_sub_agent_call_in_one_turn(
     # The local tool's result was persisted into the suspended state
     # alongside the pending sub-agent call, not dropped.
     assert ("tool", "call_local") in roles_and_ids
-    assert state["pending"] == [
-        {"tool_call_id": "call_sub", "tool_name": "sub_assistant"}
-    ]
+    assert len(state["pending"]) == 1
+    assert state["pending"][0]["tool_call_id"] == "call_sub"
+    assert state["pending"][0]["tool_name"] == "sub_assistant"
+    assert state["pending"][0]["message_id"]
 
 
 @pytest.mark.asyncio

--- a/libs/by-framework-agent/tests/test_agent_as_tool.py
+++ b/libs/by-framework-agent/tests/test_agent_as_tool.py
@@ -200,7 +200,9 @@ async def test_mixed_local_tool_and_sub_agent_call_in_one_turn(
     # The local tool's result was persisted into the suspended state
     # alongside the pending sub-agent call, not dropped.
     assert ("tool", "call_local") in roles_and_ids
-    assert state["pending_tool_call_id"] == "call_sub"
+    assert state["pending"] == [
+        {"tool_call_id": "call_sub", "tool_name": "sub_assistant"}
+    ]
 
 
 @pytest.mark.asyncio

--- a/libs/by-framework-agent/tests/test_agent_as_tool.py
+++ b/libs/by-framework-agent/tests/test_agent_as_tool.py
@@ -1,0 +1,237 @@
+# pylint: disable=redefined-outer-name
+import json
+
+import pytest
+from by_framework.common.constants import RedisKeys
+from conftest import mark_agent_type_online
+from test_ask_user_suspend_resume import _execution, _resume_command
+from test_native_agent_worker import (_agent_config, _ChatWorker, _command, _registry)
+
+from by_framework_agent.model_client import ModelChunk
+from by_framework_agent.testing import StubModelClient
+from by_framework_agent.tool_spec import ToolSpec
+
+
+def _sub_agent_call_chunk(content: str, call_id: str = "call_sub") -> ModelChunk:
+    return ModelChunk(
+        tool_call_deltas=[
+            {
+                "index": 0,
+                "id": call_id,
+                "function": {
+                    "name": "sub_assistant",
+                    "arguments": json.dumps({"content": content}),
+                },
+            }
+        ],
+        is_final=True,
+        finish_reason="tool_calls",
+    )
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_auto_registered_as_tool_without_explicit_declaration(
+    mock_redis, workspace_manager
+):
+    parent = _agent_config(sub_agents=["sub_assistant"])
+    sub = _agent_config(agent_id="sub_assistant", description="Handles sub-tasks.")
+    model_client = StubModelClient(
+        turns=[[ModelChunk(content="hi", is_final=True, finish_reason="stop")]]
+    )
+    worker = _ChatWorker(
+        worker_id="worker-a",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([parent, sub]),
+        model_client=model_client,
+    )
+
+    await worker._handle_message(_command())  # pylint: disable=protected-access
+
+    tools = model_client.calls[0]["tools"]
+    sub_agent_tool = next(t for t in tools if t["function"]["name"] == "sub_assistant")
+    assert sub_agent_tool["function"]["description"] == "Handles sub-tasks."
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_tool_call_dispatches_via_call_agent(
+    mock_redis, workspace_manager
+):
+    await mark_agent_type_online(mock_redis, "sub_assistant")
+    parent = _agent_config(sub_agents=["sub_assistant"])
+    sub = _agent_config(agent_id="sub_assistant")
+    model_client = StubModelClient(turns=[[_sub_agent_call_chunk("Please help")]])
+    worker = _ChatWorker(
+        worker_id="worker-a",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([parent, sub]),
+        model_client=model_client,
+    )
+
+    result = await worker._handle_message(  # pylint: disable=protected-access
+        _command(), execution=_execution("exec-1", "worker-a")
+    )
+
+    assert result.status == "QUEUED"
+    dispatched_streams = [call.args[0] for call in mock_redis.xadd.call_args_list]
+    assert RedisKeys.ctrl_stream("sub_assistant") in dispatched_streams
+
+
+@pytest.mark.asyncio
+async def test_resume_after_sub_agent_reply_on_different_worker_instance(
+    mock_redis, workspace_manager
+):
+    await mark_agent_type_online(mock_redis, "sub_assistant")
+    parent = _agent_config(sub_agents=["sub_assistant"])
+    sub = _agent_config(agent_id="sub_assistant")
+
+    first_model_client = StubModelClient(turns=[[_sub_agent_call_chunk("Please help")]])
+    worker_a = _ChatWorker(
+        worker_id="worker-a",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([parent, sub]),
+        model_client=first_model_client,
+    )
+    suspend_result = await worker_a._handle_message(  # pylint: disable=protected-access
+        _command(), execution=_execution("exec-1", "worker-a")
+    )
+    assert suspend_result.status == "QUEUED"
+
+    second_model_client = StubModelClient(
+        turns=[
+            [
+                ModelChunk(
+                    content="Delegated answer.", is_final=True, finish_reason="stop"
+                )
+            ]
+        ]
+    )
+    worker_b = _ChatWorker(
+        worker_id="worker-b",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([parent, sub]),
+        model_client=second_model_client,
+    )
+    resume_result = await worker_b._handle_message(  # pylint: disable=protected-access
+        _resume_command("Sub-agent's answer"),
+        execution=_execution("exec-1", "worker-b"),
+    )
+
+    assert resume_result.status == "COMPLETED"
+    assert resume_result.content == "Delegated answer."
+
+    sent_messages = second_model_client.calls[0]["messages"]
+    tool_result = next(m for m in sent_messages if m.get("role") == "tool")
+    assert tool_result["tool_call_id"] == "call_sub"
+    assert tool_result["content"] == "Sub-agent's answer"
+    assert await mock_redis.get(RedisKeys.harness_state("exec-1")) is None
+
+
+@pytest.mark.asyncio
+async def test_mixed_local_tool_and_sub_agent_call_in_one_turn(
+    mock_redis, workspace_manager
+):
+    await mark_agent_type_online(mock_redis, "sub_assistant")
+    local_calls: list[dict] = []
+
+    async def local_handler(context, arguments):  # pylint: disable=unused-argument
+        local_calls.append(arguments)
+        return "local result"
+
+    local_tool = ToolSpec(name="local_tool", handler=local_handler)
+    parent = _agent_config(
+        sub_agents=["sub_assistant"], tools={"local_tool": local_tool}
+    )
+    sub = _agent_config(agent_id="sub_assistant")
+
+    model_client = StubModelClient(
+        turns=[
+            [
+                ModelChunk(
+                    tool_call_deltas=[
+                        {
+                            "index": 0,
+                            "id": "call_local",
+                            "function": {"name": "local_tool", "arguments": "{}"},
+                        },
+                        {
+                            "index": 1,
+                            "id": "call_sub",
+                            "function": {
+                                "name": "sub_assistant",
+                                "arguments": json.dumps({"content": "help"}),
+                            },
+                        },
+                    ],
+                    is_final=True,
+                    finish_reason="tool_calls",
+                )
+            ]
+        ]
+    )
+    worker = _ChatWorker(
+        worker_id="worker-a",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([parent, sub]),
+        model_client=model_client,
+    )
+
+    result = await worker._handle_message(  # pylint: disable=protected-access
+        _command(), execution=_execution("exec-1", "worker-a")
+    )
+
+    assert result.status == "QUEUED"
+    assert local_calls == [{}]
+
+    raw_state = await mock_redis.get(RedisKeys.harness_state("exec-1"))
+    state = json.loads(raw_state)
+    roles_and_ids = [
+        (m.get("role"), m.get("tool_call_id")) for m in state["messages"] if "role" in m
+    ]
+    # The local tool's result was persisted into the suspended state
+    # alongside the pending sub-agent call, not dropped.
+    assert ("tool", "call_local") in roles_and_ids
+    assert state["pending_tool_call_id"] == "call_sub"
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_dispatch_failure_surfaces_as_tool_error_and_continues(
+    mock_redis, workspace_manager
+):
+    # sub_assistant is deliberately never marked online.
+    parent = _agent_config(sub_agents=["sub_assistant"])
+    sub = _agent_config(agent_id="sub_assistant")
+    model_client = StubModelClient(
+        turns=[
+            [_sub_agent_call_chunk("help", call_id="call_sub")],
+            [ModelChunk(content="fell back", is_final=True, finish_reason="stop")],
+        ]
+    )
+    worker = _ChatWorker(
+        worker_id="worker-a",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([parent, sub]),
+        model_client=model_client,
+    )
+
+    result = await worker._handle_message(  # pylint: disable=protected-access
+        _command(), execution=_execution("exec-1", "worker-a")
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.content == "fell back"
+    tool_message = model_client.calls[1]["messages"][-1]
+    assert tool_message["role"] == "tool"
+    assert tool_message["tool_call_id"] == "call_sub"
+    assert "sub_assistant" in tool_message["content"]

--- a/libs/by-framework-agent/tests/test_ask_user_suspend_resume.py
+++ b/libs/by-framework-agent/tests/test_ask_user_suspend_resume.py
@@ -79,8 +79,7 @@ async def test_ask_user_tool_suspends_and_persists_loop_state(
     raw_state = await mock_redis.get(RedisKeys.harness_state("exec-1"))
     assert raw_state is not None
     state = json.loads(raw_state)
-    assert state["pending_tool_call_id"] == "call_ask"
-    assert state["pending_tool_name"] == "ask_user"
+    assert state["pending"] == [{"tool_call_id": "call_ask", "tool_name": "ask_user"}]
     assert state["messages"][-1]["tool_calls"][0]["function"]["name"] == "ask_user"
 
     pipe = mock_redis.pipeline.return_value

--- a/libs/by-framework-agent/tests/test_ask_user_suspend_resume.py
+++ b/libs/by-framework-agent/tests/test_ask_user_suspend_resume.py
@@ -1,0 +1,181 @@
+# pylint: disable=redefined-outer-name
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from by_framework import RunningExecution
+from by_framework.common.constants import RedisKeys
+from by_framework.core.protocol.commands import ResumeCommand
+from by_framework.core.protocol.message_header import MessageHeader
+from test_native_agent_worker import (_agent_config, _ChatWorker, _command, _registry)
+
+from by_framework_agent.model_client import ModelChunk
+from by_framework_agent.testing import StubModelClient
+
+
+def _execution(execution_id: str, worker_id: str) -> RunningExecution:
+    return RunningExecution(
+        execution_id=execution_id,
+        message_id="msg-1",
+        session_id="session-1",
+        worker_id=worker_id,
+        task=AsyncMock(),
+        cancel_event=AsyncMock(),
+    )
+
+
+def _resume_command(reply: str) -> ResumeCommand:
+    return ResumeCommand(
+        header=MessageHeader(
+            message_id="msg-2",
+            session_id="session-1",
+            trace_id="trace-1",
+            parent_message_id="msg-1",
+            user_code="user-1",
+            user_name="user-1",
+            target_agent_type="assistant",
+        ),
+        content=reply,
+    )
+
+
+def _ask_user_chunk(prompt: str) -> ModelChunk:
+    return ModelChunk(
+        tool_call_deltas=[
+            {
+                "index": 0,
+                "id": "call_ask",
+                "function": {
+                    "name": "ask_user",
+                    "arguments": json.dumps({"prompt": prompt}),
+                },
+            }
+        ],
+        is_final=True,
+        finish_reason="tool_calls",
+    )
+
+
+@pytest.mark.asyncio
+async def test_ask_user_tool_suspends_and_persists_loop_state(
+    mock_redis, workspace_manager
+):
+    model_client = StubModelClient(turns=[[_ask_user_chunk("Which city?")]])
+    worker = _ChatWorker(
+        worker_id="worker-a",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([_agent_config()]),
+        model_client=model_client,
+    )
+
+    result = await worker._handle_message(  # pylint: disable=protected-access
+        _command(), execution=_execution("exec-1", "worker-a")
+    )
+
+    assert result.status == "WAITING_USER"
+
+    raw_state = await mock_redis.get(RedisKeys.harness_state("exec-1"))
+    assert raw_state is not None
+    state = json.loads(raw_state)
+    assert state["pending_tool_call_id"] == "call_ask"
+    assert state["pending_tool_name"] == "ask_user"
+    assert state["messages"][-1]["tool_calls"][0]["function"]["name"] == "ask_user"
+
+    pipe = mock_redis.pipeline.return_value
+    payloads = [call.args[1]["data"] for call in pipe.xadd.call_args_list]
+    assert any("Which city?" in payload for payload in payloads)
+
+
+@pytest.mark.asyncio
+async def test_resume_on_different_worker_instance_rehydrates_and_continues(
+    mock_redis, workspace_manager
+):
+    first_model_client = StubModelClient(turns=[[_ask_user_chunk("Which city?")]])
+    worker_a = _ChatWorker(
+        worker_id="worker-a",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([_agent_config()]),
+        model_client=first_model_client,
+    )
+    suspend_result = await worker_a._handle_message(  # pylint: disable=protected-access
+        _command(), execution=_execution("exec-1", "worker-a")
+    )
+    assert suspend_result.status == "WAITING_USER"
+
+    # A *separate* worker instance — simulating a different process/machine —
+    # picks up the resume, sharing only the Redis-backed harness_state.
+    second_model_client = StubModelClient(
+        turns=[
+            [ModelChunk(content="Tokyo it is.", is_final=True, finish_reason="stop")]
+        ]
+    )
+    worker_b = _ChatWorker(
+        worker_id="worker-b",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([_agent_config()]),
+        model_client=second_model_client,
+    )
+    resume_result = await worker_b._handle_message(  # pylint: disable=protected-access
+        _resume_command("Tokyo"), execution=_execution("exec-1", "worker-b")
+    )
+
+    assert resume_result.status == "COMPLETED"
+    assert resume_result.content == "Tokyo it is."
+
+    # The continuation's model call included the user's reply as the tool
+    # result for the pending ask_user call.
+    sent_messages = second_model_client.calls[0]["messages"]
+    tool_result = next(m for m in sent_messages if m.get("role") == "tool")
+    assert tool_result["tool_call_id"] == "call_ask"
+    assert tool_result["content"] == "Tokyo"
+
+    # harness_state was consumed and cleared once the loop reached completion.
+    assert await mock_redis.get(RedisKeys.harness_state("exec-1")) is None
+
+
+@pytest.mark.asyncio
+async def test_stray_resume_without_harness_state_fails_loudly(
+    mock_redis, workspace_manager
+):
+    worker = _ChatWorker(
+        worker_id="worker-a",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([_agent_config()]),
+        model_client=StubModelClient(turns=[]),
+    )
+
+    result = await worker._handle_message(  # pylint: disable=protected-access
+        _resume_command("hello"), execution=_execution("exec-missing", "worker-a")
+    )
+
+    assert result.status == "FAILED"
+
+
+@pytest.mark.asyncio
+async def test_ask_user_without_tracked_execution_id_fails_loudly(
+    mock_redis, workspace_manager
+):
+    model_client = StubModelClient(turns=[[_ask_user_chunk("Which city?")]])
+    worker = _ChatWorker(
+        worker_id="worker-a",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([_agent_config()]),
+        model_client=model_client,
+    )
+
+    # No `execution=` passed — same seam used by slices 1-2 — so
+    # context.execution_id is empty; the harness must refuse to silently
+    # suspend without an id it can resume against later.
+    result = await worker._handle_message(_command())  # pylint: disable=protected-access
+
+    assert result.status == "FAILED"

--- a/libs/by-framework-agent/tests/test_ask_user_suspend_resume.py
+++ b/libs/by-framework-agent/tests/test_ask_user_suspend_resume.py
@@ -79,7 +79,9 @@ async def test_ask_user_tool_suspends_and_persists_loop_state(
     raw_state = await mock_redis.get(RedisKeys.harness_state("exec-1"))
     assert raw_state is not None
     state = json.loads(raw_state)
-    assert state["pending"] == [{"tool_call_id": "call_ask", "tool_name": "ask_user"}]
+    assert state["pending"] == [
+        {"tool_call_id": "call_ask", "tool_name": "ask_user", "message_id": ""}
+    ]
     assert state["messages"][-1]["tool_calls"][0]["function"]["name"] == "ask_user"
 
     pipe = mock_redis.pipeline.return_value

--- a/libs/by-framework-agent/tests/test_cancel_cleanup.py
+++ b/libs/by-framework-agent/tests/test_cancel_cleanup.py
@@ -1,0 +1,209 @@
+# pylint: disable=redefined-outer-name
+import asyncio
+
+import pytest
+from by_framework.common.constants import RedisKeys
+from conftest import mark_agent_type_online
+from test_ask_user_suspend_resume import (_ask_user_chunk, _execution, _resume_command)
+from test_native_agent_worker import (_agent_config, _ChatWorker, _command, _registry)
+from test_task_group_batching import _multi_sub_agent_turn_chunk
+
+from by_framework_agent.testing import StubModelClient
+
+
+def _set_cancel_event() -> asyncio.Event:
+    event = asyncio.Event()
+    event.set()
+    return event
+
+
+@pytest.mark.asyncio
+async def test_cancelled_resume_after_ask_user_suspend_cleans_up_and_no_ops(
+    mock_redis, workspace_manager
+):
+    worker_a = _ChatWorker(
+        worker_id="worker-a",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([_agent_config()]),
+        model_client=StubModelClient(turns=[[_ask_user_chunk("Which city?")]]),
+    )
+    suspend_result = await worker_a._handle_message(  # pylint: disable=protected-access
+        _command(), execution=_execution("exec-1", "worker-a")
+    )
+    assert suspend_result.status == "WAITING_USER"
+    assert await mock_redis.get(RedisKeys.harness_state("exec-1")) is not None
+
+    never_called = StubModelClient(turns=[])
+    worker_b = _ChatWorker(
+        worker_id="worker-b",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([_agent_config()]),
+        model_client=never_called,
+    )
+    resume_result = await worker_b._handle_message(  # pylint: disable=protected-access
+        _resume_command("Tokyo"),
+        cancel_event=_set_cancel_event(),
+        cancel_reason="user requested cancellation",
+        execution=_execution("exec-1", "worker-b"),
+    )
+
+    assert resume_result.status == "CANCELLED"
+    assert never_called.calls == []
+    assert await mock_redis.get(RedisKeys.harness_state("exec-1")) is None
+
+
+@pytest.mark.asyncio
+async def test_cancelled_resume_after_single_agent_as_tool_suspend_cleans_up(
+    mock_redis, workspace_manager
+):
+    await mark_agent_type_online(mock_redis, "sub_assistant")
+    parent = _agent_config(sub_agents=["sub_assistant"])
+    sub = _agent_config(agent_id="sub_assistant")
+
+    from test_agent_as_tool import _sub_agent_call_chunk  # pylint: disable=import-outside-toplevel
+
+    worker_a = _ChatWorker(
+        worker_id="worker-a",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([parent, sub]),
+        model_client=StubModelClient(turns=[[_sub_agent_call_chunk("help")]]),
+    )
+    suspend_result = await worker_a._handle_message(  # pylint: disable=protected-access
+        _command(), execution=_execution("exec-1", "worker-a")
+    )
+    assert suspend_result.status == "QUEUED"
+
+    never_called = StubModelClient(turns=[])
+    worker_b = _ChatWorker(
+        worker_id="worker-b",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([parent, sub]),
+        model_client=never_called,
+    )
+    resume_result = await worker_b._handle_message(  # pylint: disable=protected-access
+        _resume_command("Sub-agent reply"),
+        cancel_event=_set_cancel_event(),
+        cancel_reason="user requested cancellation",
+        execution=_execution("exec-1", "worker-b"),
+    )
+
+    assert resume_result.status == "CANCELLED"
+    assert never_called.calls == []
+    assert await mock_redis.get(RedisKeys.harness_state("exec-1")) is None
+
+
+@pytest.mark.asyncio
+async def test_cancelled_resume_after_task_group_suspend_discards_all_stray_replies(
+    mock_redis, workspace_manager
+):
+    await mark_agent_type_online(mock_redis, "sub_a", worker_id="worker-a-online")
+    await mark_agent_type_online(mock_redis, "sub_b", worker_id="worker-b-online")
+    parent = _agent_config(sub_agents=["sub_a", "sub_b"])
+    sub_a = _agent_config(agent_id="sub_a")
+    sub_b = _agent_config(agent_id="sub_b")
+
+    worker_1 = _ChatWorker(
+        worker_id="worker-1",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([parent, sub_a, sub_b]),
+        model_client=StubModelClient(turns=[[_multi_sub_agent_turn_chunk()]]),
+    )
+    suspend_result = await worker_1._handle_message(  # pylint: disable=protected-access
+        _command(), execution=_execution("exec-1", "worker-1")
+    )
+    assert suspend_result.status == "QUEUED"
+    assert await mock_redis.get(RedisKeys.harness_state("exec-1")) is not None
+
+    # First straggler (sub_a) arrives after cancellation.
+    reply_a = _resume_command("Answer from A")
+    reply_a.header.task_group_id = "irrelevant-once-cancelled"
+    reply_a.header.source_agent_type = "sub_a"
+    reply_a.header.parent_message_id = "dispatch-a"
+    never_called_2 = StubModelClient(turns=[])
+    worker_2 = _ChatWorker(
+        worker_id="worker-2",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([parent, sub_a, sub_b]),
+        model_client=never_called_2,
+    )
+    result_a = await worker_2._handle_message(  # pylint: disable=protected-access
+        reply_a,
+        cancel_event=_set_cancel_event(),
+        cancel_reason="user requested cancellation",
+        execution=_execution("exec-1", "worker-2"),
+    )
+    assert result_a.status == "CANCELLED"
+    assert never_called_2.calls == []
+    assert await mock_redis.get(RedisKeys.harness_state("exec-1")) is None
+
+    # Second straggler (sub_b) arrives later still — also discarded, no crash,
+    # no revival of the loop, regardless of harness_state already being gone.
+    reply_b = _resume_command("Answer from B")
+    reply_b.header.task_group_id = "irrelevant-once-cancelled"
+    reply_b.header.source_agent_type = "sub_b"
+    reply_b.header.parent_message_id = "dispatch-b"
+    never_called_3 = StubModelClient(turns=[])
+    worker_3 = _ChatWorker(
+        worker_id="worker-3",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([parent, sub_a, sub_b]),
+        model_client=never_called_3,
+    )
+    result_b = await worker_3._handle_message(  # pylint: disable=protected-access
+        reply_b,
+        cancel_event=_set_cancel_event(),
+        cancel_reason="user requested cancellation",
+        execution=_execution("exec-1", "worker-3"),
+    )
+    assert result_b.status == "CANCELLED"
+    assert never_called_3.calls == []
+
+
+@pytest.mark.asyncio
+async def test_live_task_cancellation_cleans_up_harness_state_via_on_cancel_task(
+    mock_redis, workspace_manager
+):
+    from by_framework.core.protocol.commands import CancelTaskCommand
+    from by_framework.core.protocol.message_header import MessageHeader
+
+    await mock_redis.set(
+        RedisKeys.harness_state("exec-live"), '{"messages": [], "pending": []}'
+    )
+
+    worker = _ChatWorker(
+        worker_id="worker-a",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([_agent_config()]),
+        model_client=StubModelClient(turns=[]),
+    )
+
+    cancel_command = CancelTaskCommand(
+        header=MessageHeader(
+            message_id="cancel-1",
+            session_id="session-1",
+            trace_id="trace-1",
+            target_agent_type="assistant",
+        ),
+        target_message_id="msg-1",
+        target_execution_id="exec-live",
+        reason="user requested",
+    )
+    await worker.on_cancel_task(cancel_command)
+
+    assert await mock_redis.get(RedisKeys.harness_state("exec-live")) is None

--- a/libs/by-framework-agent/tests/test_native_agent_worker.py
+++ b/libs/by-framework-agent/tests/test_native_agent_worker.py
@@ -238,3 +238,77 @@ async def test_non_dict_model_params_fails_loudly(mock_redis, workspace_manager)
     result = await worker._handle_message(_command())  # pylint: disable=protected-access
 
     assert result.status == "FAILED"
+
+
+@pytest.mark.asyncio
+async def test_different_agents_use_independent_model_provider_and_credentials(
+    mock_redis, workspace_manager
+):
+    """extra["model"]/extra["model_params"] live on AgentConfig, not the
+    worker — two agents (e.g. an orchestrator and a self-hosted sub-agent)
+    can each point at a completely different provider, model, and
+    credentials, and never see each other's."""
+    openai_client = StubModelClient(
+        turns=[[ModelChunk(content="from openai", is_final=True, finish_reason="stop")]]
+    )
+    openai_worker = _ChatWorker(
+        worker_id="openai-worker",
+        redis_client=mock_redis,
+        registry=MagicMock(),
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry(
+            [
+                _agent_config(
+                    extra={
+                        "model": "gpt-4o-mini",
+                        "model_params": {"api_key": "sk-openai-key"},
+                    }
+                )
+            ]
+        ),
+        model_client=openai_client,
+    )
+
+    self_hosted_client = StubModelClient(
+        turns=[
+            [
+                ModelChunk(
+                    content="from self-hosted", is_final=True, finish_reason="stop"
+                )
+            ]
+        ]
+    )
+    self_hosted_worker = _ChatWorker(
+        worker_id="self-hosted-worker",
+        redis_client=mock_redis,
+        registry=MagicMock(),
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry(
+            [
+                _agent_config(
+                    extra={
+                        "model": "openai/local-llama",
+                        "model_params": {
+                            "api_key": "sk-local-anything",
+                            "api_base": "http://localhost:8000/v1",
+                        },
+                    }
+                )
+            ]
+        ),
+        model_client=self_hosted_client,
+    )
+
+    await openai_worker._handle_message(_command())  # pylint: disable=protected-access
+    await self_hosted_worker._handle_message(  # pylint: disable=protected-access
+        _command()
+    )
+
+    assert openai_client.calls[0]["model"] == "gpt-4o-mini"
+    assert openai_client.calls[0]["params"] == {"api_key": "sk-openai-key"}
+
+    assert self_hosted_client.calls[0]["model"] == "openai/local-llama"
+    assert self_hosted_client.calls[0]["params"] == {
+        "api_key": "sk-local-anything",
+        "api_base": "http://localhost:8000/v1",
+    }

--- a/libs/by-framework-agent/tests/test_native_agent_worker.py
+++ b/libs/by-framework-agent/tests/test_native_agent_worker.py
@@ -1,0 +1,198 @@
+# pylint: disable=redefined-outer-name
+from unittest.mock import MagicMock
+
+import pytest
+from by_framework.core.extensions.agent_config import AgentConfig, CallbackType
+from by_framework.core.extensions.registry import PluginRegistry
+from by_framework.core.protocol.commands import AskAgentCommand
+from by_framework.core.protocol.message_header import MessageHeader
+
+from by_framework_agent.model_client import ModelChunk
+from by_framework_agent.testing import StubModelClient
+from by_framework_agent.worker import NativeAgentWorker
+
+
+class _ChatWorker(NativeAgentWorker):
+
+    def get_agent_types(self) -> list[str]:
+        return ["assistant"]
+
+
+def _agent_config(**overrides) -> AgentConfig:
+    defaults: dict = {
+        "agent_id": "assistant",
+        "name": "Assistant",
+        "prompts": {"system": "You are a helpful assistant."},
+        "extra": {"model": "gpt-4o-mini"},
+    }
+    defaults.update(overrides)
+    return AgentConfig(**defaults)
+
+
+def _registry(configs: list[AgentConfig]) -> PluginRegistry:
+    registry = PluginRegistry()
+    registry._set_agent_configs(configs)  # pylint: disable=protected-access
+    return registry
+
+
+def _command(content: str = "Hi there") -> AskAgentCommand:
+    return AskAgentCommand(
+        header=MessageHeader(
+            message_id="msg-1",
+            session_id="session-1",
+            trace_id="trace-1",
+            user_code="user-1",
+            user_name="user-1",
+            target_agent_type="assistant",
+        ),
+        content=content,
+    )
+
+
+@pytest.mark.asyncio
+async def test_plain_chat_turn_streams_and_completes(mock_redis, workspace_manager):
+    model_client = StubModelClient(
+        turns=[
+            [
+                ModelChunk(content="Hello"),
+                ModelChunk(content=", world!"),
+                ModelChunk(
+                    is_final=True,
+                    finish_reason="stop",
+                    usage={"prompt_tokens": 12, "completion_tokens": 4},
+                    cost=0.0002,
+                    model="gpt-4o-mini",
+                ),
+            ]
+        ]
+    )
+    worker = _ChatWorker(
+        worker_id="agent-1",
+        redis_client=mock_redis,
+        registry=MagicMock(),
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([_agent_config()]),
+        model_client=model_client,
+    )
+
+    result = await worker._handle_message(_command())  # pylint: disable=protected-access
+
+    assert result.status == "COMPLETED"
+    assert result.content == "Hello, world!"
+
+    # Streamed deltas went out over the (mocked) data stream.
+    pipe = mock_redis.pipeline.return_value
+    payloads = [call.args[1]["data"] for call in pipe.xadd.call_args_list]
+    assert any("Hello" in payload for payload in payloads)
+    assert any(", world!" in payload for payload in payloads)
+
+    # The model boundary is the one seam: exactly one call, with the system
+    # prompt and the auto-saved user turn assembled from history.
+    assert len(model_client.calls) == 1
+    sent_messages = model_client.calls[0]["messages"]
+    assert sent_messages[0] == {
+        "role": "system",
+        "content": "You are a helpful assistant.",
+    }
+    assert sent_messages[-1] == {"role": "user", "content": "Hi there"}
+    assert model_client.calls[0]["model"] == "gpt-4o-mini"
+
+
+@pytest.mark.asyncio
+async def test_no_agent_config_fails_gracefully(mock_redis, workspace_manager):
+    worker = _ChatWorker(
+        worker_id="agent-1",
+        redis_client=mock_redis,
+        registry=MagicMock(),
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([]),
+        model_client=StubModelClient(turns=[]),
+    )
+
+    result = await worker._handle_message(_command())  # pylint: disable=protected-access
+
+    assert result.status == "FAILED"
+
+
+@pytest.mark.asyncio
+async def test_before_and_after_model_callbacks_fire(mock_redis, workspace_manager):
+    calls: list[str] = []
+
+    async def before(context, payload):  # pylint: disable=unused-argument
+        calls.append("before")
+
+    def after(context, payload):  # pylint: disable=unused-argument
+        calls.append("after")
+
+    config = _agent_config(
+        callbacks={
+            CallbackType.before_model_callback: [before],
+            CallbackType.after_model_callback: [after],
+        }
+    )
+    model_client = StubModelClient(
+        turns=[[ModelChunk(content="hi", is_final=True, finish_reason="stop")]]
+    )
+    worker = _ChatWorker(
+        worker_id="agent-1",
+        redis_client=mock_redis,
+        registry=MagicMock(),
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([config]),
+        model_client=model_client,
+    )
+
+    await worker._handle_message(_command())  # pylint: disable=protected-access
+
+    assert calls == ["before", "after"]
+
+
+@pytest.mark.asyncio
+async def test_token_usage_and_cost_recorded(mock_redis, workspace_manager):
+    model_client = StubModelClient(
+        turns=[
+            [
+                ModelChunk(content="hi"),
+                ModelChunk(
+                    is_final=True,
+                    finish_reason="stop",
+                    usage={"prompt_tokens": 7, "completion_tokens": 3},
+                    cost=0.001,
+                    model="gpt-4o-mini",
+                ),
+            ]
+        ]
+    )
+    worker = _ChatWorker(
+        worker_id="agent-1",
+        redis_client=mock_redis,
+        registry=MagicMock(),
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([_agent_config()]),
+        model_client=model_client,
+    )
+
+    # Capture token usage by wrapping AgentContext.record_token_usage — the
+    # context itself is created internally by _handle_message, so this is
+    # the seam available to observe what the loop recorded on it.
+    from by_framework.worker.context import AgentContext
+
+    captured = {}
+    original_record = AgentContext.record_token_usage
+
+    def _spy(self, **kwargs):
+        captured.update(kwargs)
+        return original_record(self, **kwargs)
+
+    AgentContext.record_token_usage = _spy
+    try:
+        await worker._handle_message(_command())  # pylint: disable=protected-access
+    finally:
+        AgentContext.record_token_usage = original_record
+
+    assert captured == {
+        "prompt_tokens": 7,
+        "completion_tokens": 3,
+        "model": "gpt-4o-mini",
+        "cost": 0.001,
+    }

--- a/libs/by-framework-agent/tests/test_native_agent_worker.py
+++ b/libs/by-framework-agent/tests/test_native_agent_worker.py
@@ -196,3 +196,45 @@ async def test_token_usage_and_cost_recorded(mock_redis, workspace_manager):
         "model": "gpt-4o-mini",
         "cost": 0.001,
     }
+
+
+@pytest.mark.asyncio
+async def test_model_params_forwarded_to_model_client(mock_redis, workspace_manager):
+    model_client = StubModelClient(
+        turns=[[ModelChunk(content="ok", is_final=True, finish_reason="stop")]]
+    )
+    config = _agent_config(
+        extra={
+            "model": "gpt-4o-mini",
+            "model_params": {"temperature": 0.2, "max_tokens": 500},
+        }
+    )
+    worker = _ChatWorker(
+        worker_id="agent-1",
+        redis_client=mock_redis,
+        registry=MagicMock(),
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([config]),
+        model_client=model_client,
+    )
+
+    await worker._handle_message(_command())  # pylint: disable=protected-access
+
+    assert model_client.calls[0]["params"] == {"temperature": 0.2, "max_tokens": 500}
+
+
+@pytest.mark.asyncio
+async def test_non_dict_model_params_fails_loudly(mock_redis, workspace_manager):
+    config = _agent_config(extra={"model": "gpt-4o-mini", "model_params": "oops"})
+    worker = _ChatWorker(
+        worker_id="agent-1",
+        redis_client=mock_redis,
+        registry=MagicMock(),
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([config]),
+        model_client=StubModelClient(turns=[]),
+    )
+
+    result = await worker._handle_message(_command())  # pylint: disable=protected-access
+
+    assert result.status == "FAILED"

--- a/libs/by-framework-agent/tests/test_task_group_batching.py
+++ b/libs/by-framework-agent/tests/test_task_group_batching.py
@@ -155,13 +155,24 @@ async def test_group_join_resumes_loop_with_each_result_mapped_to_its_tool_call(
     assert len(task_group_keys) == 1
     task_group_id = task_group_keys[0].split(":")[-1]
 
+    # Each sibling's reply must carry its own dispatch-time message_id back
+    # as parent_message_id — that's what Group Join keys results by, and
+    # now what the harness correlates tool_call_ids by too — so recover the
+    # real ones from what was actually dispatched, per target agent type.
+    dispatch_message_id_by_target = {}
+    for call in mock_redis.xadd.call_args_list:
+        for target in ("sub_a", "sub_b"):
+            if call.args[0] == RedisKeys.ctrl_stream(target):
+                payload = json.loads(call.args[1]["data"])
+                dispatch_message_id_by_target[target] = payload["header"]["message_id"]
+
     # First sibling (sub_a) replies — worker.py's Group Join keeps this
     # execution QUEUED (waiting_for_group) without ever calling
     # process_command, since not everyone has replied yet.
     reply_a = _resume_command("Answer from A")
     reply_a.header.task_group_id = task_group_id
     reply_a.header.source_agent_type = "sub_a"
-    reply_a.header.parent_message_id = "dispatch-a"
+    reply_a.header.parent_message_id = dispatch_message_id_by_target["sub_a"]
     worker_2 = _ChatWorker(
         worker_id="worker-2",
         redis_client=mock_redis,
@@ -180,7 +191,7 @@ async def test_group_join_resumes_loop_with_each_result_mapped_to_its_tool_call(
     reply_b = _resume_command("Answer from B")
     reply_b.header.task_group_id = task_group_id
     reply_b.header.source_agent_type = "sub_b"
-    reply_b.header.parent_message_id = "dispatch-b"
+    reply_b.header.parent_message_id = dispatch_message_id_by_target["sub_b"]
     final_model_client = StubModelClient(
         turns=[[ModelChunk(content="combined", is_final=True, finish_reason="stop")]]
     )
@@ -209,3 +220,117 @@ async def test_group_join_resumes_loop_with_each_result_mapped_to_its_tool_call(
     assert tool_messages["call_b"]["name"] == "sub_b"
 
     assert await mock_redis.get(RedisKeys.harness_state("exec-1")) is None
+
+
+@pytest.mark.asyncio
+async def test_duplicate_sub_agent_target_in_one_turn_keeps_both_results_distinct(
+    mock_redis, workspace_manager
+):
+    """A turn dispatching the SAME sub-agent type twice must not collapse
+    the two replies onto one tool_call_id — correlation has to key off each
+    dispatch's own unique message_id, not target_agent_type (which is
+    identical for both calls here)."""
+    await mark_agent_type_online(mock_redis, "sub_a", worker_id="worker-a-online")
+    parent = _agent_config(sub_agents=["sub_a"])
+    sub_a = _agent_config(agent_id="sub_a")
+
+    dual_call_chunk = ModelChunk(
+        tool_call_deltas=[
+            {
+                "index": 0,
+                "id": "call_first",
+                "function": {
+                    "name": "sub_a",
+                    "arguments": json.dumps({"content": "first task"}),
+                },
+            },
+            {
+                "index": 1,
+                "id": "call_second",
+                "function": {
+                    "name": "sub_a",
+                    "arguments": json.dumps({"content": "second task"}),
+                },
+            },
+        ],
+        is_final=True,
+        finish_reason="tool_calls",
+    )
+    worker_1 = _ChatWorker(
+        worker_id="worker-1",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([parent, sub_a]),
+        model_client=StubModelClient(turns=[[dual_call_chunk]]),
+    )
+    suspend_result = await worker_1._handle_message(  # pylint: disable=protected-access
+        _command(), execution=_execution("exec-1", "worker-1")
+    )
+    assert suspend_result.status == "QUEUED"
+
+    # Recover each dispatch's own unique message_id from what was actually
+    # sent on the wire, the same way a real sub-agent's reply would carry
+    # it back via header.parent_message_id.
+    dispatched_message_ids = []
+    for call in mock_redis.xadd.call_args_list:
+        if call.args[0] != RedisKeys.ctrl_stream("sub_a"):
+            continue
+        payload = json.loads(call.args[1]["data"])
+        dispatched_message_ids.append(payload["header"]["message_id"])
+    assert len(dispatched_message_ids) == 2
+    assert len(set(dispatched_message_ids)) == 2  # genuinely distinct
+
+    task_group_keys = [
+        k
+        for k in mock_redis.store.hashes
+        if k.startswith("byai_gateway:task_group:") and not k.endswith(":results")
+    ]
+    assert len(task_group_keys) == 1
+    task_group_id = task_group_keys[0].split(":")[-1]
+
+    reply_first = _resume_command("Answer to first")
+    reply_first.header.task_group_id = task_group_id
+    reply_first.header.source_agent_type = "sub_a"
+    reply_first.header.parent_message_id = dispatched_message_ids[0]
+    worker_2 = _ChatWorker(
+        worker_id="worker-2",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([parent, sub_a]),
+        model_client=StubModelClient(turns=[]),
+    )
+    partial = await worker_2._handle_message(  # pylint: disable=protected-access
+        reply_first, execution=_execution("exec-1", "worker-2")
+    )
+    assert "waiting_for_group" in partial.status
+
+    reply_second = _resume_command("Answer to second")
+    reply_second.header.task_group_id = task_group_id
+    reply_second.header.source_agent_type = "sub_a"
+    reply_second.header.parent_message_id = dispatched_message_ids[1]
+    final_model_client = StubModelClient(
+        turns=[[ModelChunk(content="done", is_final=True, finish_reason="stop")]]
+    )
+    worker_3 = _ChatWorker(
+        worker_id="worker-3",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([parent, sub_a]),
+        model_client=final_model_client,
+    )
+    final_result = await worker_3._handle_message(  # pylint: disable=protected-access
+        reply_second, execution=_execution("exec-1", "worker-3")
+    )
+
+    assert final_result.status == "COMPLETED"
+    sent_messages = final_model_client.calls[0]["messages"]
+    tool_messages = {
+        m["tool_call_id"]: m for m in sent_messages if m.get("role") == "tool"
+    }
+    # Both tool_call_ids survive with their own distinct answer — neither
+    # collapsed onto the other.
+    assert tool_messages["call_first"]["content"] == "Answer to first"
+    assert tool_messages["call_second"]["content"] == "Answer to second"

--- a/libs/by-framework-agent/tests/test_task_group_batching.py
+++ b/libs/by-framework-agent/tests/test_task_group_batching.py
@@ -1,0 +1,211 @@
+# pylint: disable=redefined-outer-name
+import json
+
+import pytest
+from by_framework.common.constants import RedisKeys
+from conftest import mark_agent_type_online
+from test_ask_user_suspend_resume import _execution, _resume_command
+from test_native_agent_worker import (_agent_config, _ChatWorker, _command, _registry)
+
+from by_framework_agent.model_client import ModelChunk
+from by_framework_agent.testing import StubModelClient
+
+
+def _multi_sub_agent_turn_chunk() -> ModelChunk:
+    return ModelChunk(
+        tool_call_deltas=[
+            {
+                "index": 0,
+                "id": "call_a",
+                "function": {
+                    "name": "sub_a",
+                    "arguments": json.dumps({"content": "task for a"}),
+                },
+            },
+            {
+                "index": 1,
+                "id": "call_b",
+                "function": {
+                    "name": "sub_b",
+                    "arguments": json.dumps({"content": "task for b"}),
+                },
+            },
+        ],
+        is_final=True,
+        finish_reason="tool_calls",
+    )
+
+
+@pytest.mark.asyncio
+async def test_multi_target_turn_dispatches_single_task_group_not_sequential_calls(
+    mock_redis, workspace_manager
+):
+    await mark_agent_type_online(mock_redis, "sub_a", worker_id="worker-a-online")
+    await mark_agent_type_online(mock_redis, "sub_b", worker_id="worker-b-online")
+    parent = _agent_config(sub_agents=["sub_a", "sub_b"])
+    sub_a = _agent_config(agent_id="sub_a")
+    sub_b = _agent_config(agent_id="sub_b")
+    model_client = StubModelClient(turns=[[_multi_sub_agent_turn_chunk()]])
+    worker = _ChatWorker(
+        worker_id="worker-1",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([parent, sub_a, sub_b]),
+        model_client=model_client,
+    )
+
+    result = await worker._handle_message(  # pylint: disable=protected-access
+        _command(), execution=_execution("exec-1", "worker-1")
+    )
+
+    assert result.status == "QUEUED"
+
+    # Exactly one Task Group was created (one task_group hash key), not two
+    # independent call_agent dispatches.
+    task_group_keys = [
+        k
+        for k in mock_redis.store.hashes
+        if k.startswith("byai_gateway:task_group:") and not k.endswith(":results")
+    ]
+    assert len(task_group_keys) == 1
+
+    dispatched_streams = [call.args[0] for call in mock_redis.xadd.call_args_list]
+    assert RedisKeys.ctrl_stream("sub_a") in dispatched_streams
+    assert RedisKeys.ctrl_stream("sub_b") in dispatched_streams
+
+
+@pytest.mark.asyncio
+async def test_single_sub_agent_call_still_uses_call_agent_not_task_group(
+    mock_redis, workspace_manager
+):
+    await mark_agent_type_online(mock_redis, "sub_a")
+    parent = _agent_config(sub_agents=["sub_a"])
+    sub_a = _agent_config(agent_id="sub_a")
+    model_client = StubModelClient(
+        turns=[
+            [
+                ModelChunk(
+                    tool_call_deltas=[
+                        {
+                            "index": 0,
+                            "id": "call_a",
+                            "function": {
+                                "name": "sub_a",
+                                "arguments": json.dumps({"content": "solo task"}),
+                            },
+                        }
+                    ],
+                    is_final=True,
+                    finish_reason="tool_calls",
+                )
+            ]
+        ]
+    )
+    worker = _ChatWorker(
+        worker_id="worker-1",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([parent, sub_a]),
+        model_client=model_client,
+    )
+
+    await worker._handle_message(  # pylint: disable=protected-access
+        _command(), execution=_execution("exec-1", "worker-1")
+    )
+
+    task_group_keys = [
+        k for k in mock_redis.store.hashes if k.startswith("byai_gateway:task_group:")
+    ]
+    assert not task_group_keys
+
+
+@pytest.mark.asyncio
+async def test_group_join_resumes_loop_with_each_result_mapped_to_its_tool_call(
+    mock_redis, workspace_manager
+):
+    await mark_agent_type_online(mock_redis, "sub_a", worker_id="worker-a-online")
+    await mark_agent_type_online(mock_redis, "sub_b", worker_id="worker-b-online")
+    parent = _agent_config(sub_agents=["sub_a", "sub_b"])
+    sub_a = _agent_config(agent_id="sub_a")
+    sub_b = _agent_config(agent_id="sub_b")
+
+    first_model_client = StubModelClient(turns=[[_multi_sub_agent_turn_chunk()]])
+    worker_1 = _ChatWorker(
+        worker_id="worker-1",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([parent, sub_a, sub_b]),
+        model_client=first_model_client,
+    )
+    suspend_result = await worker_1._handle_message(  # pylint: disable=protected-access
+        _command(), execution=_execution("exec-1", "worker-1")
+    )
+    assert suspend_result.status == "QUEUED"
+
+    # Extract the task_group_id from the single dispatched AskAgentCommand
+    # payloads so the test can simulate both siblings replying.
+    task_group_keys = [
+        k
+        for k in mock_redis.store.hashes
+        if k.startswith("byai_gateway:task_group:") and not k.endswith(":results")
+    ]
+    assert len(task_group_keys) == 1
+    task_group_id = task_group_keys[0].split(":")[-1]
+
+    # First sibling (sub_a) replies — worker.py's Group Join keeps this
+    # execution QUEUED (waiting_for_group) without ever calling
+    # process_command, since not everyone has replied yet.
+    reply_a = _resume_command("Answer from A")
+    reply_a.header.task_group_id = task_group_id
+    reply_a.header.source_agent_type = "sub_a"
+    reply_a.header.parent_message_id = "dispatch-a"
+    worker_2 = _ChatWorker(
+        worker_id="worker-2",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([parent, sub_a, sub_b]),
+        model_client=StubModelClient(turns=[]),
+    )
+    partial_result = await worker_2._handle_message(  # pylint: disable=protected-access
+        reply_a, execution=_execution("exec-1", "worker-2")
+    )
+    assert "waiting_for_group" in partial_result.status
+
+    # Second sibling (sub_b) replies — this completes the group, so
+    # process_command finally runs once, with reply_data holding both.
+    reply_b = _resume_command("Answer from B")
+    reply_b.header.task_group_id = task_group_id
+    reply_b.header.source_agent_type = "sub_b"
+    reply_b.header.parent_message_id = "dispatch-b"
+    final_model_client = StubModelClient(
+        turns=[[ModelChunk(content="combined", is_final=True, finish_reason="stop")]]
+    )
+    worker_3 = _ChatWorker(
+        worker_id="worker-3",
+        redis_client=mock_redis,
+        registry=None,
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([parent, sub_a, sub_b]),
+        model_client=final_model_client,
+    )
+    final_result = await worker_3._handle_message(  # pylint: disable=protected-access
+        reply_b, execution=_execution("exec-1", "worker-3")
+    )
+
+    assert final_result.status == "COMPLETED"
+    assert final_result.content == "combined"
+
+    sent_messages = final_model_client.calls[0]["messages"]
+    tool_messages = {
+        m["tool_call_id"]: m for m in sent_messages if m.get("role") == "tool"
+    }
+    assert tool_messages["call_a"]["content"] == "Answer from A"
+    assert tool_messages["call_a"]["name"] == "sub_a"
+    assert tool_messages["call_b"]["content"] == "Answer from B"
+    assert tool_messages["call_b"]["name"] == "sub_b"
+
+    assert await mock_redis.get(RedisKeys.harness_state("exec-1")) is None

--- a/libs/by-framework-agent/tests/test_tool_calling_loop.py
+++ b/libs/by-framework-agent/tests/test_tool_calling_loop.py
@@ -1,0 +1,330 @@
+# pylint: disable=redefined-outer-name
+import asyncio
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from by_framework.core.extensions.agent_config import CallbackType
+from by_framework.core.runtime.history.history_manager import HistoryManager
+from test_native_agent_worker import (_agent_config, _ChatWorker, _command, _registry)
+
+from by_framework_agent.model_client import ModelChunk
+from by_framework_agent.testing import StubModelClient
+from by_framework_agent.tool_spec import ToolSpec
+
+
+def _weather_tool_spec(handler) -> ToolSpec:
+    return ToolSpec(
+        name="get_weather",
+        handler=handler,
+        description="Get the current weather for a city.",
+        parameters={
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_tool_call_then_final_answer(mock_redis, workspace_manager):
+    calls: list[dict] = []
+
+    async def get_weather(context, arguments):  # pylint: disable=unused-argument
+        calls.append(arguments)
+        return {"tempC": 21}
+
+    tool = _weather_tool_spec(get_weather)
+    model_client = StubModelClient(
+        turns=[
+            [
+                ModelChunk(
+                    tool_call_deltas=[
+                        {
+                            "index": 0,
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city": "SF"}',
+                            },
+                        }
+                    ],
+                    finish_reason="tool_calls",
+                    is_final=True,
+                    usage={"prompt_tokens": 10, "completion_tokens": 5},
+                    model="gpt-4o-mini",
+                ),
+            ],
+            [
+                ModelChunk(
+                    content="It's 21C in SF.",
+                    is_final=True,
+                    finish_reason="stop",
+                    usage={"prompt_tokens": 20, "completion_tokens": 8},
+                    model="gpt-4o-mini",
+                ),
+            ],
+        ]
+    )
+    worker = _ChatWorker(
+        worker_id="agent-1",
+        redis_client=mock_redis,
+        registry=MagicMock(),
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([_agent_config(tools={"get_weather": tool})]),
+        model_client=model_client,
+    )
+
+    result = await worker._handle_message(_command())  # pylint: disable=protected-access
+
+    assert result.status == "COMPLETED"
+    assert result.content == "It's 21C in SF."
+    assert calls == [{"city": "SF"}]
+
+    # Two model calls: the tool_call turn, then the follow-up with the result.
+    assert len(model_client.calls) == 2
+    assert model_client.calls[0]["tools"] == [tool.to_openai_schema()]
+    second_call_messages = model_client.calls[1]["messages"]
+    assert second_call_messages[-2]["tool_calls"][0]["function"]["name"] == (
+        "get_weather"
+    )
+    assert second_call_messages[-1] == {
+        "role": "tool",
+        "tool_call_id": "call_1",
+        "name": "get_weather",
+        "content": json.dumps({"tempC": 21}),
+    }
+
+
+@pytest.mark.asyncio
+async def test_multiple_tool_calls_in_one_turn_run_concurrently(
+    mock_redis, workspace_manager
+):
+    order: list[str] = []
+
+    async def slow(context, arguments):  # pylint: disable=unused-argument
+        order.append("slow_start")
+        await asyncio.sleep(0.05)
+        order.append("slow_end")
+        return "slow done"
+
+    async def fast(context, arguments):  # pylint: disable=unused-argument
+        order.append("fast_start")
+        return "fast done"
+
+    tools = {
+        "slow_tool": ToolSpec(name="slow_tool", handler=slow),
+        "fast_tool": ToolSpec(name="fast_tool", handler=fast),
+    }
+    model_client = StubModelClient(
+        turns=[
+            [
+                ModelChunk(
+                    tool_call_deltas=[
+                        {
+                            "index": 0,
+                            "id": "call_slow",
+                            "function": {"name": "slow_tool", "arguments": "{}"},
+                        },
+                        {
+                            "index": 1,
+                            "id": "call_fast",
+                            "function": {"name": "fast_tool", "arguments": "{}"},
+                        },
+                    ],
+                    is_final=True,
+                    finish_reason="tool_calls",
+                ),
+            ],
+            [ModelChunk(content="done", is_final=True, finish_reason="stop")],
+        ]
+    )
+    worker = _ChatWorker(
+        worker_id="agent-1",
+        redis_client=mock_redis,
+        registry=MagicMock(),
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([_agent_config(tools=tools)]),
+        model_client=model_client,
+    )
+
+    await worker._handle_message(_command())  # pylint: disable=protected-access
+
+    # If tools ran sequentially, fast_start couldn't happen until slow_end.
+    assert order.index("fast_start") < order.index("slow_end")
+
+
+@pytest.mark.asyncio
+async def test_before_tool_callback_veto_prevents_handler_execution(
+    mock_redis, workspace_manager
+):
+    handler_called = False
+
+    async def handler(context, arguments):  # pylint: disable=unused-argument
+        nonlocal handler_called
+        handler_called = True
+        return "should not run"
+
+    def veto(context, payload):  # pylint: disable=unused-argument
+        raise PermissionError("denied")
+
+    tool = ToolSpec(name="dangerous_tool", handler=handler)
+    config = _agent_config(
+        tools={"dangerous_tool": tool},
+        callbacks={CallbackType.before_tool_callback: [veto]},
+    )
+    model_client = StubModelClient(
+        turns=[
+            [
+                ModelChunk(
+                    tool_call_deltas=[
+                        {
+                            "index": 0,
+                            "id": "call_1",
+                            "function": {"name": "dangerous_tool", "arguments": "{}"},
+                        }
+                    ],
+                    is_final=True,
+                    finish_reason="tool_calls",
+                ),
+            ],
+            [ModelChunk(content="ok", is_final=True, finish_reason="stop")],
+        ]
+    )
+    worker = _ChatWorker(
+        worker_id="agent-1",
+        redis_client=mock_redis,
+        registry=MagicMock(),
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([config]),
+        model_client=model_client,
+    )
+
+    result = await worker._handle_message(_command())  # pylint: disable=protected-access
+
+    assert not handler_called
+    assert result.status == "COMPLETED"
+    second_call_messages = model_client.calls[1]["messages"]
+    tool_message = second_call_messages[-1]
+    assert tool_message["role"] == "tool"
+    assert "denied" in tool_message["content"]
+
+
+@pytest.mark.asyncio
+async def test_tool_handler_exception_surfaces_as_tool_error_and_loop_continues(
+    mock_redis, workspace_manager
+):
+    async def broken_handler(context, arguments):  # pylint: disable=unused-argument
+        raise RuntimeError("boom")
+
+    tool = ToolSpec(name="broken_tool", handler=broken_handler)
+    model_client = StubModelClient(
+        turns=[
+            [
+                ModelChunk(
+                    tool_call_deltas=[
+                        {
+                            "index": 0,
+                            "id": "call_1",
+                            "function": {"name": "broken_tool", "arguments": "{}"},
+                        }
+                    ],
+                    is_final=True,
+                    finish_reason="tool_calls",
+                ),
+            ],
+            [ModelChunk(content="recovered", is_final=True, finish_reason="stop")],
+        ]
+    )
+    worker = _ChatWorker(
+        worker_id="agent-1",
+        redis_client=mock_redis,
+        registry=MagicMock(),
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([_agent_config(tools={"broken_tool": tool})]),
+        model_client=model_client,
+    )
+
+    result = await worker._handle_message(_command())  # pylint: disable=protected-access
+
+    assert result.status == "COMPLETED"
+    assert result.content == "recovered"
+    tool_message = model_client.calls[1]["messages"][-1]
+    assert "boom" in tool_message["content"]
+
+
+@pytest.mark.asyncio
+async def test_tool_call_and_result_persisted_to_history(mock_redis, workspace_manager):
+    async def handler(context, arguments):  # pylint: disable=unused-argument
+        return "42"
+
+    tool = ToolSpec(name="answer_tool", handler=handler)
+    model_client = StubModelClient(
+        turns=[
+            [
+                ModelChunk(
+                    tool_call_deltas=[
+                        {
+                            "index": 0,
+                            "id": "call_1",
+                            "function": {"name": "answer_tool", "arguments": "{}"},
+                        }
+                    ],
+                    is_final=True,
+                    finish_reason="tool_calls",
+                ),
+            ],
+            [
+                ModelChunk(
+                    content="the answer is 42", is_final=True, finish_reason="stop"
+                )
+            ],
+        ]
+    )
+    worker = _ChatWorker(
+        worker_id="agent-1",
+        redis_client=mock_redis,
+        registry=MagicMock(),
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([_agent_config(tools={"answer_tool": tool})]),
+        model_client=model_client,
+    )
+
+    await worker._handle_message(_command())  # pylint: disable=protected-access
+
+    history = await HistoryManager("session-1").get_history(limit=50)
+    roles = [entry["role"] for entry in history]
+    assert "tool" in roles
+    tool_entry = next(entry for entry in history if entry["role"] == "tool")
+    assert tool_entry["content"] == "42"
+    assert tool_entry["metadata"]["tool_call_id"] == "call_1"
+
+
+@pytest.mark.asyncio
+async def test_tools_declared_but_no_tool_call_behaves_like_plain_chat(
+    mock_redis, workspace_manager
+):
+    async def unused_handler(context, arguments):  # pylint: disable=unused-argument
+        raise AssertionError("should never be called")
+
+    tool = ToolSpec(name="unused_tool", handler=unused_handler)
+    model_client = StubModelClient(
+        turns=[
+            [ModelChunk(content="no tools needed", is_final=True, finish_reason="stop")]
+        ]
+    )
+    worker = _ChatWorker(
+        worker_id="agent-1",
+        redis_client=mock_redis,
+        registry=MagicMock(),
+        workspace_manager=workspace_manager,
+        plugin_registry=_registry([_agent_config(tools={"unused_tool": tool})]),
+        model_client=model_client,
+    )
+
+    result = await worker._handle_message(_command())  # pylint: disable=protected-access
+
+    assert result.status == "COMPLETED"
+    assert result.content == "no tools needed"
+    assert len(model_client.calls) == 1

--- a/libs/by-framework-agent/tests/test_tool_calling_loop.py
+++ b/libs/by-framework-agent/tests/test_tool_calling_loop.py
@@ -84,7 +84,8 @@ async def test_tool_call_then_final_answer(mock_redis, workspace_manager):
 
     # Two model calls: the tool_call turn, then the follow-up with the result.
     assert len(model_client.calls) == 2
-    assert model_client.calls[0]["tools"] == [tool.to_openai_schema()]
+    # The built-in ask_user tool is always offered alongside declared tools.
+    assert tool.to_openai_schema() in model_client.calls[0]["tools"]
     second_call_messages = model_client.calls[1]["messages"]
     assert second_call_messages[-2]["tool_calls"][0]["function"]["name"] == (
         "get_weather"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ packages = ["src/by_framework"]
 
 [tool.uv.workspace]
 members = [
+    "libs/by-framework-agent",
     "libs/by-framework-history-postgres",
     "libs/by-framework-history-byclaw",
     "libs/by-framework-langgraph",

--- a/src/by_framework/common/constants.py
+++ b/src/by_framework/common/constants.py
@@ -543,6 +543,10 @@ MSG_MAP_PREFIX = "msg_map:"
 TASK_GROUP_FIELD_TOTAL = "total"
 TASK_GROUP_FIELD_COMPLETED = "completed"
 TASK_GROUP_FIELD_SOURCE_AGENT = "source_agent_type"
+# Set once dispatch fails partway through a batch; any reply that arrives
+# for an aborted group is discarded instead of resuming the (already
+# terminated) caller execution.
+TASK_GROUP_FIELD_ABORTED = "aborted"
 
 
 # --- Timing and Sleep Constants ---

--- a/src/by_framework/common/constants.py
+++ b/src/by_framework/common/constants.py
@@ -297,6 +297,20 @@ class RedisKeys:
             v2_suffix=f"task_group:{{{group_id}}}:results",
         )
 
+    @classmethod
+    def harness_state(cls, execution_id: str) -> str:
+        """Serialized in-flight native-agent-harness loop state.
+
+        Keyed purely by execution_id — the same identity the registry
+        already reattaches on RESUME — so any worker instance that picks up
+        the eventual ResumeCommand can rehydrate the loop, not only the one
+        that started it.
+        """
+        return cls._versioned(
+            v1_key=f"byai_gateway:harness_state:{execution_id}",
+            v2_suffix=f"harness_state:{{{execution_id}}}",
+        )
+
     # --- Registry ---
     @classmethod
     def known_workers(cls) -> str:
@@ -538,6 +552,8 @@ CONTROL_LOOP_SLEEP_SECONDS = 0.01
 WAIT_FOR_TASKS_TIMEOUT_SECONDS = 5.0
 # Task group Key TTL (seconds), default 1 day
 TASK_GROUP_TTL_SECONDS = 86400
+# Native agent harness loop-state Key TTL (seconds), default 1 day
+HARNESS_STATE_TTL_SECONDS = 86400
 # First retry wait time (seconds)
 FIRST_RETRY_WAIT_SECONDS = 1.0
 # Maximum retry count

--- a/src/by_framework/worker/context.py
+++ b/src/by_framework/worker/context.py
@@ -23,6 +23,7 @@ from typing_extensions import deprecated
 from by_framework.common.constants import (
     EXECUTION_ID_PREFIX,
     MESSAGE_ID_PREFIX,
+    TASK_GROUP_FIELD_ABORTED,
     TASK_GROUP_FIELD_COMPLETED,
     TASK_GROUP_FIELD_SOURCE_AGENT,
     TASK_GROUP_FIELD_TOTAL,
@@ -548,6 +549,42 @@ class AgentContext:
         Args:
             route_policy: Controls online checks and unavailable-agent behavior.
         """
+        return await self._dispatch_single_task(
+            target_agent_type=target_agent_type,
+            content=content,
+            extra_payload=extra_payload,
+            wait_for_reply=wait_for_reply,
+            metadata=metadata,
+            message_id=message_id,
+            parent_message_id=parent_message_id,
+            route_policy=route_policy,
+            availability_timeout_ms=availability_timeout_ms,
+            region=region,
+            priority=priority,
+        )
+
+    async def _dispatch_single_task(
+        self,
+        *,
+        target_agent_type: str,
+        content: object,
+        extra_payload: Optional[Dict[str, Any]] = None,
+        wait_for_reply: bool = True,
+        metadata: Optional[Dict[str, Any]] = None,
+        message_id: Optional[str] = None,
+        parent_message_id: Optional[str] = None,
+        task_group_id: str = "",
+        route_policy: str = RoutePolicy.FAIL_FAST,
+        availability_timeout_ms: int = 30000,
+        region: Optional[str] = None,
+        priority: int = 0,
+    ) -> dict:
+        """Build, availability-check, and dispatch one AskAgentCommand.
+
+        Shared by call_agent (a single task) and call_agents/dispatch_group
+        (a batch, one call per task). Returns a call_agent-shaped result dict:
+        {status, message_id, parent_message_id, target_agent_type, [error, error_code]}.
+        """
         message_id = message_id or self.generate_message_id()
         parent_message_id = parent_message_id if parent_message_id else self.message_id
         merged_extra_payload = dict(extra_payload or {})
@@ -579,6 +616,7 @@ class AgentContext:
                 source_agent_type=self.current_agent_id if wait_for_reply else "",
                 target_agent_type=target_agent_type,
                 parent_message_id=parent_message_id,
+                task_group_id=task_group_id,
                 user_code=self.agent_runtime_state.session_manager.user_code,
                 user_name=self.agent_runtime_state.session_manager.user_name,
                 metadata=metadata,
@@ -673,6 +711,11 @@ class AgentContext:
         delivery_stream = availability.stream_name or RedisKeys.ctrl_stream(
             target_agent_type
         )
+        target_worker_id = availability.target_worker_id
+        effective_route_status = availability.status
+        selected_agent_type = availability.selected_agent_type
+        availability_error_code = availability.error_code
+        availability_error = availability.error
 
         from by_framework.core.registry import WorkerRegistry
 
@@ -693,10 +736,10 @@ class AgentContext:
                         "stream_name": delivery_stream,
                         "status": "QUEUED",
                         "route_policy": route_policy,
-                        "route_status": availability.status,
-                        "selected_agent_type": availability.selected_agent_type,
-                        "availability_error_code": availability.error_code,
-                        "availability_error": availability.error,
+                        "route_status": effective_route_status,
+                        "selected_agent_type": selected_agent_type,
+                        "availability_error_code": availability_error_code,
+                        "availability_error": availability_error,
                     }
                 )
             except Exception:  # pylint: disable=broad-exception-caught
@@ -711,9 +754,9 @@ class AgentContext:
                 parent_message_id=parent_message_id,
                 source_agent_type=self.current_agent_id if wait_for_reply else "",
                 target_agent_type=target_agent_type,
-                target_worker_id=availability.target_worker_id,
+                target_worker_id=target_worker_id,
                 route_policy=route_policy,
-                route_status=availability.status,
+                route_status=effective_route_status,
                 start_ts=dispatch_started_at,
                 end_ts=int(time.time() * 1000),
             )
@@ -783,7 +826,7 @@ class AgentContext:
         except Exception as err:  # pylint: disable=broad-exception-caught
             logger.debug("Failed to record agent dispatch span: %s", err)
 
-    async def dispatch_group(
+    async def call_agents(
         self,
         tasks: list[dict[str, Any]],
         wait_for_reply: bool = True,
@@ -791,8 +834,9 @@ class AgentContext:
         parent_message_id: Optional[str] = None,
     ) -> dict:
         """
-        Dispatch multiple tasks concurrently as a group.
-        The caller agent will be resumed ONLY when ALL tasks in the group are completed.
+        Dispatch multiple tasks concurrently as a Task Group — call_agent's
+        plural. The caller agent will be resumed with every task's result,
+        aggregated, ONLY when ALL tasks in the group are complete.
 
         Args:
             tasks: A list of dicts, each containing:
@@ -805,7 +849,7 @@ class AgentContext:
             wait_for_reply: bool. If True, sets up Redis counters to wait for all.
         """
         if not tasks:
-            return {"status": "EMPTY", "task_group_id": ""}
+            raise ValueError("dispatch_group/call_agents requires at least one task")
 
         task_group_id = f"{TASK_GROUP_ID_PREFIX}{uuid.uuid4().hex[:8]}"
         total_tasks = len(tasks)
@@ -833,114 +877,63 @@ class AgentContext:
             content = task.get("content", "")
             extra_payload = task.get("extra_payload", {})
             metadata = dict(task.get("metadata", {}) or {})
-            serialized_content = self._serialize_outbound_content(content)
 
             current_message_id = message_id or self.generate_message_id()
-            parent_message_id = (
-                parent_message_id if parent_message_id else self.message_id
-            )
-            call_parent_span_id = f"{current_message_id}:client.dispatch"
-            trace_parent_span_id = self._resolve_call_trace_parent_span_id(
-                call_parent_span_id
-            )
-            metadata.setdefault("trace_parent_span_id", trace_parent_span_id)
-            metadata.setdefault("framework_parent_span_id", call_parent_span_id)
-            langfuse_parent_observation_id = (
-                str(metadata.get("langfuse_parent_observation_id", "") or "")
-                or self._resolve_call_langfuse_parent_id()
-            )
-            merged_extra_payload = dict(extra_payload)
-            if wait_for_reply:
-                merged_extra_payload["wait_for_reply"] = True
-
-            command = AskAgentCommand(
-                header=MessageHeader(
-                    message_id=current_message_id,
-                    session_id=self.session_id,
-                    trace_id=self.trace_id,
-                    source_agent_type=self.current_agent_id if wait_for_reply else "",
+            try:
+                task_result = await self._dispatch_single_task(
                     target_agent_type=target_agent_type,
+                    content=content,
+                    extra_payload=extra_payload,
+                    metadata=metadata,
+                    wait_for_reply=wait_for_reply,
+                    message_id=current_message_id,
                     parent_message_id=parent_message_id,
                     task_group_id=task_group_id,
-                    user_code=self.agent_runtime_state.session_manager.user_code,
-                    user_name=self.agent_runtime_state.session_manager.user_name,
-                    metadata=metadata,
-                    trace_parent_span_id=trace_parent_span_id,
-                    langfuse_parent_observation_id=langfuse_parent_observation_id,
-                ),
-                content=serialized_content,
-                wait_for_reply=wait_for_reply,
-                extra_payload={
-                    k: v
-                    for k, v in merged_extra_payload.items()
-                    if k != "wait_for_reply"
-                },
-            )
-
-            if self.plugin_registry:
-                await self.plugin_registry.on_call_agent_start(self, command)
-
-            execution_id = f"{EXECUTION_ID_PREFIX}{uuid.uuid4().hex[:8]}"
-            from by_framework.core.registry import WorkerRegistry
-
-            registry = WorkerRegistry(self.redis)
-            if hasattr(registry, "initialize_execution"):
-                try:
-                    await registry.initialize_execution(
-                        {
-                            "execution_id": execution_id,
-                            "message_id": current_message_id,
-                            "session_id": self.session_id,
-                            "trace_id": self.trace_id,
-                            "parent_message_id": parent_message_id or "",
-                            "source_agent_type": self.current_agent_id
-                            if wait_for_reply
-                            else "",
-                            "target_agent_type": target_agent_type,
-                            "stream_name": RedisKeys.ctrl_stream(target_agent_type),
-                            "status": "QUEUED",
-                        }
+                )
+            except Exception:
+                # A genuine dispatch-time failure (not an availability-check
+                # rejection, which _dispatch_single_task already turns into a
+                # FAILED result instead of raising). Stop fanning out and mark
+                # the group aborted so already-sent siblings' replies don't
+                # later resume this (now-failed) caller execution.
+                if wait_for_reply:
+                    await self.redis.hset(  # type: ignore
+                        RedisKeys.task_group(task_group_id),
+                        TASK_GROUP_FIELD_ABORTED,
+                        "1",
                     )
-                except Exception:  # pylint: disable=broad-exception-caught
-                    pass  # Fallback if registry fails
-
-            dispatch_started_at = int(time.time() * 1000)
-            try:
-                await self.redis.xadd(
-                    RedisKeys.ctrl_stream(target_agent_type), command.to_redis_payload()
-                )
-                await self._record_agent_dispatch_span(
-                    message_id=current_message_id,
-                    parent_message_id=parent_message_id,
-                    source_agent_type=self.current_agent_id if wait_for_reply else "",
-                    target_agent_type=target_agent_type,
-                    target_worker_id="",
-                    route_policy=RoutePolicy.SEND_ANYWAY,
-                    route_status="GROUP_DISPATCH",
-                    start_ts=dispatch_started_at,
-                    end_ts=int(time.time() * 1000),
-                )
-            except Exception as error:
-                if self.plugin_registry:
-                    await self.plugin_registry.on_call_agent_error(self, command, error)
                 raise
 
-            if self.plugin_registry:
-                await self.plugin_registry.on_call_agent_complete(
-                    self,
-                    command,
-                    {
-                        "status": AgentState.QUEUED.value,
-                        "message_id": current_message_id,
-                        "parent_message_id": parent_message_id,
-                        "target_agent_type": target_agent_type,
-                    },
+            if task_result["status"] == AgentState.FAILED.value and wait_for_reply:
+                # Target agent type unavailable: record the failure as this
+                # task's result immediately, without blocking the rest of
+                # the batch or waiting for a reply that will never arrive.
+                result_data = {
+                    "status": task_result["status"],
+                    "reply_data": None,
+                    "content": "",
+                    "target_agent_type": target_agent_type,
+                    "metadata": {},
+                    "extra_payload": {},
+                    "error": task_result.get("error"),
+                    "error_code": task_result.get("error_code"),
+                }
+                results_key = RedisKeys.task_group_results(task_group_id)
+                await self.redis.hset(  # type: ignore
+                    results_key, current_message_id, json.dumps(result_data)
+                )
+                await self.redis.expire(results_key, TASK_GROUP_TTL_SECONDS)
+                await self.redis.hincrby(  # type: ignore
+                    RedisKeys.task_group(task_group_id), TASK_GROUP_FIELD_COMPLETED, 1
                 )
 
             dispatched.append(
                 {
                     "message_id": current_message_id,
-                    "target_agent_type": target_agent_type,
+                    # task_result["target_agent_type"] reflects any fallback
+                    # reroute _dispatch_single_task performed, so this stays
+                    # consistent with what Group Join later reports.
+                    "target_agent_type": task_result["target_agent_type"],
                 }
             )
 
@@ -976,10 +969,29 @@ class AgentContext:
             logger.debug("Failed to record dispatch_group span: %s", err)
 
         return {
-            "status": "GROUP_QUEUED",
+            "status": AgentState.QUEUED.value,
             "task_group_id": task_group_id,
             "dispatched_tasks": dispatched,
         }
+
+    async def dispatch_group(
+        self,
+        tasks: list[dict[str, Any]],
+        wait_for_reply: bool = True,
+        message_id: Optional[str] = None,
+        parent_message_id: Optional[str] = None,
+    ) -> dict:
+        """Alias for call_agents, kept permanently for source compatibility.
+
+        Not deprecated: shares call_agents' implementation and behavior
+        exactly, so existing callers upgrade automatically without a rename.
+        """
+        return await self.call_agents(
+            tasks,
+            wait_for_reply=wait_for_reply,
+            message_id=message_id,
+            parent_message_id=parent_message_id,
+        )
 
     def _serialize_outbound_content(self, content: object) -> WireContent:
         if self.content_codec is not None:

--- a/src/by_framework/worker/context.py
+++ b/src/by_framework/worker/context.py
@@ -498,12 +498,14 @@ class AgentContext:
         prompt_tokens: int = 0,
         completion_tokens: int = 0,
         model: str = "",
+        cost: float | None = None,
     ) -> None:
-        """Accumulate token usage from a single LLM call.
+        """Accumulate token usage (and optionally cost) from a single LLM call.
 
         Intended for agent implementations and framework adapters.  Each call
         adds to the running totals for the current execution so that the final
         worker.execute span and the Langfuse observation reflect the aggregate.
+        ``cost`` is additive across calls, mirroring the token counters.
         """
         self._token_usage["prompt_tokens"] = self._token_usage.get(
             "prompt_tokens", 0
@@ -516,6 +518,10 @@ class AgentContext:
         )
         if model:
             self._token_usage["model"] = model
+        if cost is not None:
+            self._token_usage["cost"] = self._token_usage.get("cost", 0.0) + max(
+                0.0, cost
+            )
 
     def get_token_usage(self) -> dict[str, Any]:
         """Return accumulated token usage for this execution."""

--- a/src/by_framework/worker/runner.py
+++ b/src/by_framework/worker/runner.py
@@ -699,6 +699,7 @@ class WorkerRunner:
                 chunk_count=chunk_count,
                 parent_span_id=framework_parent_span_id,
                 tokens=token_usage,
+                cost={"total": token_usage["cost"]} if "cost" in token_usage else {},
             )
 
             # Finalize trace root when the root execution completes so the
@@ -810,6 +811,7 @@ class WorkerRunner:
         parent_span_id: str = "",
         chunk_count: int = 0,
         tokens: Optional[dict] = None,
+        cost: Optional[dict] = None,
     ) -> None:
         try:
             await self.span_recorder.record_span(
@@ -837,6 +839,7 @@ class WorkerRunner:
                     route_status=route_status,
                     chunk_count=chunk_count,
                     tokens=tokens or {},
+                    cost=cost or {},
                 )
             )
         except Exception as err:  # pylint: disable=broad-exception-caught

--- a/src/by_framework/worker/worker.py
+++ b/src/by_framework/worker/worker.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 from by_framework.common.config import WorkerConfig
 from by_framework.common.constants import (
     MESSAGE_ID_PREFIX,
+    TASK_GROUP_FIELD_ABORTED,
     TASK_GROUP_FIELD_COMPLETED,
     TASK_GROUP_FIELD_TOTAL,
     TASK_GROUP_TTL_SECONDS,
@@ -654,12 +655,33 @@ class GatewayWorker(ABC):
                         group_key, TASK_GROUP_FIELD_TOTAL
                     )
                     if total_str is not None:
+                        aborted = await self.redis.hget(  # type: ignore
+                            group_key, TASK_GROUP_FIELD_ABORTED
+                        )
+                        if aborted:
+                            logger.warning(
+                                "[%s] TaskGroup %s is aborted, discarding late "
+                                "reply from message_id=%s",
+                                self.worker_id,
+                                header.task_group_id,
+                                header.message_id,
+                            )
+                            return AgentTaskResult(
+                                status=f"{AgentState.CANCELLED.value}: group_aborted"
+                            )
+
                         # Store result in Redis Hash for distributed access
                         if isinstance(raw_command, ResumeCommand):
                             result_data = {
                                 "status": raw_command.status,
                                 "reply_data": raw_command.reply_data,
                                 "content": raw_command.content,
+                                # This ResumeCommand flows FROM the sub-agent
+                                # back TO the caller, so its header's
+                                # source_agent_type is the sub-agent that
+                                # produced this result — i.e. the original
+                                # dispatch's target_agent_type.
+                                "target_agent_type": header.source_agent_type,
                                 "metadata": raw_command.header.metadata,
                                 "extra_payload": raw_command.extra_payload,
                             }
@@ -690,6 +712,15 @@ class GatewayWorker(ABC):
                             header.task_group_id,
                             total_str,
                         )
+                        raw_results = await self.redis.hgetall(  # type: ignore
+                            results_key
+                        )
+                        aggregated_results = [
+                            {"message_id": msg_id, **json.loads(data)}
+                            for msg_id, data in raw_results.items()
+                        ]
+                        if isinstance(command, ResumeCommand):
+                            command.reply_data = aggregated_results
 
                 # await context.emit_state(
                 #     StateChangeEvent(state=AgentState.RESUMED.value)

--- a/src/by_framework/worker/worker.py
+++ b/src/by_framework/worker/worker.py
@@ -661,10 +661,10 @@ class GatewayWorker(ABC):
                         if aborted:
                             logger.warning(
                                 "[%s] TaskGroup %s is aborted, discarding late "
-                                "reply from message_id=%s",
+                                "reply from sub-task message_id=%s",
                                 self.worker_id,
                                 header.task_group_id,
-                                header.message_id,
+                                header.parent_message_id,
                             )
                             return AgentTaskResult(
                                 status=f"{AgentState.CANCELLED.value}: group_aborted"
@@ -685,9 +685,18 @@ class GatewayWorker(ABC):
                                 "metadata": raw_command.header.metadata,
                                 "extra_payload": raw_command.extra_payload,
                             }
+                            # _enqueue_agent_return sets a reply's header.
+                            # message_id to the ORIGINAL dispatch's
+                            # parent_message_id (the caller's own message
+                            # id) — identical across every sibling in this
+                            # Task Group. Keying results by that would let
+                            # siblings overwrite each other; header.
+                            # parent_message_id on the reply is the
+                            # sub-task's own dispatch-time message_id
+                            # instead, which is unique per task.
                             await self.redis.hset(  # type: ignore
                                 results_key,
-                                header.message_id,
+                                header.parent_message_id,
                                 json.dumps(result_data),
                             )
                             await self.redis.expire(results_key, TASK_GROUP_TTL_SECONDS)

--- a/src/by_framework/worker/worker.py
+++ b/src/by_framework/worker/worker.py
@@ -131,6 +131,20 @@ class GatewayWorker(ABC):
         """
         pass
 
+    async def on_cancelled_resume(
+        self, command: GatewayCommand, context: AgentContext, reason: str
+    ) -> None:
+        """Called when a resume arrives for an execution already marked
+        cancelled — the execution has no live task to cancel (it fully
+        suspended, e.g. awaiting ask_user or a sub-agent reply), so this is
+        the only hook that fires before ``_handle_message`` bails out
+        without calling ``process_command``.
+
+        Override this to clean up any out-of-band state (e.g. Redis) a
+        suspended execution left behind. No-op by default.
+        """
+        pass
+
     async def process_command(
         self, command: GatewayCommand, context: AgentContext
     ) -> ProcessCommandResult:
@@ -640,6 +654,7 @@ class GatewayWorker(ABC):
             # 3. Process
             logger.info("[%s] Starting task processing", self.worker_id)
             if cancel_event and cancel_event.is_set():
+                await self.on_cancelled_resume(command, context, cancel_reason)
                 raise asyncio.CancelledError(
                     f"Task cancelled before processing (reason: {cancel_reason})"
                 )

--- a/tests/integration/test_scatter_gather.py
+++ b/tests/integration/test_scatter_gather.py
@@ -190,14 +190,21 @@ async def test_group_join_delivers_aggregated_results_on_resume(tmp_path):
     task_group_id = dispatch_result["task_group_id"]
     msg_b, msg_c = (t["message_id"] for t in dispatch_result["dispatched_tasks"])
 
+    # _enqueue_agent_return sets a reply's header.message_id to the caller's
+    # own message_id (shared by every sibling reply in this Task Group) and
+    # header.parent_message_id to the sub-task's own dispatch-time message_id
+    # (msg_b/msg_c here, distinct per task) — mirror that real relationship,
+    # not a hand-picked distinct message_id per reply, or this test can't
+    # catch a Group Join bug that only shows up when siblings' replies
+    # collide on the shared header.message_id.
     reply_b = ResumeCommand(
         header=MessageHeader(
-            message_id=msg_b,
+            message_id="parent-msg",
             session_id="s1",
             trace_id="t1",
             source_agent_type="agent-b",
             target_agent_type="caller_agent",
-            parent_message_id="parent-msg",
+            parent_message_id=msg_b,
             task_group_id=task_group_id,
         ),
         status="COMPLETED",
@@ -209,12 +216,12 @@ async def test_group_join_delivers_aggregated_results_on_resume(tmp_path):
 
     reply_c = ResumeCommand(
         header=MessageHeader(
-            message_id=msg_c,
+            message_id="parent-msg",
             session_id="s1",
             trace_id="t1",
             source_agent_type="agent-c",
             target_agent_type="caller_agent",
-            parent_message_id="parent-msg",
+            parent_message_id=msg_c,
             task_group_id=task_group_id,
         ),
         status="COMPLETED",
@@ -274,12 +281,12 @@ async def test_group_join_delivers_aggregate_even_with_partial_failure(tmp_path)
     await worker._handle_message(
         ResumeCommand(
             header=MessageHeader(
-                message_id=msg_b,
+                message_id="parent-msg",
                 session_id="s1",
                 trace_id="t1",
                 source_agent_type="agent-b",
                 target_agent_type="caller_agent",
-                parent_message_id="parent-msg",
+                parent_message_id=msg_b,
                 task_group_id=task_group_id,
             ),
             status="FAILED",
@@ -289,12 +296,12 @@ async def test_group_join_delivers_aggregate_even_with_partial_failure(tmp_path)
     await worker._handle_message(
         ResumeCommand(
             header=MessageHeader(
-                message_id=msg_c,
+                message_id="parent-msg",
                 session_id="s1",
                 trace_id="t1",
                 source_agent_type="agent-c",
                 target_agent_type="caller_agent",
-                parent_message_id="parent-msg",
+                parent_message_id=msg_c,
                 task_group_id=task_group_id,
             ),
             status="COMPLETED",
@@ -341,12 +348,12 @@ async def test_collect_group_results_still_works_outside_process_command(tmp_pat
     await worker._handle_message(
         ResumeCommand(
             header=MessageHeader(
-                message_id=msg_b,
+                message_id="parent-msg",
                 session_id="s1",
                 trace_id="t1",
                 source_agent_type="agent-b",
                 target_agent_type="caller_agent",
-                parent_message_id="parent-msg",
+                parent_message_id=msg_b,
                 task_group_id=task_group_id,
             ),
             status="COMPLETED",
@@ -396,12 +403,12 @@ async def test_collect_group_results_times_out_with_partial_results(tmp_path):
     await worker._handle_message(
         ResumeCommand(
             header=MessageHeader(
-                message_id=msg_b,
+                message_id="parent-msg",
                 session_id="s1",
                 trace_id="t1",
                 source_agent_type="agent-b",
                 target_agent_type="caller_agent",
-                parent_message_id="parent-msg",
+                parent_message_id=msg_b,
                 task_group_id=task_group_id,
             ),
             status="COMPLETED",
@@ -451,12 +458,12 @@ async def test_group_join_discards_reply_for_aborted_task_group(tmp_path):
     await worker._handle_message(
         ResumeCommand(
             header=MessageHeader(
-                message_id=msg_b,
+                message_id="parent-msg",
                 session_id="s1",
                 trace_id="t1",
                 source_agent_type="agent-b",
                 target_agent_type="caller_agent",
-                parent_message_id="parent-msg",
+                parent_message_id=msg_b,
                 task_group_id=task_group_id,
             ),
             status="COMPLETED",

--- a/tests/integration/test_scatter_gather.py
+++ b/tests/integration/test_scatter_gather.py
@@ -1,9 +1,16 @@
 from typing import List
+from unittest.mock import AsyncMock
 
 import pytest
 
+from by_framework.common.constants import (
+    TASK_GROUP_FIELD_ABORTED,
+    TASK_GROUP_FIELD_COMPLETED,
+    RedisKeys,
+)
 from by_framework.core.protocol.commands import ResumeCommand
 from by_framework.core.protocol.message_header import MessageHeader
+from by_framework.worker.context import AgentContext
 from by_framework.worker.worker import GatewayWorker
 
 
@@ -13,6 +20,87 @@ class DummyWorker(GatewayWorker):
         return ["dummy"]
 
     async def process_command(self, command, context):
+        return {"status": "ok"}
+
+
+class MockRedis:
+    """Minimal in-memory Redis hash store for scatter-gather join tests."""
+
+    def __init__(self):
+        self.data = {}
+
+    async def hset(self, name, key=None, value=None, mapping=None):
+        bucket = self.data.setdefault(name, {})
+        if mapping:
+            bucket.update(mapping)
+        else:
+            bucket[key] = value
+
+    async def hget(self, name, key):
+        return self.data.get(name, {}).get(key)
+
+    async def hgetall(self, name):
+        return dict(self.data.get(name, {}))
+
+    async def hincrby(self, name, key, amount=1):
+        bucket = self.data.setdefault(name, {})
+        value = int(bucket.get(key, 0)) + amount
+        bucket[key] = value
+        return value
+
+    async def expire(self, name, ttl):
+        return 1
+
+    async def xadd(self, name, fields):
+        return "0-1"
+
+    async def smembers(self, name):
+        # Every agent type is treated as having one online worker, so
+        # dispatch-time availability checks always pass in these tests.
+        return {b"worker-1"}
+
+    async def get(self, name):
+        return b"1"
+
+    def pipeline(self):
+        return _MockPipeline(self)
+
+
+class _MockPipeline:
+    """Minimal pipeline shim: queues (method, args) and applies them on execute()."""
+
+    def __init__(self, redis):
+        self._redis = redis
+        self._ops = []
+
+    def __getattr__(self, name):
+
+        def queue(*args, **kwargs):
+            self._ops.append((name, args, kwargs))
+            return self
+
+        return queue
+
+    async def execute(self):
+        results = []
+        for name, args, kwargs in self._ops:
+            results.append(await getattr(self._redis, name)(*args, **kwargs))
+        self._ops = []
+        return results
+
+
+class RecordingProcessCommandWorker(GatewayWorker):
+    """Worker that records every command handed to process_command."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.received_commands = []
+
+    def get_agent_types(self) -> List[str]:
+        return ["caller_agent"]
+
+    async def process_command(self, command, context):
+        self.received_commands.append(command)
         return {"status": "ok"}
 
 
@@ -66,3 +154,316 @@ async def test_persist_agent_return_state_scatter_gather(tmp_path):
     assert "B result" in content_b
     content_c = (returns_dir / "msg-c.json").read_text()
     assert "C result" in content_c
+
+
+@pytest.mark.asyncio
+async def test_group_join_delivers_aggregated_results_on_resume(tmp_path):
+    """process_command is resumed with every sub-task's result once the
+    Task Group completes, not with whichever reply happened to arrive last."""
+    redis = MockRedis()
+    workspace_manager = AsyncMock()
+    workspace_manager.setup_workspace.return_value = {
+        "private": str(tmp_path),
+        "public": str(tmp_path),
+    }
+
+    worker = RecordingProcessCommandWorker(
+        worker_id="test-join",
+        redis_client=redis,
+        registry=AsyncMock(),
+        workspace_manager=workspace_manager,
+    )
+
+    caller_context = AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=redis,
+        current_agent_id="caller_agent",
+        message_id="parent-msg",
+    )
+    dispatch_result = await caller_context.dispatch_group(
+        tasks=[
+            {"target_agent_type": "agent-b", "content": "task one"},
+            {"target_agent_type": "agent-c", "content": "task two"},
+        ],
+    )
+    task_group_id = dispatch_result["task_group_id"]
+    msg_b, msg_c = (t["message_id"] for t in dispatch_result["dispatched_tasks"])
+
+    reply_b = ResumeCommand(
+        header=MessageHeader(
+            message_id=msg_b,
+            session_id="s1",
+            trace_id="t1",
+            source_agent_type="agent-b",
+            target_agent_type="caller_agent",
+            parent_message_id="parent-msg",
+            task_group_id=task_group_id,
+        ),
+        status="COMPLETED",
+        content="B result",
+        reply_data={"value": "b"},
+    )
+    await worker._handle_message(reply_b)
+    assert worker.received_commands == []
+
+    reply_c = ResumeCommand(
+        header=MessageHeader(
+            message_id=msg_c,
+            session_id="s1",
+            trace_id="t1",
+            source_agent_type="agent-c",
+            target_agent_type="caller_agent",
+            parent_message_id="parent-msg",
+            task_group_id=task_group_id,
+        ),
+        status="COMPLETED",
+        content="C result",
+        reply_data={"value": "c"},
+    )
+    await worker._handle_message(reply_c)
+
+    assert len(worker.received_commands) == 1
+    resumed = worker.received_commands[0]
+    aggregate = resumed.reply_data
+    assert isinstance(aggregate, list)
+    assert len(aggregate) == 2
+
+    by_message_id = {item["message_id"]: item for item in aggregate}
+    assert by_message_id[msg_b]["target_agent_type"] == "agent-b"
+    assert by_message_id[msg_b]["reply_data"] == {"value": "b"}
+    assert by_message_id[msg_b]["status"] == "COMPLETED"
+    assert by_message_id[msg_c]["target_agent_type"] == "agent-c"
+    assert by_message_id[msg_c]["reply_data"] == {"value": "c"}
+
+
+@pytest.mark.asyncio
+async def test_group_join_delivers_aggregate_even_with_partial_failure(tmp_path):
+    """A failed sub-task still completes the group; the caller sees both
+    outcomes in the aggregate instead of the group hanging or erroring."""
+    redis = MockRedis()
+    workspace_manager = AsyncMock()
+    workspace_manager.setup_workspace.return_value = {
+        "private": str(tmp_path),
+        "public": str(tmp_path),
+    }
+
+    worker = RecordingProcessCommandWorker(
+        worker_id="test-join-partial",
+        redis_client=redis,
+        registry=AsyncMock(),
+        workspace_manager=workspace_manager,
+    )
+
+    caller_context = AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=redis,
+        current_agent_id="caller_agent",
+        message_id="parent-msg",
+    )
+    dispatch_result = await caller_context.dispatch_group(
+        tasks=[
+            {"target_agent_type": "agent-b", "content": "task one"},
+            {"target_agent_type": "agent-c", "content": "task two"},
+        ],
+    )
+    task_group_id = dispatch_result["task_group_id"]
+    msg_b, msg_c = (t["message_id"] for t in dispatch_result["dispatched_tasks"])
+
+    await worker._handle_message(
+        ResumeCommand(
+            header=MessageHeader(
+                message_id=msg_b,
+                session_id="s1",
+                trace_id="t1",
+                source_agent_type="agent-b",
+                target_agent_type="caller_agent",
+                parent_message_id="parent-msg",
+                task_group_id=task_group_id,
+            ),
+            status="FAILED",
+            reply_data={"error": "boom"},
+        )
+    )
+    await worker._handle_message(
+        ResumeCommand(
+            header=MessageHeader(
+                message_id=msg_c,
+                session_id="s1",
+                trace_id="t1",
+                source_agent_type="agent-c",
+                target_agent_type="caller_agent",
+                parent_message_id="parent-msg",
+                task_group_id=task_group_id,
+            ),
+            status="COMPLETED",
+            reply_data={"value": "c"},
+        )
+    )
+
+    assert len(worker.received_commands) == 1
+    aggregate = worker.received_commands[0].reply_data
+    by_message_id = {item["message_id"]: item for item in aggregate}
+    assert by_message_id[msg_b]["status"] == "FAILED"
+    assert by_message_id[msg_c]["status"] == "COMPLETED"
+
+
+@pytest.mark.asyncio
+async def test_collect_group_results_still_works_outside_process_command(tmp_path):
+    """collect_group_results remains a valid manual-polling path, unchanged
+    by the automatic aggregation delivered through resume."""
+    redis = MockRedis()
+    caller_context = AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=redis,
+        current_agent_id="caller_agent",
+        message_id="parent-msg",
+    )
+    dispatch_result = await caller_context.dispatch_group(
+        tasks=[{"target_agent_type": "agent-b", "content": "task one"}],
+    )
+    task_group_id = dispatch_result["task_group_id"]
+    msg_b = dispatch_result["dispatched_tasks"][0]["message_id"]
+
+    workspace_manager = AsyncMock()
+    workspace_manager.setup_workspace.return_value = {
+        "private": str(tmp_path),
+        "public": str(tmp_path),
+    }
+    worker = RecordingProcessCommandWorker(
+        worker_id="test-manual-poll",
+        redis_client=redis,
+        registry=AsyncMock(),
+        workspace_manager=workspace_manager,
+    )
+    await worker._handle_message(
+        ResumeCommand(
+            header=MessageHeader(
+                message_id=msg_b,
+                session_id="s1",
+                trace_id="t1",
+                source_agent_type="agent-b",
+                target_agent_type="caller_agent",
+                parent_message_id="parent-msg",
+                task_group_id=task_group_id,
+            ),
+            status="COMPLETED",
+            reply_data={"value": "b"},
+        )
+    )
+
+    results = await caller_context.collect_group_results(task_group_id, timeout=1.0)
+    assert len(results) == 1
+    assert results[0]["message_id"] == msg_b
+    assert results[0]["reply_data"] == {"value": "b"}
+
+
+@pytest.mark.asyncio
+async def test_collect_group_results_times_out_with_partial_results(tmp_path):
+    """A sub-task that never replies still lets manual polling time out
+    and return whatever partial results were collected."""
+    redis = MockRedis()
+    caller_context = AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=redis,
+        current_agent_id="caller_agent",
+        message_id="parent-msg",
+    )
+    dispatch_result = await caller_context.dispatch_group(
+        tasks=[
+            {"target_agent_type": "agent-b", "content": "task one"},
+            {"target_agent_type": "agent-c", "content": "task two"},
+        ],
+    )
+    task_group_id = dispatch_result["task_group_id"]
+    msg_b = dispatch_result["dispatched_tasks"][0]["message_id"]
+
+    workspace_manager = AsyncMock()
+    workspace_manager.setup_workspace.return_value = {
+        "private": str(tmp_path),
+        "public": str(tmp_path),
+    }
+    worker = RecordingProcessCommandWorker(
+        worker_id="test-timeout",
+        redis_client=redis,
+        registry=AsyncMock(),
+        workspace_manager=workspace_manager,
+    )
+    # Only agent-b ever replies; agent-c never does.
+    await worker._handle_message(
+        ResumeCommand(
+            header=MessageHeader(
+                message_id=msg_b,
+                session_id="s1",
+                trace_id="t1",
+                source_agent_type="agent-b",
+                target_agent_type="caller_agent",
+                parent_message_id="parent-msg",
+                task_group_id=task_group_id,
+            ),
+            status="COMPLETED",
+            reply_data={"value": "b"},
+        )
+    )
+
+    results = await caller_context.collect_group_results(task_group_id, timeout=0.3)
+    assert len(results) == 1
+    assert results[0]["message_id"] == msg_b
+
+
+@pytest.mark.asyncio
+async def test_group_join_discards_reply_for_aborted_task_group(tmp_path):
+    """A reply for a Task Group that was aborted mid-dispatch is dropped,
+    never counted, and never used to resume the (already-failed) caller."""
+    redis = MockRedis()
+    workspace_manager = AsyncMock()
+    workspace_manager.setup_workspace.return_value = {
+        "private": str(tmp_path),
+        "public": str(tmp_path),
+    }
+    worker = RecordingProcessCommandWorker(
+        worker_id="test-abort",
+        redis_client=redis,
+        registry=AsyncMock(),
+        workspace_manager=workspace_manager,
+    )
+
+    caller_context = AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=redis,
+        current_agent_id="caller_agent",
+        message_id="parent-msg",
+    )
+    dispatch_result = await caller_context.dispatch_group(
+        tasks=[{"target_agent_type": "agent-b", "content": "one"}],
+    )
+    task_group_id = dispatch_result["task_group_id"]
+    msg_b = dispatch_result["dispatched_tasks"][0]["message_id"]
+
+    # Simulate a mid-dispatch failure (e.g. a later sibling's xadd raised)
+    # that marked this group aborted after agent-b had already been sent.
+    await redis.hset(RedisKeys.task_group(task_group_id), TASK_GROUP_FIELD_ABORTED, "1")
+
+    await worker._handle_message(
+        ResumeCommand(
+            header=MessageHeader(
+                message_id=msg_b,
+                session_id="s1",
+                trace_id="t1",
+                source_agent_type="agent-b",
+                target_agent_type="caller_agent",
+                parent_message_id="parent-msg",
+                task_group_id=task_group_id,
+            ),
+            status="COMPLETED",
+            reply_data={"value": "b"},
+        )
+    )
+
+    assert worker.received_commands == []
+    group_hash = redis.data[RedisKeys.task_group(task_group_id)]
+    assert group_hash.get(TASK_GROUP_FIELD_COMPLETED, "0") == "0"

--- a/tests/worker/test_context.py
+++ b/tests/worker/test_context.py
@@ -8,8 +8,10 @@ import pytest
 
 import by_framework.worker.context as context_module
 from by_framework import AgentContext
+from by_framework.common.constants import TASK_GROUP_FIELD_ABORTED, RedisKeys
 from by_framework.core.extensions.plugin import Plugin, PluginManifest
 from by_framework.core.extensions.registry import PluginRegistry
+from by_framework.core.protocol.agent_state import AgentState
 from by_framework.core.protocol.byai_codec import ByaiContentCodec
 from by_framework.core.protocol.commands import (AskAgentCommand, command_from_dict)
 from by_framework.core.protocol.message import (BaiYingMessage, BaiYingMessageRole)
@@ -327,6 +329,8 @@ async def test_context_dispatch_group_propagates_langfuse_observation_id():
     mock_pipe = MagicMock()
     mock_pipe.execute = AsyncMock(return_value=[])
     mock_redis.pipeline.return_value = mock_pipe
+    mock_redis.smembers = AsyncMock(return_value={b"worker-1"})
+    mock_redis.get = AsyncMock(return_value=b"1")
 
     ctx = AgentContext(session_id="s1", trace_id="t1", redis_client=mock_redis)
 
@@ -365,6 +369,8 @@ async def test_context_dispatch_group_prefers_metadata_langfuse_parent():
     mock_pipe = MagicMock()
     mock_pipe.execute = AsyncMock(return_value=[])
     mock_redis.pipeline.return_value = mock_pipe
+    mock_redis.smembers = AsyncMock(return_value={b"worker-1"})
+    mock_redis.get = AsyncMock(return_value=b"1")
 
     ctx = AgentContext(session_id="s1", trace_id="t1", redis_client=mock_redis)
 
@@ -405,6 +411,8 @@ async def test_context_dispatch_group_triggers_plugin_lifecycle_hooks():
     mock_pipe = MagicMock()
     mock_pipe.execute = AsyncMock(return_value=[])
     mock_redis.pipeline.return_value = mock_pipe
+    mock_redis.smembers = AsyncMock(return_value={b"worker-1"})
+    mock_redis.get = AsyncMock(return_value=b"1")
 
     plugin = RecordingCallAgentPlugin()
     registry = PluginRegistry()
@@ -426,7 +434,7 @@ async def test_context_dispatch_group_triggers_plugin_lifecycle_hooks():
         ],
     )
 
-    assert result["status"] == "GROUP_QUEUED"
+    assert result["status"] == AgentState.QUEUED.value
     assert [event[0] for event in plugin.events] == [
         "start",
         "complete",
@@ -437,6 +445,129 @@ async def test_context_dispatch_group_triggers_plugin_lifecycle_hooks():
         "agent-b",
         "agent-c",
     }
+
+
+@pytest.mark.asyncio
+async def test_context_call_agents_dispatches_like_dispatch_group():
+    """call_agents is call_agent's plural: same dispatch, same status vocabulary."""
+    from unittest.mock import MagicMock
+
+    mock_redis = MagicMock()
+    mock_redis.xadd = AsyncMock()
+    mock_redis.hset = AsyncMock()
+    mock_redis.expire = AsyncMock()
+    mock_redis.smembers = AsyncMock(return_value={b"worker-1"})
+    mock_redis.get = AsyncMock(return_value=b"1")
+
+    ctx = AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=mock_redis,
+        current_agent_id="agent-a",
+        message_id="parent-msg",
+    )
+
+    result = await ctx.call_agents(
+        tasks=[
+            {"target_agent_type": "agent-b", "content": "one"},
+            {"target_agent_type": "agent-c", "content": "two"},
+        ],
+    )
+
+    assert result["status"] == AgentState.QUEUED.value
+    assert len(result["dispatched_tasks"]) == 2
+    assert mock_redis.xadd.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_context_call_agents_marks_unavailable_task_failed():
+    """An offline target agent type fails fast as one group member, the
+    rest of the batch still dispatches."""
+    from unittest.mock import MagicMock
+
+    mock_redis = MagicMock()
+    mock_redis.xadd = AsyncMock()
+    mock_redis.hset = AsyncMock()
+    mock_redis.expire = AsyncMock()
+    mock_redis.hincrby = AsyncMock(return_value=1)
+
+    async def smembers_side_effect(name):
+        if name == RedisKeys.agent_type_members("agent-b"):
+            return {b"worker-1"}
+        return set()
+
+    mock_redis.smembers = AsyncMock(side_effect=smembers_side_effect)
+    mock_redis.get = AsyncMock(return_value=b"1")
+
+    plugin = RecordingCallAgentPlugin()
+    registry = PluginRegistry()
+    registry.register_bundle(plugin)
+
+    ctx = AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=mock_redis,
+        current_agent_id="agent-a",
+        message_id="parent-msg",
+        plugin_registry=registry,
+    )
+
+    result = await ctx.call_agents(
+        tasks=[
+            {"target_agent_type": "agent-b", "content": "one"},
+            {"target_agent_type": "agent-c", "content": "two"},
+        ],
+    )
+
+    assert result["status"] == AgentState.QUEUED.value
+    assert len(result["dispatched_tasks"]) == 2
+
+    # Only the available target actually got dispatched.
+    assert mock_redis.xadd.await_count == 1
+    xadd_args, _ = mock_redis.xadd.call_args
+    dispatched_command = command_from_dict(json.loads(xadd_args[1]["data"]))
+    assert dispatched_command.header.target_agent_type == "agent-b"
+
+    # The unavailable task was recorded as FAILED and counted toward completion.
+    assert mock_redis.hincrby.await_count == 1
+    results_writes = [c for c in mock_redis.hset.await_args_list if len(c.args) >= 3]
+    assert len(results_writes) == 1
+    failure_payload = json.loads(results_writes[0].args[2])
+    assert failure_payload["status"] == AgentState.FAILED.value
+    assert failure_payload["target_agent_type"] == "agent-c"
+    assert failure_payload["error_code"] == "AGENT_TYPE_UNAVAILABLE"
+
+    # Same plugin hooks call_agent's own availability failure fires: a
+    # "start"/"error" pair for the unavailable agent-c, alongside the
+    # normal "start"/"complete" pair for the dispatched agent-b.
+    assert [event[0] for event in plugin.events] == [
+        "start",
+        "complete",
+        "start",
+        "error",
+    ]
+    assert {e[1] for e in plugin.events if e[0] == "start"} == {"agent-b", "agent-c"}
+    error_event = next(e for e in plugin.events if e[0] == "error")
+    assert failure_payload["error"] in error_event[1]
+
+
+@pytest.mark.asyncio
+async def test_context_dispatch_group_rejects_empty_task_list():
+    """An empty task list is a caller bug, not a valid no-op group."""
+    from unittest.mock import MagicMock
+
+    mock_redis = MagicMock()
+    mock_redis.hset = AsyncMock()
+    mock_redis.expire = AsyncMock()
+    mock_redis.xadd = AsyncMock()
+
+    ctx = AgentContext(session_id="s1", trace_id="t1", redis_client=mock_redis)
+
+    with pytest.raises(ValueError):
+        await ctx.dispatch_group(tasks=[])
+
+    mock_redis.hset.assert_not_called()
+    mock_redis.xadd.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -451,6 +582,8 @@ async def test_context_dispatch_group_triggers_error_hook_on_dispatch_failure():
     mock_pipe = MagicMock()
     mock_pipe.execute = AsyncMock(return_value=[])
     mock_redis.pipeline.return_value = mock_pipe
+    mock_redis.smembers = AsyncMock(return_value={b"worker-1"})
+    mock_redis.get = AsyncMock(return_value=b"1")
 
     plugin = RecordingCallAgentPlugin()
     registry = PluginRegistry()
@@ -473,6 +606,49 @@ async def test_context_dispatch_group_triggers_error_hook_on_dispatch_failure():
     assert [event[0] for event in plugin.events] == ["start", "error"]
     assert plugin.events[0][1] == "agent-b"
     assert "redis down" in plugin.events[1][1]
+
+
+@pytest.mark.asyncio
+async def test_context_call_agents_marks_group_aborted_on_mid_dispatch_failure():
+    """A dispatch-time infra error stops the batch and marks the Task Group
+    aborted, so already-sent siblings' replies won't later resume a caller
+    execution that already ended in failure."""
+    from unittest.mock import MagicMock
+
+    mock_redis = MagicMock()
+    mock_redis.xadd = AsyncMock(side_effect=[None, RuntimeError("redis down")])
+    mock_redis.hset = AsyncMock()
+    mock_redis.expire = AsyncMock()
+    mock_redis.smembers = AsyncMock(return_value={b"worker-1"})
+    mock_redis.get = AsyncMock(return_value=b"1")
+
+    ctx = AgentContext(
+        session_id="s1",
+        trace_id="t1",
+        redis_client=mock_redis,
+        current_agent_id="agent-a",
+        message_id="parent-msg",
+    )
+
+    with pytest.raises(RuntimeError, match="redis down"):
+        await ctx.call_agents(
+            tasks=[
+                {"target_agent_type": "agent-b", "content": "one"},
+                {"target_agent_type": "agent-c", "content": "two"},
+                {"target_agent_type": "agent-d", "content": "three"},
+            ],
+        )
+
+    # Only the two tasks up to (and including) the failing one were attempted.
+    assert mock_redis.xadd.await_count == 2
+
+    abort_writes = [
+        c
+        for c in mock_redis.hset.await_args_list
+        if len(c.args) >= 2 and c.args[1] == TASK_GROUP_FIELD_ABORTED
+    ]
+    assert len(abort_writes) == 1
+    assert abort_writes[0].args[2] == "1"
 
 
 @pytest.mark.asyncio
@@ -637,6 +813,8 @@ async def test_context_dispatch_group_serializes_baiying_message_with_codec():
     mock_pipe = MagicMock()
     mock_pipe.execute = AsyncMock(return_value=[])
     mock_redis.pipeline.return_value = mock_pipe
+    mock_redis.smembers = AsyncMock(return_value={b"worker-1"})
+    mock_redis.get = AsyncMock(return_value=b"1")
 
     ctx = AgentContext(
         session_id="s1",
@@ -682,6 +860,8 @@ async def test_context_dispatch_group_records_dispatch_spans():
     mock_pipe = MagicMock()
     mock_pipe.execute = AsyncMock(return_value=[])
     mock_redis.pipeline.return_value = mock_pipe
+    mock_redis.smembers = AsyncMock(return_value={b"worker-1"})
+    mock_redis.get = AsyncMock(return_value=b"1")
     span_recorder = AsyncMock()
 
     ctx = AgentContext(

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,7 @@ resolution-markers = [
 members = [
     "by-framework",
     "by-framework-adk",
+    "by-framework-agent",
     "by-framework-dashboard",
     "by-framework-history-byclaw",
     "by-framework-history-postgres",
@@ -394,6 +395,38 @@ requires-dist = [
     { name = "google-adk" },
     { name = "google-genai" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.13.0" },
+    { name = "pyink", marker = "extra == 'dev'", specifier = ">=24.0.0" },
+    { name = "pylint", marker = "extra == 'dev'", specifier = ">=3.0.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "by-framework-agent"
+version = "0.0.1.dev1"
+source = { editable = "libs/by-framework-agent" }
+dependencies = [
+    { name = "by-framework" },
+    { name = "litellm" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "isort" },
+    { name = "pyink" },
+    { name = "pylint" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "by-framework", editable = "." },
+    { name = "isort", marker = "extra == 'dev'", specifier = ">=5.13.0" },
+    { name = "litellm", specifier = ">=1.93.0" },
     { name = "pyink", marker = "extra == 'dev'", specifier = ">=24.0.0" },
     { name = "pylint", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -926,6 +959,47 @@ wheels = [
 ]
 
 [[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/a2/e78fcc5df65467f0d207661b7ef86c5b7ac62eea337c0c0fcedbeee6fb13/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77e94728324b63660ebf8adb27055e92d2e4611645bf12ed9d88d30486471d0a", size = 510164, upload-time = "2025-10-19T22:31:45.635Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b3/c846f933f22f581f558ee63f81f29fa924acd971ce903dab1a9b6701816e/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:caa1f14d2102cb8d353096bc6ef6c13b2c81f347e6ab9d6fbd48b9dea41c153d", size = 261837, upload-time = "2025-10-19T22:38:38.53Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ea/682551030f8c4fa9a769d9825570ad28c0c71e30cf34020b85c1f7ee7382/fastuuid-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d23ef06f9e67163be38cece704170486715b177f6baae338110983f99a72c070", size = 251370, upload-time = "2025-10-19T22:40:26.07Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/5927f0a523d8e6a76b70968e6004966ee7df30322f5fc9b6cdfb0276646a/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c9ec605ace243b6dbe3bd27ebdd5d33b00d8d1d3f580b39fdd15cd96fd71796", size = 277766, upload-time = "2025-10-19T22:37:23.779Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6e/c0fb547eef61293153348f12e0f75a06abb322664b34a1573a7760501336/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:808527f2407f58a76c916d6aa15d58692a4a019fdf8d4c32ac7ff303b7d7af09", size = 278105, upload-time = "2025-10-19T22:26:56.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b1/b9c75e03b768f61cf2e84ee193dc18601aeaf89a4684b20f2f0e9f52b62c/fastuuid-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fb3c0d7fef6674bbeacdd6dbd386924a7b60b26de849266d1ff6602937675c8", size = 301564, upload-time = "2025-10-19T22:30:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/fa/f7395fdac07c7a54f18f801744573707321ca0cee082e638e36452355a9d/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab3f5d36e4393e628a4df337c2c039069344db5f4b9d2a3c9cea48284f1dd741", size = 459659, upload-time = "2025-10-19T22:31:32.341Z" },
+    { url = "https://files.pythonhosted.org/packages/66/49/c9fd06a4a0b1f0f048aacb6599e7d96e5d6bc6fa680ed0d46bf111929d1b/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b9a0ca4f03b7e0b01425281ffd44e99d360e15c895f1907ca105854ed85e2057", size = 478430, upload-time = "2025-10-19T22:26:22.962Z" },
+    { url = "https://files.pythonhosted.org/packages/be/9c/909e8c95b494e8e140e8be6165d5fc3f61fdc46198c1554df7b3e1764471/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3acdf655684cc09e60fb7e4cf524e8f42ea760031945aa8086c7eae2eeeabeb8", size = 450894, upload-time = "2025-10-19T22:27:01.647Z" },
+    { url = "https://files.pythonhosted.org/packages/90/eb/d29d17521976e673c55ef7f210d4cdd72091a9ec6755d0fd4710d9b3c871/fastuuid-0.14.0-cp312-cp312-win32.whl", hash = "sha256:9579618be6280700ae36ac42c3efd157049fe4dd40ca49b021280481c78c3176", size = 154374, upload-time = "2025-10-19T22:29:19.879Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fc/f5c799a6ea6d877faec0472d0b27c079b47c86b1cdc577720a5386483b36/fastuuid-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:d9e4332dc4ba054434a9594cbfaf7823b57993d7d8e7267831c3e059857cf397", size = 156550, upload-time = "2025-10-19T22:27:49.658Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/ae12dd39b9a39b55d7f90abb8971f1a5f3c321fd72d5aa83f90dc67fe9ed/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77a09cb7427e7af74c594e409f7731a0cf887221de2f698e1ca0ebf0f3139021", size = 510720, upload-time = "2025-10-19T22:42:34.633Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b0/a4b03ff5d00f563cc7546b933c28cb3f2a07344b2aec5834e874f7d44143/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9bd57289daf7b153bfa3e8013446aa144ce5e8c825e9e366d455155ede5ea2dc", size = 262024, upload-time = "2025-10-19T22:30:25.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6d/64aee0a0f6a58eeabadd582e55d0d7d70258ffdd01d093b30c53d668303b/fastuuid-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ac60fc860cdf3c3f327374db87ab8e064c86566ca8c49d2e30df15eda1b0c2d5", size = 251679, upload-time = "2025-10-19T22:36:14.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f5/a7e9cda8369e4f7919d36552db9b2ae21db7915083bc6336f1b0082c8b2e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab32f74bd56565b186f036e33129da77db8be09178cd2f5206a5d4035fb2a23f", size = 277862, upload-time = "2025-10-19T22:36:23.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d3/8ce11827c783affffd5bd4d6378b28eb6cc6d2ddf41474006b8d62e7448e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33e678459cf4addaedd9936bbb038e35b3f6b2061330fd8f2f6a1d80414c0f87", size = 278278, upload-time = "2025-10-19T22:29:43.809Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/680fb6352d0bbade04036da46264a8001f74b7484e2fd1f4da9e3db1c666/fastuuid-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e3cc56742f76cd25ecb98e4b82a25f978ccffba02e4bdce8aba857b6d85d87b", size = 301788, upload-time = "2025-10-19T22:36:06.825Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7c/2014b5785bd8ebdab04ec857635ebd84d5ee4950186a577db9eff0fb8ff6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cb9a030f609194b679e1660f7e32733b7a0f332d519c5d5a6a0a580991290022", size = 459819, upload-time = "2025-10-19T22:35:31.623Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d2/524d4ceeba9160e7a9bc2ea3e8f4ccf1ad78f3bde34090ca0c51f09a5e91/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:09098762aad4f8da3a888eb9ae01c84430c907a297b97166b8abc07b640f2995", size = 478546, upload-time = "2025-10-19T22:26:03.023Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/354d04951ce114bf4afc78e27a18cfbd6ee319ab1829c2d5fb5e94063ac6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:1383fff584fa249b16329a059c68ad45d030d5a4b70fb7c73a08d98fd53bcdab", size = 450921, upload-time = "2025-10-19T22:31:02.151Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/be/d7be8670151d16d88f15bb121c5b66cdb5ea6a0c2a362d0dcf30276ade53/fastuuid-0.14.0-cp313-cp313-win32.whl", hash = "sha256:a0809f8cc5731c066c909047f9a314d5f536c871a7a22e815cc4967c110ac9ad", size = 154559, upload-time = "2025-10-19T22:36:36.011Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1d/5573ef3624ceb7abf4a46073d3554e37191c868abc3aecd5289a72f9810a/fastuuid-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0df14e92e7ad3276327631c9e7cec09e32572ce82089c55cb1bb8df71cf394ed", size = 156539, upload-time = "2025-10-19T22:33:35.898Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c9/8c7660d1fe3862e3f8acabd9be7fc9ad71eb270f1c65cce9a2b7a31329ab/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b852a870a61cfc26c884af205d502881a2e59cc07076b60ab4a951cc0c94d1ad", size = 510600, upload-time = "2025-10-19T22:43:44.17Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f4/a989c82f9a90d0ad995aa957b3e572ebef163c5299823b4027986f133dfb/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c7502d6f54cd08024c3ea9b3514e2d6f190feb2f46e6dbcd3747882264bb5f7b", size = 262069, upload-time = "2025-10-19T22:43:38.38Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6c/a1a24f73574ac995482b1326cf7ab41301af0fabaa3e37eeb6b3df00e6e2/fastuuid-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ca61b592120cf314cfd66e662a5b54a578c5a15b26305e1b8b618a6f22df714", size = 251543, upload-time = "2025-10-19T22:32:22.537Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/20/2a9b59185ba7a6c7b37808431477c2d739fcbdabbf63e00243e37bd6bf49/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa75b6657ec129d0abded3bec745e6f7ab642e6dba3a5272a68247e85f5f316f", size = 277798, upload-time = "2025-10-19T22:33:53.821Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/33/4105ca574f6ded0af6a797d39add041bcfb468a1255fbbe82fcb6f592da2/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8a0dfea3972200f72d4c7df02c8ac70bad1bb4c58d7e0ec1e6f341679073a7f", size = 278283, upload-time = "2025-10-19T22:29:02.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8c/fca59f8e21c4deb013f574eae05723737ddb1d2937ce87cb2a5d20992dc3/fastuuid-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1bf539a7a95f35b419f9ad105d5a8a35036df35fdafae48fb2fd2e5f318f0d75", size = 301627, upload-time = "2025-10-19T22:35:54.985Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e2/f78c271b909c034d429218f2798ca4e89eeda7983f4257d7865976ddbb6c/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:9a133bf9cc78fdbd1179cb58a59ad0100aa32d8675508150f3658814aeefeaa4", size = 459778, upload-time = "2025-10-19T22:28:00.999Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f0/5ff209d865897667a2ff3e7a572267a9ced8f7313919f6d6043aed8b1caa/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_i686.whl", hash = "sha256:f54d5b36c56a2d5e1a31e73b950b28a0d83eb0c37b91d10408875a5a29494bad", size = 478605, upload-time = "2025-10-19T22:36:21.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c8/2ce1c78f983a2c4987ea865d9516dbdfb141a120fd3abb977ae6f02ba7ca/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:ec27778c6ca3393ef662e2762dba8af13f4ec1aaa32d08d77f71f2a70ae9feb8", size = 450837, upload-time = "2025-10-19T22:34:37.178Z" },
+    { url = "https://files.pythonhosted.org/packages/df/60/dad662ec9a33b4a5fe44f60699258da64172c39bd041da2994422cdc40fe/fastuuid-0.14.0-cp314-cp314-win32.whl", hash = "sha256:e23fc6a83f112de4be0cc1990e5b127c27663ae43f866353166f87df58e73d06", size = 154532, upload-time = "2025-10-19T22:35:18.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/da4db31001e854025ffd26bc9ba0740a9cbba2c3259695f7c5834908b336/fastuuid-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:df61342889d0f5e7a32f7284e55ef95103f2110fee433c2ae7c2c0956d76ac8a", size = 156457, upload-time = "2025-10-19T22:33:44.579Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.25.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1021,6 +1095,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
 ]
 
 [[package]]
@@ -1710,6 +1793,30 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/39/67be8d71f900d9a55761b6022821d6679fb56c64f1b6063d5af2c2606727/hf_xet-1.5.2.tar.gz", hash = "sha256:73044bd31bae33c984af832d19c752a0dffb67518fee9ddbd91d616e1101cf47", size = 903674, upload-time = "2026-07-16T17:29:56.833Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/be/525eabac5d1736b679c39e342ecd4292534012546a2d18f0043c8e3b6021/hf_xet-1.5.2-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:4a5ecb9cda8512ba2aa8ee5d37c87a1422992165892d653098c7b90247481c3b", size = 4064284, upload-time = "2026-07-16T17:29:29.907Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/3f/699749dd78442480eda4e4fca494284b0e3542e4063cc37654d5fdc929e6/hf_xet-1.5.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8764488197c1d7b1378c8438c18d2eea902e150dbca0b0f0d2d32603fb9b5576", size = 3828537, upload-time = "2026-07-16T17:29:31.549Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d7/2658ac0a5b9f4664ca27ce31bd015044fe9dea50ed455fb5197aba819c11/hf_xet-1.5.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8d7446f72abbf7e01ca5ff131786bc2e74a56393462c17a6bf1e303fbab81db4", size = 4417133, upload-time = "2026-07-16T17:29:33.391Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/58/8343f3cb63c8fa058d576136df3871550f7d5214a8f048a7ea2eab6ac906/hf_xet-1.5.2-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:580e59e29bf37aece1f2b68537de1e3fb04f43a23d910dcf6f128280b5bfbba4", size = 4212613, upload-time = "2026-07-16T17:29:34.989Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/33/a968f4e4535037b36941ec00714625fb60e026302407e7e26ca9f3e65f4e/hf_xet-1.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bee28c619622d36968056532fd49cf2b35ca75099b1d616c31a618a893491380", size = 4412710, upload-time = "2026-07-16T17:29:36.646Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d9/9e33981173dbaf194ba0015202b02d467b624d44d4eba89e1bf06c0d2995/hf_xet-1.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e396ab0faf6298199ad7a95305c3ca8498cb825978a6485be6d00587ee4ec577", size = 4628455, upload-time = "2026-07-16T17:29:38.352Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/4b/cc682832de4264a03880a2d1b5ec3e1fab3bf307f508817250baafdb9996/hf_xet-1.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:fd3add255549e8ef58fa35b2e42dc016961c050600444e7d77d030ba6b57120e", size = 3979044, upload-time = "2026-07-16T17:29:40.329Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/09/b2cdf2a0fb39a08af3222b96092a36bd3b40c54123eef07de4422e870971/hf_xet-1.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d6f9c58549407b84b9a5383afd68db0acc42345326a3159990b36a5ca8a20e4e", size = 3808037, upload-time = "2026-07-16T17:29:42.357Z" },
+    { url = "https://files.pythonhosted.org/packages/de/ba/2b70603c7552db82baeb2623e2336898304a17328845151be4fe1f48d420/hf_xet-1.5.2-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f922b8f5fb84f1dd3d7ab7a1316354a1bca9b1c73ecfc19c76e51a2a49d29799", size = 4033760, upload-time = "2026-07-16T17:29:43.884Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ac/b097a86a1e4a6098f3a79382643ab09d5733d87ccc864877ad1e12b49b70/hf_xet-1.5.2-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:045f84440c55cdeb659cf1a1dd48c77bcd0d2e93632e2fea8f2c3bdee79f38ed", size = 3841438, upload-time = "2026-07-16T17:29:45.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/35/db860aa3a0780660324a506ad4b3d322ddc6ecbba4b9340aed0942cbf21c/hf_xet-1.5.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db78c39c83d6279daddc98e2238f373ab8980685556d42472b4ec51abcf03e8c", size = 4428006, upload-time = "2026-07-16T17:29:46.996Z" },
+    { url = "https://files.pythonhosted.org/packages/af/6b/832dd980af4b0c3ae0660e309285f2ffcdff2faa38129390dbb47aa4a3f9/hf_xet-1.5.2-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:7db73c810500c54c6760be8c39d4b2e476974de85424c50063efc22fdda13025", size = 4221099, upload-time = "2026-07-16T17:29:48.525Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/05/ae50f0d34e3254e6c3e208beb2519f6b8673016fc4b3643badaf6450d186/hf_xet-1.5.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6395cfe3c9cbead4f16b31808b0e67eac428b66c656f856e99636adaddea878f", size = 4420766, upload-time = "2026-07-16T17:29:50.092Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a9/c050bc2743a2bcd68928bfee157b08681667a164a24ec95fbfcfcd717e08/hf_xet-1.5.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:cde8cd167126bb6109b2ceb19b844433a4988643e8f3e01dd9dd0e4a34535097", size = 4636716, upload-time = "2026-07-16T17:29:51.62Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f8/68b01c5c2edb56ac9a67b3d076ffddcb90867abaee923923eb34e7a14e76/hf_xet-1.5.2-cp38-abi3-win_amd64.whl", hash = "sha256:ecf63d1cb69a9a7319910f8f83fcf9b46e7a32dfcf4b8f8eeddb55f647306e65", size = 3988373, upload-time = "2026-07-16T17:29:53.395Z" },
+    { url = "https://files.pythonhosted.org/packages/39/c6/988383e9dc17294d536fcbcd6fd16eed882e411ad16c954984a53e47b09c/hf_xet-1.5.2-cp38-abi3-win_arm64.whl", hash = "sha256:1da28519496eb7c8094c11e4d25509b4a468457a0302d58136099db2fd9a671d", size = 3816957, upload-time = "2026-07-16T17:29:54.991Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1759,6 +1866,26 @@ wheels = [
 ]
 
 [[package]]
+name = "huggingface-hub"
+version = "1.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.18"
 source = { registry = "https://pypi.org/simple" }
@@ -1804,6 +1931,86 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/2b/52ace16ed031354f0539749a49e4bf33797d82bea5137910835fa4b09793/jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a", size = 306943, upload-time = "2026-06-29T13:03:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2e/34957c2c1b661c252ba9bcc60ae0bddc27e0f7202c6073326a13c5390eec/jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9", size = 307779, upload-time = "2026-06-29T13:03:15.418Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6c/59bd309cab4460c54cf1079f3eb7fe7af6a4c895c5c957a53378693bad2b/jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72", size = 335826, upload-time = "2026-06-29T13:03:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8c/f5ef7b65f0df47afa16596969defb281ebb86e96df346d62be6fd853d620/jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e", size = 362573, upload-time = "2026-06-29T13:03:18.781Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0b/ace4354da061ee38844a0c27dc2c21eecd27aea119e8da324bea987522d0/jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290", size = 457979, upload-time = "2026-06-29T13:03:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/55/40/c0253d3772eb9dcd8e6606ee9b2d53ec8e5b814589c47f140aa585f21eaa/jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01", size = 372302, upload-time = "2026-06-29T13:03:21.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48", size = 343805, upload-time = "2026-06-29T13:03:23.384Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/59/e196888a05befdda7dbe299b722d56f2f6eec65402bc34c0a3306d595feb/jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9", size = 351107, upload-time = "2026-06-29T13:03:24.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/74/4cd9e0fca65232136400354b630fbfcd2de634e22ccbb96567725981b548/jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5", size = 388441, upload-time = "2026-06-29T13:03:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8c/554691e48bc711299c0a293dd8a6179e24b2d66a54dc295421fcf64569c0/jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730", size = 516354, upload-time = "2026-06-29T13:03:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/cb/01e9d69dc2cc6759d4f91e230b34489c4fdb2518992650633f9e20bece89/jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f", size = 547880, upload-time = "2026-06-29T13:03:29.534Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/2953195f1c6ad00f49fa67e13df7e60acb3dd4f387101bc15abccddd905e/jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274", size = 203473, upload-time = "2026-06-29T13:03:31.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/05/2909a8b10699a4d560f8c502b6b2c5f3991b682b1922c1eedda242b225bd/jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7", size = 196905, upload-time = "2026-06-29T13:03:32.472Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a9/6b82bb1c8d7790d602489b967b982a909e5d092875a6c2ade96444c8dfc5/jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331", size = 190618, upload-time = "2026-06-29T13:03:34.672Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
+    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
+    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
+    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ab/664fd8c4be028b2bedd3d2ff08769c4ede23d0dbc87a77c62384a0515b5d/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127", size = 303106, upload-time = "2026-06-29T13:05:07.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
 ]
 
 [[package]]
@@ -1992,6 +2199,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/46/e7/d27d952ce9824d684a3bb500a06541a2d55734bc4d849cdfcca2dfd4d93a/langsmith-0.7.30.tar.gz", hash = "sha256:d9df7ba5e42f818b63bda78776c8f2fc853388be3ae77b117e5d183a149321a2", size = 1106040, upload-time = "2026-04-09T21:12:01.892Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/19/96250cf58070c5563446651b03bb76c2eb5afbf08e754840ab639532d8c6/langsmith-0.7.30-py3-none-any.whl", hash = "sha256:43dd9f8d290e4d406606d6cc0bd62f5d1050963f05fe0ab6ffe50acf41f2f55a", size = 372682, upload-time = "2026-04-09T21:12:00.481Z" },
+]
+
+[[package]]
+name = "litellm"
+version = "1.93.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/e1/4f05ca4cbb4efb739c9e66a182ecd5c816bc05bf3665ec8e0fb4ab408379/litellm-1.93.0.tar.gz", hash = "sha256:140bf215e264c71601bca9c06d2436c5451bb59e1e195ea23fc2d3d87b6929ec", size = 15948866, upload-time = "2026-07-19T03:01:24.389Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/69/cabe7e747fea4c744752bd7ff8f7f208723151a63a89bb7c2437212523ff/litellm-1.93.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3daf5c5aceb07f5d68871071e0ecdc678caccebadca9143cc00bb76f5a8c54e8", size = 20164234, upload-time = "2026-07-19T03:01:05.713Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/db/6af798603c6e2cf21ad7f2edf7e95019bd859dda82284b94014d608fcd85/litellm-1.93.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0784172435de48f66ef7ad89d421604db1ad0db1321ef7f39dbcfe6b20111417", size = 20156724, upload-time = "2026-07-19T03:01:09.037Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/e1/eabe3f13d9c8b853a01377b59e78a295f34c24c36b09e5fc1c60c0167f19/litellm-1.93.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:23b8eea4fb8b3b6ade05e7b6085ec9ca12daffcfb38d033d0bbce9c1d5894da5", size = 20164863, upload-time = "2026-07-19T03:01:12.035Z" },
+    { url = "https://files.pythonhosted.org/packages/64/49/2db5757f7e284eb12618b547cb62dab49687ffaf1d749ca048210e3d0dbd/litellm-1.93.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:98c15e84d32e922a821c105308bf9ddae8700de9ed396530bee2cbb1cacf4cbb", size = 20157288, upload-time = "2026-07-19T03:01:15.395Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/7f/b48d88cb32055b4ba7e51cd67e4ea13a589d4a568d33c3d0dc6994d13b83/litellm-1.93.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:1a476ebc340c070c982eab15b4673fa63a70f5936935f9f20e4d2acb5f35d23b", size = 20165502, upload-time = "2026-07-19T03:01:18.425Z" },
+    { url = "https://files.pythonhosted.org/packages/45/6c/65a7f916326daa151131f1fce5e254d4834127a95d53a18f1c4d238dd5c3/litellm-1.93.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:cd70ccd4ba3ef1a395535c287bce72d30c7d937ecca4290c0db37a00738f7ada", size = 20159007, upload-time = "2026-07-19T03:01:21.704Z" },
 ]
 
 [[package]]
@@ -2321,6 +2556,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ae/d4d1835488c0350424009dac5095b9a3e173bee12fd2e421ee27e2142c42/openai-2.48.0.tar.gz", hash = "sha256:231b1e7661dda14574986c2f71451e9d584b7fe69e0ee6480e12ed090b48fc16", size = 1093427, upload-time = "2026-07-23T20:15:50.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/2a/dcb891114e303c4379d4a498f10222e33eee540bcef4e1e493bd0af2b242/openai-2.48.0-py3-none-any.whl", hash = "sha256:c98df30aaaf93c51979f64d3e7c5b76464f8be0173368266229eb8fe6bd30f2c", size = 1648520, upload-time = "2026-07-23T20:15:48.052Z" },
 ]
 
 [[package]]
@@ -3285,6 +3539,94 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.7.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/98/04b13f1ddfb63158025291c02e03eb42fbb7acb51d091d541050eb4e35e8/regex-2026.7.19.tar.gz", hash = "sha256:7e77b324909c1617cbb4c668677e2c6ae13f44d7c1de0d4f15f2e3c10f3315b5", size = 416440, upload-time = "2026-07-19T00:19:48.923Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/b9/d11d7e501ac8fd7d617684423ebb9561e0b998481c1e4cbc0cb212c5d74a/regex-2026.7.19-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2cc3460cedf7579948486eab03bc9ad7089df4d7281c0f47f4afe03e8d13f02d", size = 496778, upload-time = "2026-07-19T00:17:05.677Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/a9/a5ab6f312f24318019170dc485d5421fe4f89e43a98640da50d95a8a7041/regex-2026.7.19-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0e9554c8785eac5cffe6300f69a91f58ba72bc88a5f8d661235ad7c6aa5b8ccd", size = 297122, upload-time = "2026-07-19T00:17:07.59Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/63/4cab4d7f2d384a144d420b763d97674cb70619c878ea6fcd7640d0e62143/regex-2026.7.19-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d7da47a0f248977f08e2cb659ff3c17ddc13a4d39b3a7baa0a81bf5b415430f6", size = 292009, upload-time = "2026-07-19T00:17:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/22/85/102a81b218298957d4ea7d2f084fae537a71add9d6ff93c8e67284c5f45e/regex-2026.7.19-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:93db40c8de0815baab96a06e08a984bac71f989d13bab789e382158c5d426797", size = 796708, upload-time = "2026-07-19T00:17:11.542Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b5/dc136af5629938a037cd2b304c12240e132ec92f38be8ff9cc89af2a1f2d/regex-2026.7.19-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:66bd62c59a5427746e8c44becae1d9b99d22fb13f30f492083dfb9ad7c45cc18", size = 865651, upload-time = "2026-07-19T00:17:13.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/75/67402ae3cd9c8c988a4c805d15ee3eef015e7ca4cb112cf3e640fc1f4153/regex-2026.7.19-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1649eb39fcc9ea80c4d2f110fde2b8ab2aef3877b98f02ab9b14e961f418c511", size = 911756, upload-time = "2026-07-19T00:17:15.015Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/8e/096d00c7c480ef2ff4265349b14e2261d4ab787ba1f74e2e80d1c58079c3/regex-2026.7.19-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9dce8ec9695f531a1b8a6f314fd4b393adcccf2ea861db480cdf97a301d01a68", size = 801798, upload-time = "2026-07-19T00:17:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/41/e7ecac6edb5722417f85cc67eaf386322fbe8acf6918ec2fdc37c20dd9d0/regex-2026.7.19-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3080a7fd38ef049bd489e01c970c97dd84ff446a885b0f1f6b26d9b1ad13ce11", size = 776933, upload-time = "2026-07-19T00:17:19.347Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/69/03c9b3f058d66403e0ca2c938696e81d51cd4c6d47ec5265f02f96948d9a/regex-2026.7.19-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1d793a7988e04fcb1e2e135567443d82173225d657419ec09414a9b5a145b986", size = 784338, upload-time = "2026-07-19T00:17:21.057Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f7/b38ab3d43f284afbb618fcd15d0e77eb786ae461ce1f6bc7494619ddc0f2/regex-2026.7.19-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e8b0abe7d870f53ca5143895fef7d1041a0c831a140d3dc2c760dd7ba25d4a8b", size = 860452, upload-time = "2026-07-19T00:17:23.119Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5c/ff60ef0571121714f3cf9920bc183071e384a10b556d042e0fdb06cc07a5/regex-2026.7.19-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:4e5413bd5f13d3a4e3539ca98f70f75e7fca92518dd7f117f030ebedd10b60cb", size = 765958, upload-time = "2026-07-19T00:17:24.81Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/0f/bd34021162c0ab47f9a315bd56cd5642e920c8e5668a75ef6c6a6fca590d/regex-2026.7.19-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:73b133a9e6fb512858e7f065e96f1180aa46646bc74a83aea62f1d314f3dd035", size = 851765, upload-time = "2026-07-19T00:17:26.993Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/20/a2ca43edade0595cccfdc98636739f536d9e26898e7dbddc2b9e98898953/regex-2026.7.19-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dbe6493fbd27321b1d1f2dd4f5c7e5bd4d8b1d7cab7f32fd67db3d0b2ed8248a", size = 789714, upload-time = "2026-07-19T00:17:28.699Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/47/e02db4015d424fc83c00ea0ac8c5e5ec14397943de9abf909d5ce3a25931/regex-2026.7.19-cp312-cp312-win32.whl", hash = "sha256:ddd67571c10869f65a5d7dde536d1e066e306cc90de57d7de4d5f34802428bb5", size = 267157, upload-time = "2026-07-19T00:17:31.051Z" },
+    { url = "https://files.pythonhosted.org/packages/08/8e/c780c131f79b42ed22d1bd7da4096c2c35f813e835acd02ef0f018bd892c/regex-2026.7.19-cp312-cp312-win_amd64.whl", hash = "sha256:e30d40268a28d54ce0437031750497004c22602b8e3ab891f759b795a003b312", size = 277777, upload-time = "2026-07-19T00:17:32.848Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4c/e4d7e086449bdf379d89774bf1f89dc4a41943f3c5a6125a03905b34b5fb/regex-2026.7.19-cp312-cp312-win_arm64.whl", hash = "sha256:de9208bb427130c82a5dbfd104f92c8876fc9559278c880b3002755bbbe9c83d", size = 277136, upload-time = "2026-07-19T00:17:34.803Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/3d/84165e4299ff76f3a40fe1f2abf939e976f693383a08d2beea6af62bd2c1/regex-2026.7.19-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f035d9dc1d25eff9d361456572231c7d27b5ccd473ca7dc0adfce732bd006d40", size = 496552, upload-time = "2026-07-19T00:17:36.808Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/a65293e6e4cf28eb7ee1be5335a5386c40d6742e9f47fafc8fec785e16c7/regex-2026.7.19-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c42572142ed0b9d5d261ba727157c426510da78e20828b66bbb855098b8a4e38", size = 296983, upload-time = "2026-07-19T00:17:38.816Z" },
+    { url = "https://files.pythonhosted.org/packages/95/47/2d0564e93d87bc48618360ddca232a2ca612bbdf53ce8465d45ca5ce14ee/regex-2026.7.19-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:40b34dd88658e4fedd2fddbf0275ac970d00614b731357f425722a3ed1983d11", size = 291832, upload-time = "2026-07-19T00:17:40.726Z" },
+    { url = "https://files.pythonhosted.org/packages/07/cd/42dfbabff3dfc9603c501c0e2e2c5adbb09d127b267bf5348de0af338c15/regex-2026.7.19-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c41c63992bf1874cebb6e7f56fd7d3c007924659a604ae3d90e427d40d4fd13", size = 796775, upload-time = "2026-07-19T00:17:42.382Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5d/f6a4839f2b934e3eed5973fd07f5929ee97d4c98939fb275ea23c274ee16/regex-2026.7.19-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1d3372064506b94dd2c67c845f2db8062e9e9ba84d04e33cb96d7d33c11fe1ae", size = 865687, upload-time = "2026-07-19T00:17:44.185Z" },
+    { url = "https://files.pythonhosted.org/packages/14/b0/b47d6c36049bc59806a50bd4c86ced70bbe058d787f80281b1d7a9b0e024/regex-2026.7.19-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fce7760bf283405b2c7999cab3da4e72f7deca6396013115e3f7a955db9760da", size = 911962, upload-time = "2026-07-19T00:17:46.442Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/be/ff61f28f9273658cfe23acbbac5217221f6519960ed401e61dfdab12bc35/regex-2026.7.19-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0d702548d89d572b2929879bc883bb7a4c4709efafe4512cadee56c55c9bd15", size = 801817, upload-time = "2026-07-19T00:17:48.25Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/bb/8b4f7f26b333f9f79e1b453613c39bb4776f51d38ae66dd0ba31d6b354ca/regex-2026.7.19-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d446c6ac40bb6e05025ccee55b84d80fe9bf8e93010ffc4bb9484f13d498835f", size = 776908, upload-time = "2026-07-19T00:17:50.183Z" },
+    { url = "https://files.pythonhosted.org/packages/09/13/610110fc5921d380516d03c26b652555f08aa0d23ea78a771231873c3638/regex-2026.7.19-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4c3501bfa814ab07b5580741f9bf78dfdfe146a04057f82df9e2402d2a975939", size = 784426, upload-time = "2026-07-19T00:17:52.454Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f5/1ef9e2a83a5947c57ebff0b377cb5727c3d5ec1992317a320d035cd0dbb6/regex-2026.7.19-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c4585c3e64b4f9e583b4d2683f18f5d5d872b3d71dcf24594b74ecc23602fa96", size = 860600, upload-time = "2026-07-19T00:17:54.229Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/02/073af33a3ec149241d11c80acea91e722aa0adbf05addd50f251c4fe89c3/regex-2026.7.19-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:571fde9741eb0ccde23dd4e0c1d50fbae910e901fa7e629faf39b2dda740d220", size = 765950, upload-time = "2026-07-19T00:17:56.041Z" },
+    { url = "https://files.pythonhosted.org/packages/81/a9/d1e9f819dc394a568ef370cd56cf25394e957a2235f8370f23b576e5a475/regex-2026.7.19-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:15b364b9b98d6d2fe1a85034c23a3180ff913f46caddc3895f6fd65186255ccc", size = 851794, upload-time = "2026-07-19T00:17:57.897Z" },
+    { url = "https://files.pythonhosted.org/packages/03/3a/8ae83eda7579feacdf984e71fb9e70635fb6f832eeddca58427ec4fca926/regex-2026.7.19-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ffd8893ccc1c2fce6e0d6ca402d716fe1b29db70c7132609a05955e31b2aa8f2", size = 789845, upload-time = "2026-07-19T00:17:59.97Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/23/c195cbfe5a75fdec64d8f6554fd15237b837919d2c61bdc141d7c807b08b/regex-2026.7.19-cp313-cp313-win32.whl", hash = "sha256:f0fa4fa9c3632d708742baf2282f2055c11d888a790362670a403cbf48a2c404", size = 267135, upload-time = "2026-07-19T00:18:01.958Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/80/a11de8404b7272b70acb45c1c05987cce60b45d5693da2e176f0e390d564/regex-2026.7.19-cp313-cp313-win_amd64.whl", hash = "sha256:d51ffd3427640fa2da6ade574ceba932f210ad095f65fcc450a2b0a0d454868e", size = 277747, upload-time = "2026-07-19T00:18:04.121Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/29/0f5c8eff1b4f1f3d83276d365fccecf666afcc7d947420943bf394d07adb/regex-2026.7.19-cp313-cp313-win_arm64.whl", hash = "sha256:c670fe7be5b6020b76bc6e8d2196074657e1327595bca93a389e1a76ab130ad8", size = 277129, upload-time = "2026-07-19T00:18:05.821Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/4c/44b74742052cedda40f9ae469532a037112f7311a36669a891fba8984bb0/regex-2026.7.19-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db47b561c9afd884baa1f96f797c9ca369872c4b65912bc691cfa99e68340af2", size = 501134, upload-time = "2026-07-19T00:18:07.567Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/45/bbd038b5e39ee5613a5a689290145b40058cc152c41de9cc23639d2b9734/regex-2026.7.19-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:65dcd28d3eba2ab7c2fd906485cc301392b47cc2234790d27d4e4814e02cdfda", size = 299418, upload-time = "2026-07-19T00:18:09.38Z" },
+    { url = "https://files.pythonhosted.org/packages/65/38/c5bde94b4cedfd5850d64c3f08222d8e1600e84f6ee71d9b44b4b8163f74/regex-2026.7.19-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f2e7f8e2ab6c2922be02c7ec45185aa5bd771e2e57b95455ee343a44d8130dff", size = 294486, upload-time = "2026-07-19T00:18:11.188Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/6a/2f5e107cb26c960b781967178899daf2787a7ab151844ed3c01d6fc95474/regex-2026.7.19-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe31f28c94402043161876a258a9c6f757cb485905c7614ce8d6cd40e6b7bdc1", size = 811643, upload-time = "2026-07-19T00:18:12.975Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d4/a2f963406d7d73a62eed84ba05a258afb6cad1b21aa4517443ce40506b78/regex-2026.7.19-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f8f6fa298bb4f7f58a33334406218ba74716e68feddf5e4e54cd5d8082705abf", size = 871081, upload-time = "2026-07-19T00:18:14.733Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a3/44be546340bedb15f13063f5e7fe16793ea4d9ea2e805d09bd174ac27724/regex-2026.7.19-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cc1b2440423a851fad781309dd87843868f4f66a6bcd1ddb9225cf4ec2c84732", size = 917372, upload-time = "2026-07-19T00:18:16.724Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f6/e0870b0fd2a40dba0074e4b76e514b21313d37946c9248453e34ec43923e/regex-2026.7.19-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ac59a0900474a52b7c04af8196affc22bd9842acb0950df12f7b813e983609a", size = 816089, upload-time = "2026-07-19T00:18:18.617Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/27/957e8e22690ad6634572b39b71f130a6105f4d0718bb16849eac00fff147/regex-2026.7.19-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4896db1f4ce0576765b8272aa922df324e0f5b9bb2c3d03044ff32a7234a9aba", size = 785206, upload-time = "2026-07-19T00:18:20.464Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a4/186e410941e731037c01166069ab86da9f65e8f8110c18009ccf4bd623ee/regex-2026.7.19-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4e6883a021db30511d9fb8cfb0f222ce1f2c369f7d4d8b0448f449a93ba0bdfc", size = 800431, upload-time = "2026-07-19T00:18:22.716Z" },
+    { url = "https://files.pythonhosted.org/packages/73/9f/e4e10e023d291d64a33e246610b724493bf1ce98e0e59c9b7c837e5acfb7/regex-2026.7.19-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:09523a592938aa9f587fb74467c63ff0cf88fc3df14c82ab0f0517dcf76aaa62", size = 864906, upload-time = "2026-07-19T00:18:24.772Z" },
+    { url = "https://files.pythonhosted.org/packages/24/57/ccb20b6be5f1f52a053d1ba2a8f7a077edb9d918248b8490d7506c6832b3/regex-2026.7.19-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:1ebac3474b8589fce2f9b225b650afd61448f7c73a5d0255a10cc6366471aed1", size = 773559, upload-time = "2026-07-19T00:18:27.008Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/82/f3b263cf8fad927dc102891da8502e718b7ff9d19af7a2a07c03865d7188/regex-2026.7.19-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:4a0530bb1b8c1c985e7e2122e2b4d3aedd8a3c21c6bfddae6767c4405668b56e", size = 857739, upload-time = "2026-07-19T00:18:29.107Z" },
+    { url = "https://files.pythonhosted.org/packages/47/2e/1687bd1b6c2aed5e672ccf845fc11557821fe7366d921b50889ea5ce57bf/regex-2026.7.19-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2ef7eeb108c47ce7bcc9513e51bcb1bf57e8f483d52fce68a8642e3527141ae0", size = 804522, upload-time = "2026-07-19T00:18:31.362Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7c/cc4e7655181b2d9235b704f2c5e19d8eff002bbc437bae59baee0e381aca/regex-2026.7.19-cp313-cp313t-win32.whl", hash = "sha256:64b6ca7391a1395c2638dd5c7456d67bea44fc6c5e8e92c5dc8aa6a8f23292b4", size = 269141, upload-time = "2026-07-19T00:18:33.479Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/14/961b4c7b05a2391c32dbc85e27773076671ef8f97f36cec70fe414734c02/regex-2026.7.19-cp313-cp313t-win_amd64.whl", hash = "sha256:f04b9f56b0e0614c0126be12c2c2d9f8850c1e57af302bd0a63bed379d4af974", size = 280036, upload-time = "2026-07-19T00:18:35.419Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/795644550d788ddbb6dc458c95895f8009978ea6d6ea76b005eb3f45e8c9/regex-2026.7.19-cp313-cp313t-win_arm64.whl", hash = "sha256:fcee38cd8e5089d6d4f048ba1233b3ad76e5954f545382180889112ff5cb712d", size = 279394, upload-time = "2026-07-19T00:18:37.454Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/25/0c4c452f8ef3efe456745b2f33195f5904b573fb4c2ff3f0cb9ec188461e/regex-2026.7.19-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:a81758ed242b861b72e778ba34d41366441a2e10b16b472784c88da2dea7e2dd", size = 496750, upload-time = "2026-07-19T00:18:39.633Z" },
+    { url = "https://files.pythonhosted.org/packages/24/9e/b70ca6c1704f6c7cd32a9e143c86cc5968d10981eca284bad670c245ea7d/regex-2026.7.19-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4aa5435cdb3eb6f55fe98a171b05e3fbcd95fadaa4aa32acf62afd9b0cfdbcac", size = 297093, upload-time = "2026-07-19T00:18:41.583Z" },
+    { url = "https://files.pythonhosted.org/packages/87/74/0b692da2520d51fbff19c88b83d97e4c702909dd02386c585998b7e2dbed/regex-2026.7.19-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:60be8693a1dadc210bbcbc0db3e26da5f7d01d1d5a3da594e99b4fa42df404f5", size = 292043, upload-time = "2026-07-19T00:18:43.347Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a7/1d478e614016045a33feae57446215f9fd65b665a5ceb2f891fb3183bc52/regex-2026.7.19-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d19662dbedbe783d323196312d38f5ba53cf56296378252171985da6899887d3", size = 797214, upload-time = "2026-07-19T00:18:45.362Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ae/11b9c9411d92c30e3d2db32df5a31133e4a99a8fc397a604fd08f6c4bffb/regex-2026.7.19-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d15df07081d91b76ff20d43f94592ee110330152d617b730fdbe5ef9fb680053", size = 866433, upload-time = "2026-07-19T00:18:47.315Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/62/2b2efc4992f91d6d204b24c647c9f9412e85379d92b7c0ab9fdae622327e/regex-2026.7.19-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:56ad4d9f77df871a99e25c37091052a02528ec0eb059de928ee33956b854b45b", size = 911360, upload-time = "2026-07-19T00:18:49.588Z" },
+    { url = "https://files.pythonhosted.org/packages/14/71/986ceea9aa3da548bf1357cad89b63915ec6d21ec957c8113b29ece567df/regex-2026.7.19-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7322ec6cc9fba9d49ab888bb82d67ac5625627aa168f0165139b17018df3fb8a", size = 801275, upload-time = "2026-07-19T00:18:51.767Z" },
+    { url = "https://files.pythonhosted.org/packages/15/be/ce9d9534b2cda96eab32c548261224b9b4e220a4126f098f60f42ae7b4cd/regex-2026.7.19-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9c7472192ebfad53a6be7c4a8bfb2d64b81c0e93a1fc8c57e1dd0b638297b5d1", size = 777131, upload-time = "2026-07-19T00:18:54.053Z" },
+    { url = "https://files.pythonhosted.org/packages/61/2b/58b5c710f2c3929515a25f3a1ca0dad0dcd4518d4fff3cf23bc7adb8dcd2/regex-2026.7.19-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c10b82c2634df08dfb13b1f04e38fe310d086ee092f4f69c0c8da234251e556e", size = 785020, upload-time = "2026-07-19T00:18:56.579Z" },
+    { url = "https://files.pythonhosted.org/packages/84/03/5fe091935b74f15fe0f97998c215cae418d1c0413f6258c7d4d2e83aa37f/regex-2026.7.19-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:17ed5692f6acc4183e98331101a5f9e4f64d72fe58b753da4d444a2c77d05b12", size = 861263, upload-time = "2026-07-19T00:18:58.64Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/fa/d60bf82e10841eef62a9e32aac401468f05fddfbcb2942e342b1ba3d2433/regex-2026.7.19-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:22a992de9a0d91bda927bf02b94351d737a0302905432c88a53de7c4b9ce62e2", size = 766199, upload-time = "2026-07-19T00:19:00.705Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/5d/11e64d151b0662b81d6bf644c74dc118d461df85bdf2577fadbbf751788a/regex-2026.7.19-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:618a0aed532be87294c4477b0481f3aa0f1520f4014a4374dd4cf789b4cd2c97", size = 851317, upload-time = "2026-07-19T00:19:03.015Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/34/532efb87488d90807bae6a443d357ee5e2728a478c597619c8aaa17cc0bd/regex-2026.7.19-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2ce9e679f776649746729b6c86382da519ef649c8e34cc41df0d2e5e0f6c36d4", size = 789557, upload-time = "2026-07-19T00:19:05.338Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/90/3a8d5ca977171ec3ae21a71207d2228b2663bde14d7f7ef0e6363ecf9290/regex-2026.7.19-cp314-cp314-win32.whl", hash = "sha256:73f272fba87b8ccfe70a137d02a54af386f6d27aa509fbffdd978f5947aae1aa", size = 272531, upload-time = "2026-07-19T00:19:07.487Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e1/8862885e70409de70e8c005f57fb2e7be8d9ef0317250d60f4c9660a300d/regex-2026.7.19-cp314-cp314-win_amd64.whl", hash = "sha256:d721e53758b2cca74990185eb0671dd466d7a388a1a45d0c6f4c13cef41a68ac", size = 280831, upload-time = "2026-07-19T00:19:09.46Z" },
+    { url = "https://files.pythonhosted.org/packages/08/82/2693e53e29f9104d9de95d37ce4dd826bd32d5f9c0085d3aa6ac042675c4/regex-2026.7.19-cp314-cp314-win_arm64.whl", hash = "sha256:65fa6cb38ed5e9c3637e68e544f598b39c3b86b808ed0627a67b68320384b459", size = 281099, upload-time = "2026-07-19T00:19:11.398Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b7/9a01aa16461a18cde9d7b9c3ab21e501db2ce33725f53014342b91df2b0a/regex-2026.7.19-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:5a2721c8720e2cb3c209925dfb9200199b4b07361c9e01d321719404b21458b3", size = 501121, upload-time = "2026-07-19T00:19:13.425Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/5e/bbaeca815dc9191c424c94a4fdc5c87c75748a64a6271821212ebdd4e1a3/regex-2026.7.19-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:199535629f25caf89698039af3d1ad5fcae7f933e2112c73f1cdf49165c99518", size = 299415, upload-time = "2026-07-19T00:19:15.43Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d6/0dd1a321afaab95eb7ff44aa0f637301786f1dc71c6b797b9ed236ed8890/regex-2026.7.19-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9b60d7814174f059e5de4ab98271cc5ba9259cfea55273a81544dceea32dc8d9", size = 294483, upload-time = "2026-07-19T00:19:17.879Z" },
+    { url = "https://files.pythonhosted.org/packages/92/5f/40bacf91d0904f812e13bbbab3864604c463eced8afdc54aeaa50492ea95/regex-2026.7.19-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dbece16025afda5e3031af0c4059207e61dcf73ef13af844964f57f387d1c435", size = 811833, upload-time = "2026-07-19T00:19:20.102Z" },
+    { url = "https://files.pythonhosted.org/packages/94/7c/4902744261f775aeede8b5627314b38482da29cf49a57b66a6fb753246c5/regex-2026.7.19-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d24ecb4f5e009ea0bd275ee37ad9953b32005e2e5e60f8bbae16da0dbbf0d3a0", size = 871270, upload-time = "2026-07-19T00:19:22.365Z" },
+    { url = "https://files.pythonhosted.org/packages/16/70/6980c9be6bf21c0a60ed3e0aea39cf419ecf3b08d1d9947bc56e196ef186/regex-2026.7.19-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8cae6fd77a5b72dae505084b1a2ee0360139faf72fedbab667cd7cc65aae7a6a", size = 917534, upload-time = "2026-07-19T00:19:24.529Z" },
+    { url = "https://files.pythonhosted.org/packages/52/92/8b2bd872782ce8c42691e39acb38eb8efe014e5ddb78ad7d943d6f197ce9/regex-2026.7.19-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9724e6cb5e478cd7d8cabf027826178739cb18cf0e117d0e32814d479fa02276", size = 816135, upload-time = "2026-07-19T00:19:26.919Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2d/33a602f657bdc4041f17d79f92ab18261d255d91a06117a6e29df023e5e2/regex-2026.7.19-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:572fc57b0009c735ee56c175ea021b637a15551a312f56734277f923d6fd0f6c", size = 785492, upload-time = "2026-07-19T00:19:29.192Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/36/0987cf4cb271680064a70d24a475873775a151d0b7058698a006cb0cae4a/regex-2026.7.19-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:20568e182eb82d39a6bf7cff3fd58566f14c75c6f74b2c8c96537eecf9010e3a", size = 800658, upload-time = "2026-07-19T00:19:31.392Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/24/c14f31c135e1ba55fa4f9a58ca98d0842512bf6188230763c31c8f449e3b/regex-2026.7.19-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:1d58561843f0ff7dc78b4c28b5e2dc388f3eff94ebc8a232a3adba961fc00009", size = 865073, upload-time = "2026-07-19T00:19:33.485Z" },
+    { url = "https://files.pythonhosted.org/packages/14/85/181a12211f22469f24d2de1ebddfe397d2396e2c29013b9a58134a91069a/regex-2026.7.19-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:61bb1bd45520aacd56dd80943bd34991fb5350afdd1f36f2282230fd5154a218", size = 773684, upload-time = "2026-07-19T00:19:35.599Z" },
+    { url = "https://files.pythonhosted.org/packages/23/58/bd1a0c1a62251366f8d21f41b1ea3c76994962071b8b6ea42f72d505c0f0/regex-2026.7.19-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:cd3584591ea4429026cdb931b054342c2bcf189b44ff367f8d5c15bc092a2966", size = 857769, upload-time = "2026-07-19T00:19:37.738Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/4f/f7e2dad6756b2fe1fe75dd90a628c3b45f249d39f948dd90cd2476325417/regex-2026.7.19-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cc26a66e212fa5d6c6170c3a40d99d888db3020c6fdab1523250d4341382e44", size = 804546, upload-time = "2026-07-19T00:19:40.229Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d7/01d31d5bdb09bc026fab77f59a371fdf8f9b292e4810546c56182ca70498/regex-2026.7.19-cp314-cp314t-win32.whl", hash = "sha256:2c4e61e2e1be56f63ec3cc618aa9e0de81ef6f43d177205451840022e24f5b78", size = 274526, upload-time = "2026-07-19T00:19:42.398Z" },
+    { url = "https://files.pythonhosted.org/packages/52/0e/cea4ce73bc0a8247a0748228ae6669984c7e1f8134b6fa66e59c0572e0ea/regex-2026.7.19-cp314-cp314t-win_amd64.whl", hash = "sha256:c639ea314df70a7b2811e8020448c75af8c9445f5a60f8a4ced81c306a9380c2", size = 283763, upload-time = "2026-07-19T00:19:44.644Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/b6/26e41975febae63b7a6e3e02f32cff6cff2e4f10d19c929082f56aebf7c6/regex-2026.7.19-cp314-cp314t-win_arm64.whl", hash = "sha256:9a15e785f244f3e07847b984ce8773fc3da10a9f3c131cc49a4c5b4d672b4547", size = 283451, upload-time = "2026-07-19T00:19:46.639Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3562,12 +3904,98 @@ wheels = [
 ]
 
 [[package]]
+name = "tiktoken"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/e5/5f3cb2159769d0f4324c0e9e87f9de3c4b1cd45848a96b2eb3566ad5ca77/tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1", size = 38986, upload-time = "2026-05-15T04:51:27.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/8e/144bde4e01df66b34bb865557c7cd754ed08b036217ebd79c9db5e9048a9/tiktoken-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:32ac870a806cfb260a02d0cb70426aef02e038297f8ad50df5040bb5af360791", size = 1034888, upload-time = "2026-05-15T04:50:31.579Z" },
+    { url = "https://files.pythonhosted.org/packages/36/18/d4ac9d20956cdebca04841316660ed584c2fecdc2b81722a28bc7ad3b1e4/tiktoken-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4d9980f11429ed2d737c463bb1fb78cf330caa026adf002f714aced7849a687b", size = 982970, upload-time = "2026-05-15T04:50:32.961Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ed/6bb8d05b9f731f749fee5c6f5ca63e981143c826a5985877330507bd13b7/tiktoken-0.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3f277ebea5edd7b8bf03c6f9431e1d67d517530115572b2dc1d465326e8f88c7", size = 1115741, upload-time = "2026-05-15T04:50:34.475Z" },
+    { url = "https://files.pythonhosted.org/packages/34/de/2ca96b07a82d972b74fe4b46de055b79c904e45c7eab699354a0bfa697dc/tiktoken-0.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a116178fa7e1b4065bff05214360373a65cac22f965be7b3f73d00a0dbfe7649", size = 1136523, upload-time = "2026-05-15T04:50:35.782Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/dc/9dafec002c2d4424378563cf4cf5c7fb93631d2a55013c8b87554ee4012c/tiktoken-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c397ddda233208345b01bd30f2fca79ff730e55731d0108a603f9bc57f6af3b", size = 1181954, upload-time = "2026-05-15T04:50:36.99Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d0/1f8578c45b2f24759b46f0b50d31878c63c73e6bf0f2227e10ec5c5408dc/tiktoken-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:95097e4f89b06403976e498abf61a0ee73a7497e73fb599cb211d8197a054d91", size = 1240069, upload-time = "2026-05-15T04:50:38.221Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/90/28d7f154888610aa9237e541986beb62b479df29d193a5a0617dbb1514d0/tiktoken-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:8f2d16e7a7c783ad81f36e457d046d1f1c8af70b22aec8a13238efe531977c41", size = 874748, upload-time = "2026-05-15T04:50:39.587Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/83/b096c859c2a47c11731bf2f5885f4028b809dfe2396582883eed9cae372f/tiktoken-0.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5df5d1507bd245f1ccad4a074698240021239e455eb0bb4ced4e3d7181872154", size = 1034228, upload-time = "2026-05-15T04:50:40.988Z" },
+    { url = "https://files.pythonhosted.org/packages/53/61/c68e123b6d753e3fc2751e9b18e732c9d8bf1e1926762e736eee935d931c/tiktoken-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fe806a50664e83a6ffd56cbd1e4f5dcc6cd32a3e7538f70dc38b1a271384545", size = 982978, upload-time = "2026-05-15T04:50:42.195Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/8b/96cc178cc584e65d363134500f297790b06cd48cdeb1e8fcf7bbe60f4715/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:125bc05005e747f993a83dc67934249932d6e4209854452cd4c0b1d53fba3ba2", size = 1116355, upload-time = "2026-05-15T04:50:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f5/bab735d2c72ea55404b295d02d092644eb5f7cc6205e34d35eb9abfb9ab2/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5e6358911cab4adee6712da27d65573496a4f68cf8a2b5fca6a4ad10fc5748cf", size = 1135772, upload-time = "2026-05-15T04:50:44.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b9/6de04ebdf904edfaad87788011b3735087a0c9ea671b9027e1e4e965e8c8/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:975cbd78d085d75d26b59660e262736dcaed1e35f8f142cd6291025c01d25486", size = 1182415, upload-time = "2026-05-15T04:50:46.422Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9c/470a05f3b1caf038f44880e334d47ab674e0c80d514c66b375d14d5afa10/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ab9bc99fa020a4c283424590ecd7f3afd70c1c281cb3fa3192a6c3af9f9615", size = 1239879, upload-time = "2026-05-15T04:50:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/42/a6/c1936d16055436cb32e6c6128d68629622e00f4768562f55653752d34768/tiktoken-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:6b1615f0ff71953d19729ceb18865429c185b0a23c5353f1bbca34a394bf60f7", size = 874829, upload-time = "2026-05-15T04:50:49.202Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/07/acb5992c3772b5a36284f742cfb7a5895aa4471d1848ac31464ad50d7fdf/tiktoken-0.13.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6eb4a5bfbc6426938026b1a334e898ac53541360d62d8c689870160cc80abd67", size = 1033600, upload-time = "2026-05-15T04:50:50.4Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e9/742e9aec30f59b9f161f7ff7cd072e02ea836c9e1c0854a8076dfcd40d5c/tiktoken-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:43cee3e5400573b2046fbf092cc7a5bc30164f9e4c95ce20714da929df48737a", size = 982516, upload-time = "2026-05-15T04:50:52.03Z" },
+    { url = "https://files.pythonhosted.org/packages/72/74/ca1541b053e7648254d2e4b42a253e1bb4359f2c91a0a8d49228c794e1a0/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:7de52e3f566d19b3b11bd37eea552c6c305ad74081f736882bd44d148ed4c48d", size = 1115518, upload-time = "2026-05-15T04:50:53.543Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e3/93825eaf5a4a504795b787e5d5dea07fbeb3dabf97aa7b450be8bde59c89/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:51384448aa508e4df84c0f7c1dc3211c7f7b8096325660ee5fc82f3e11b381ce", size = 1136867, upload-time = "2026-05-15T04:50:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/002b68de6827091d5ae90b048f326e8aad8d953520950e5ce1508879414f/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e28157350f7ebf35008dd8e9e0fdb621f976e4230c881099c85e8cf07eaa50e2", size = 1181826, upload-time = "2026-05-15T04:50:56.296Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c6/d393e3185a276505182f7abd93fe714f3c444a2be9180798fa052347504e/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:165cf1820ea4a354985c2490a5205d4cc74661c934aca79dd0368232fff94e0f", size = 1239489, upload-time = "2026-05-15T04:50:57.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/4d/bc07d1f1635d4897a202acc0ae11c2886eaa7325c359ba4741b47bf8e225/tiktoken-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6c43a675ca14f6f2749ba7f12075d37456015a24b859f2517b9beb4ef30807ec", size = 873820, upload-time = "2026-05-15T04:50:59.528Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/93/0dd6adca026a616c3a92974566b43381eea4b475ce1f36c062b8271a9ac5/tiktoken-0.13.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaaaef47c2406277181d2086484c317bf7fc433e2d5d03ff94f56b0dcec87471", size = 1034977, upload-time = "2026-05-15T04:51:00.957Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5ec6e6bc5b30bed6d93f7f2162d8f6b32437b3ba27cb527cfe004f6109c9/tiktoken-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ca8b310bd93b3772cb1b7922d915446864860f562bdfe4825c63a0aed3fb28cd", size = 983635, upload-time = "2026-05-15T04:51:02.629Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b0/c8ae9aff00d625c50659b4513e707a0462c4bf5d4d6cc1b802103225c02e/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:32e0c12305105002c047b3bb1070b0dd9a73b0cb3b2856a8972b810e7a4f5881", size = 1116036, upload-time = "2026-05-15T04:51:04.082Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ac/6a5dddd1d0a6018ecb389bd0353e6b4a515eb4d2286611bd0ace1937b9e1/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:5ba5fd62507a932d1241346179e3b39bc7bf7408f03c272652d93b3bedf5db24", size = 1135544, upload-time = "2026-05-15T04:51:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b8/585032b4384b2f7dcdaddcb52865c83a701a420d09e3c2b4a2be1c450c57/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d108bc2d470fc53c8ecd24f2c0fd2b5f98c33e87cdb6aa2e9b8c5dced703d273", size = 1182217, upload-time = "2026-05-15T04:51:06.517Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b6/993ff1ded3958215fd341a847b8e5ffeb5de473f435296870d314fc91ac4/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cb99cb5127449f58d0a2d5f5ccfb390d8dbdfd919c221246caaee29d8725ed51", size = 1239404, upload-time = "2026-05-15T04:51:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3d/fef7e06e3b33e7538db0ced734cf9fe23b6832d2ac4990c119c377aec55e/tiktoken-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:115c4f26ffa11caac8b54eea35c2ad38c612c20a48d35dd15d70a02ac6f51f58", size = 918686, upload-time = "2026-05-15T04:51:08.925Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/82/a7fc44582bc32ab00de988a2299bf77c077f59068b233109e34b7d6ca7e6/tiktoken-0.13.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:472527e9132952f2fbf77cd290658bacf003d4d5a3fabc18e5fbd407cbae4d9b", size = 1034454, upload-time = "2026-05-15T04:51:10.035Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d0/24d8a890c14f432a05cea669c17bebeaa99f96a7c79523b590f564246411/tiktoken-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e2f67d27c9626cdd25fe33d9313c5cdb3d8d82da646b68d6eb8e7e9c20e6448", size = 982976, upload-time = "2026-05-15T04:51:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b7/2ab43f62788a9266187a9bfc1d3af99ad83e5eaa25fbef168a69cd5ad14f/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2b920b35805cd64585a37c3dc7ce65fba4d2d36016be01e1d7942482ca29093a", size = 1115526, upload-time = "2026-05-15T04:51:12.608Z" },
+    { url = "https://files.pythonhosted.org/packages/64/39/1494321ed323ce7a14d88e3cd6cb9058625977df1c6961ddc492bd10a9f3/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:493af3aa28a4aaf2e3d2600a2ee717252c9bf5ab38fff94eb5a02db5ab77e5ad", size = 1136466, upload-time = "2026-05-15T04:51:13.926Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d9/dfd086aa2d918c563a140720e0ce296cada1634efd2783d5cf51e05f984e/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6644c9c2b5cf3916f5a3641d7d12fdb3f006a7b3d9ff6acdaec44e29ab1ff91e", size = 1181863, upload-time = "2026-05-15T04:51:15.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/68/a18b4f307086954fdae32714cb4f85562e34f9d34ab206e61f1816aa6018/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cb65b60b9408563676d874a3a4ee573370066f0dc4e29d84e82e989c6517424", size = 1239218, upload-time = "2026-05-15T04:51:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5b/f2aa703a4fc5d2dff73460a7d46cc2f3f44aa0f3dd8eeb20d2a0ecf68862/tiktoken-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:85b78cc3a2c3d48723ca751fa981f1fedccd54194ca0471b957364353a898b07", size = 918110, upload-time = "2026-05-15T04:51:17.237Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/39/b87a87d5bb9470610b80a2d31df42fcffeaf35118b8b97952b2aff598cc7/tokenizers-0.23.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e03d6ffcbe0d56ee9c1ccd070e70a13fa750727c0277e138152acbc0252c2224", size = 3146732, upload-time = "2026-04-27T14:43:15.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6a/068ed9f6e444c9d7e9d55ce134181325700f3d7f30410721bdc8f848d727/tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e", size = 3054954, upload-time = "2026-04-27T14:43:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/36/e006edf031154cba92b8416057d92c3abe3635e4c4b0aa0b5b9bb39dde70/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf13402aff9bc533c89cb849ec3b412dc3fbeacc9744840e423d7bf3f7dc0e3", size = 3374081, upload-time = "2026-04-27T14:43:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ef/7735d226f9c7f874a6bee5e3f27fb25ecabdf207d37b8cf45286d0795893/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f836ca703b89ae07919a309f9651f7a88fd5a33d5f718ba5ad0870ec0256bad6", size = 3247641, upload-time = "2026-04-27T14:43:03.856Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d9/24827036f6e21297bfffda0768e58eb6096a4f411e932964a01707857931/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae848657742035523fdf261773630cb819a26995fcd3d9ecae0c1daf6e5a4959", size = 3585624, upload-time = "2026-04-27T14:43:10.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/22f3582b3a4f49358293a5206e25317621ee4526bfe9cdaa0f07a12e770e/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b09e85775d5187941e7bab30e941b4134ab4a7dd8c68e783d231fb7ca27c51", size = 3844062, upload-time = "2026-04-27T14:43:05.643Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/65/b8f8814eef95800f20721384136d9a1d22241d50b2874357cb70542c392f/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea5a0ce170074329faaa8ea3f6400ecde604b6678192688533af80980daae71a", size = 3460098, upload-time = "2026-04-27T14:43:08.854Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d5/1353e5f677ec27c2494fb6a6725e82d56c985f53e90ec511369e7e4f02c6/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4", size = 3346235, upload-time = "2026-04-27T14:43:12.377Z" },
+    { url = "https://files.pythonhosted.org/packages/71/89/39b6b8fc073fb6d413d0147aa333dc7eff7be65639ac9d19930a0b21bf33/tokenizers-0.23.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:56f3a77de629917652f876294dc9fe6bad4a0c43bc229dc72e59bb23a0f4729a", size = 3426398, upload-time = "2026-04-27T14:43:07.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/80/127c854da64827e5b79264ce524993a90dddcb320e5cd42412c5c02f9e8a/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d10a6d957ef01896dc274e890eee27d41bd0e74ef31e60616f0fc311345184e", size = 9823279, upload-time = "2026-04-27T14:43:17.222Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ba/44c2502feb1a058f096ddfb4e0996ef3225a01a388e1a9b094e91689fe93/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1974288a609c343774f1b897c8b482c791ab17b75ab5c8c2b1737565c1d82288", size = 9644986, upload-time = "2026-04-27T14:43:19.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c1/464019a9fb059870bfe4eebb4ba12208f3042035e258bf5e782906bd3847/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:120468fb4c24faf0543c835a4fabafa4deb3f20a035c9b6e83d0b553a97615d4", size = 9976181, upload-time = "2026-04-27T14:43:21.463Z" },
+    { url = "https://files.pythonhosted.org/packages/79/94/3ac1432bda31626071e9b6a12709b97ae05131c804b94c8f3ac622c5da32/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e3d8f40ea6268047de7046906326abed5134f27d4e8447b23763afe5808c8a96", size = 10113853, upload-time = "2026-04-27T14:43:23.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
+]
+
+[[package]]
 name = "tomlkit"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements the native agent harness PRD (#98) end to end, as its 6 planned vertical slices (#99-#104):

- **#99** — `NativeAgentWorker` chat-loop foundation: `ModelClient` protocol (the one test seam), `LiteLLMModelClient`, streaming, history persistence, `before/after_model_callback`, token usage + cost recording (extends `AgentContext.record_token_usage()` with a `cost` kwarg, threaded into `worker.execute` span recording).
- **#100** — Local tool-calling loop: `ToolSpec`, multi-turn tool calling, concurrent execution of multiple tool calls in one turn, `before/after_tool_callback`, tool-error results instead of crashes.
- **#101** — `ask_user` exposed as a built-in tool; a new `RedisKeys.harness_state(execution_id)` key persists the in-flight loop (messages + pending tool call) across suspend/resume, so a suspended loop can be picked up by *any* worker instance, not just the one that suspended it.
- **#102** — `AgentConfig.sub_agents` entries auto-registered as callable tools ("agent-as-tool"), dispatched via the real `context.call_agent`, reusing #101's suspend/resume mechanism.
- **#103** — A turn with 2+ sub-agent calls batches into one `call_agents` Task Group dispatch (per ADR-0001) instead of sequential hops; Group Join resumes the loop once, with each result correlated back to its own `tool_call_id`.
- **#104** — `GatewayWorker.on_cancelled_resume(...)`, a new hook fired when a resume arrives for an already-cancelled (fully suspended, no live task) execution — the only point where a harness can still clean up `harness_state` for that shape of cancellation.

### Dependency on #97

Slice #103 (Task Group batching) needed the `call_agent`/`call_agents` unification from #97 (ADR-0001), which isn't on `main` yet. Rather than reimplementing it, this branch cherry-picks the two relevant commits from #97 (`feat(worker): unify call_agent/call_agents dispatch and resume behavior`, `fix(worker): key Group Join results by the sub-task's own message_id`) — they show up as the first two commits in this diff and are **not new work reviewed here**; they'll disappear from this diff once #97 merges and this branch is rebased onto `main`. Please land #97 first.

### Review

Ran `/matt-code-review` (Standards + Spec axes) against this diff. One real bug found and fixed in a follow-up commit: `_map_group_results_to_tool_calls` was correlating Task Group replies back to `tool_call_id` by `target_agent_type`, which collides if a turn dispatches the same sub-agent type twice — fixed to correlate by each dispatch's unique `message_id` instead (the same key Group Join itself uses), with a regression test.

## Test plan

- [x] `make test` passes across the whole workspace (root + all `libs/*`), including the new `libs/by-framework-agent` package (27 tests)
- [x] `make lint` — 10.00/10 across every project
- [x] `pyright` clean on the new package (ad hoc check; this repo has no configured type checker)
- [x] TDD throughout at the `ModelClient` seam — tests drive `NativeAgentWorker._handle_message()` end to end with the same mocked-Redis pattern as existing `tests/integration/*` tests, only the model call itself stubbed

🤖 Generated with [Claude Code](https://claude.com/claude-code)