### PR TITLE
fix(worker): restore caller metadata on the inbound resume path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- A resumed agent can read its own request metadata again. Previously,
+  `command.header.metadata` after a suspend (`ask_user`, or a `call_agent`
+  hop) held only the metadata of the message that woke the agent up, and
+  everything it had originally been dispatched with was gone. It is now the
+  original dispatch metadata with the waking message's merged on top (the
+  waking message wins on key collisions). Handlers that treated the resumed
+  header's metadata as "only what this hop just sent" will now see additional
+  keys. Per-hop trace fields (`trace_parent_span_id`,
+  `framework_parent_span_id`, `langfuse_parent_observation_id`) still
+  describe the current hop and are not restored from the record. Executions
+  recorded before this change are unaffected — they degrade to the previous
+  behaviour rather than erroring.
+
 ### Added
 - Standardized Open Source governance files (CONTRIBUTING, CODE_OF_CONDUCT, SECURITY).
 - GitHub Issue and Pull Request templates.

--- a/docs/architecture/KEY_FILES.md
+++ b/docs/architecture/KEY_FILES.md
@@ -260,7 +260,13 @@ Entry anatomy:
   implementations fall back to minting a fresh execution_id. Root-dispatch
   trace writes (`_write_trace_root_start/_end`) must only fire when
   `not parent_message_id` — firing them on every `call_agent` hop would
-  duplicate trace roots.
+  duplicate trace roots. `initialize_execution()`'s payload carries the
+  dispatch `metadata`: a root agent suspends (an `ask_user` round is the
+  common case) and comes back on a `ResumeCommand` carrying the *callee's*
+  metadata, so the record is the only place its own request metadata still
+  exists for `worker.py`'s inbound restore to find. `runner.py` records the
+  same field independently on first pickup, which is what makes this work
+  for dispatchers that don't write it (TS/Java callers, a bare `xadd`).
 
 - `src/by_framework/worker/runner.py` — `WorkerRunner`, the consume loop:
   `XREADGROUP` fetch, command dispatch, resume/suspend bookkeeping, denylist
@@ -290,7 +296,16 @@ Entry anatomy:
   suspended caller persists as `WAITING_AGENT`/`WAITING_USER` precisely to
   keep that inference true; reusing QUEUED for any post-pickup state silently
   makes a resume re-derive its identity from the message header instead of
-  the record. Every `ResumeCommand` passes the `core/wait_gate.py`
+  the record. On a **non-resume** pickup it also writes `header.metadata`
+  onto the record (as an `update_execution_status` kwarg, or in the
+  `save_execution` fallback payload): `header.metadata` *is* the dispatch
+  metadata by definition, so recording it here — rather than trusting
+  whoever sent the message to have done it — is what makes
+  `worker.py`'s inbound restore work for a client root dispatch and for a
+  TS/Java caller, neither of which writes the field. The `ResumeCommand`
+  guard is load-bearing: a resume writing its own waking metadata over the
+  record would destroy the stored original that the restore exists to
+  recover, and nothing else keeps a copy. Every `ResumeCommand` passes the `core/wait_gate.py`
   idempotency gate *here*, before the execution lookup — and being upstream
   of `GatewayWorker` is what also puts it before Task Group join, whose
   `HINCRBY completed` a duplicate would push past `total` and aggregate a
@@ -353,6 +368,22 @@ Entry anatomy:
   transient hop overwrite the caller's own data instead of being layered
   under `task_result.metadata` like `_enqueue_agent_return()`'s merge
   already does correctly.
+  That is the OUTBOUND direction. The INBOUND one — what this execution's own
+  handler reads — is `_restore_inbound_metadata()`, and it is deliberately a
+  different rule: the original dispatch metadata from the same snapshot is
+  the base and the waking message's metadata is **merged on top** (waking
+  message wins collisions), because this agent *is* the addressee of that
+  message. Without it, everything a handler was dispatched with disappears
+  the moment it first suspends. Two constraints keep the directions from
+  contaminating each other: the restore must build a NEW command
+  (`prepare_command_for_processing()` returns the *same* object for the base
+  worker, so an in-place header mutation would rewrite `raw_command`'s and
+  leak the merge into the reply), and `_resolve_reply_command()` must keep
+  taking `raw_command`. The shared merge rule, including which framework
+  trace keys are excluded from the restored base, lives in
+  `_resume_metadata.py` — one copy, because the last time these two files
+  each carried their own version of a resume rule the processor was left
+  behind for a whole commit.
   The success path must NOT reply while `context._is_suspended` — a suspended
   execution has no result, and forwarding the value the handler returned in
   order to unwind both wakes the caller early and consumes the single reply it
@@ -437,8 +468,16 @@ Entry anatomy:
   waking message's own metadata, exactly as `worker.py`'s
   `_resolve_reply_command()` does (restoring only the three routing fields is
   the drift this entry warns about: it shipped that way and leaked the waking
-  hop's metadata to the caller); and no callback may be sent while
-  `context._is_suspended` (with the same terminal-status exception).
+  hop's metadata to the caller); `_restore_inbound_metadata()` mirrors
+  `worker.py`'s inbound merge for what the *handler* reads, and must run even
+  when `_resolve_reply_header()` returned `None` — a client-dispatched root
+  is owed no reply but still has its own metadata to get back, so the two
+  must not share a short-circuit. `_load_execution_snapshot()` is the single
+  registry read feeding both directions; being fail-soft there is what keeps
+  a registry error a degrade rather than a lost reply. The reply is built
+  from `raw_command`, never the inbound-restored one. And no callback may be
+  sent while `context._is_suspended` (with the same terminal-status
+  exception).
   Being a *second* entry point for replies, it carries the same
   `core/wait_gate.py` gate as `runner.py` — a gate on one of two doors is not
   a gate, and an ungated reply here would both wake a resolved caller and
@@ -446,6 +485,25 @@ Entry anatomy:
   `process()` returns `None` for a reply it drops. It also flushes
   `call_agents`' queued stand-ins on the same terms as `worker.py` — after
   the handler returns, never when it raised.
+
+- `src/by_framework/worker/_resume_metadata.py` — the one copy of the
+  **inbound** resume-metadata rule, shared by `worker.py` and `processor.py`
+  so the two cannot drift again. `merge_resume_metadata()` puts the
+  execution's original dispatch metadata underneath the waking message's
+  (waking message wins collisions) — the opposite of the outbound
+  replacement, because a resumed handler *is* the addressee of the message
+  that woke it. `FRAMEWORK_HOP_METADATA_KEYS` (`trace_parent_span_id`,
+  `framework_parent_span_id`, `langfuse_parent_observation_id`) are dropped
+  from the restored base: the framework injects them per dispatch, so a
+  stored copy describes the hop that *created* the execution, and
+  `context.py`'s `_resolve_call_langfuse_parent_id()` reads that key straight
+  off the current command — restoring it would parent a post-resume call to
+  an observation from before the suspend. The filter belongs here, at read
+  time, and not at write time: the outbound path deliberately restores the
+  stored dict verbatim, trace keys included, to stay identical to the
+  non-suspended reply. A missing/absent stored value degrades to the waking
+  message's metadata unchanged, which is the pre-restore behaviour, so old
+  records and cross-SDK callers need no migration or version gate.
 
 - `src/by_framework/core/registry.py` — `WorkerRegistry`: Redis-backed worker
   membership/heartbeat/execution-state, admin lifecycle, locking primitives.

--- a/docs/architecture/KEY_FILES.md
+++ b/docs/architecture/KEY_FILES.md
@@ -431,7 +431,13 @@ Entry anatomy:
   to no execution. `_resolve_reply_header()` must read a resumed execution's
   caller from the execution record, not from the resume header (which names
   the sub-agent), while excluding `CLIENT_SOURCE_AGENT_TYPE` for the reason
-  spelled out under `worker.py`; and no callback may be sent while
+  spelled out under `worker.py`; it restores **four** fields from that record
+  — `source_agent_type`, `parent_message_id`, `task_group_id` and
+  `metadata` — the last one as a full replacement, never merged with the
+  waking message's own metadata, exactly as `worker.py`'s
+  `_resolve_reply_command()` does (restoring only the three routing fields is
+  the drift this entry warns about: it shipped that way and leaked the waking
+  hop's metadata to the caller); and no callback may be sent while
   `context._is_suspended` (with the same terminal-status exception).
   Being a *second* entry point for replies, it carries the same
   `core/wait_gate.py` gate as `runner.py` — a gate on one of two doors is not

--- a/src/by_framework/client/client.py
+++ b/src/by_framework/client/client.py
@@ -971,6 +971,12 @@ class GatewayClient:
                         "parent_message_id": params["parent_message_id"] or "",
                         "source_agent_type": CLIENT_SOURCE_AGENT_TYPE,
                         "target_agent_type": params["target_agent_type"],
+                        # What this execution was dispatched with, so a worker
+                        # can restore it after the execution suspends and
+                        # resumes (see worker/_resume_metadata.py). Only the
+                        # non-RESUME branch reaches here, so this never
+                        # overwrites a suspended execution's original.
+                        "metadata": dict(metadata or {}),
                         "stream_name": route.stream_name,
                         "status": "QUEUED",
                         "route_policy": route_policy,

--- a/src/by_framework/worker/_resume_metadata.py
+++ b/src/by_framework/worker/_resume_metadata.py
@@ -1,0 +1,65 @@
+"""The inbound half of a resumed execution's metadata.
+
+Two different directions restore metadata on a resume, and they are NOT the
+same rule. Keep them apart:
+
+- **Outbound** (``GatewayWorker._resolve_reply_command`` /
+  ``GatewayProcessor._resolve_reply_header``): the header a resumed execution
+  *sends* to its caller. The stored dispatch metadata **replaces**
+  ``header.metadata`` wholesale — the waking hop's data is plumbing the
+  original caller never asked for, and ``_enqueue_agent_return``'s
+  ``{**header.metadata, **task_result.metadata}`` is the one sanctioned
+  channel for a handler to forward part of it.
+- **Inbound** (this module): the header a resumed execution's own handler
+  *reads*. Here the waking message's metadata is legitimate payload — an
+  ``ask_user`` answer's metadata was sent BY a client TO this agent — so it is
+  merged on top of the original dispatch metadata rather than discarded.
+
+Without this, everything a handler was originally dispatched with disappears
+the first time it suspends: it comes back seeing only whatever woke it up.
+"""
+
+from typing import Any, Mapping, Optional
+
+# Injected per dispatch by AgentContext._dispatch_single_task, not supplied by
+# business code. A stored copy of them is stale by definition — it describes
+# the hop that dispatched the execution, not the hop resuming it now — so they
+# are dropped from the restored base and always come from the current message.
+# Letting them through would surface a dispatch-time span id where the waking
+# message has none, and AgentContext._resolve_call_langfuse_parent_id() reads
+# exactly that as its last-resort fallback: a call made after a resume would
+# parent to the original dispatch's observation.
+FRAMEWORK_HOP_METADATA_KEYS = frozenset(
+    {
+        "trace_parent_span_id",
+        "framework_parent_span_id",
+        "langfuse_parent_observation_id",
+    }
+)
+
+
+def merge_resume_metadata(
+    stored: Optional[Mapping[str, Any]],
+    incoming: Optional[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Merge an execution's original dispatch metadata under this hop's.
+
+    ``stored`` is the ``metadata`` field of the execution record (what the
+    execution was originally dispatched with); ``incoming`` is the waking
+    message's own metadata. The waking message wins on key collisions: it is
+    the newer, more specific hop, and this keeps the property that every key a
+    handler can read today stays readable — the restore only ever adds keys.
+
+    A ``stored`` that is missing (an execution recorded before this field
+    existed, or one dispatched by an SDK that doesn't write it) degrades to
+    ``incoming`` unchanged, i.e. exactly the pre-restore behaviour.
+
+    Neither argument is mutated.
+    """
+    merged = {
+        key: value
+        for key, value in (stored or {}).items()
+        if key not in FRAMEWORK_HOP_METADATA_KEYS
+    }
+    merged.update(incoming or {})
+    return merged

--- a/src/by_framework/worker/processor.py
+++ b/src/by_framework/worker/processor.py
@@ -24,6 +24,7 @@ from by_framework.core.protocol.results import (
 from by_framework.core.runtime.file_permissions import FilePermissionPolicy
 from by_framework.core.wait_gate import consume_wait_entry, emit_orphaned_reply
 from by_framework.core.wait_reply import flush_pending_group_replies
+from by_framework.worker._resume_metadata import merge_resume_metadata
 from by_framework.worker.context import AgentContext
 
 ContextHandler = Callable[
@@ -99,8 +100,18 @@ class GatewayProcessor:
                 )
                 return None
 
-        reply_header = await self._resolve_reply_header(command)
+        # One lookup feeds both directions: the header this execution replies
+        # with, and the header its own handler reads. They are different
+        # rules over the same record — see _resolve_reply_header and
+        # _restore_inbound_metadata.
+        snapshot = (
+            await self._load_execution_snapshot(command) if is_agent_return else None
+        )
+        raw_command = command
+        reply_header = self._resolve_reply_header(command, snapshot)
         has_source_agent = reply_header is not None
+        command = self._restore_inbound_metadata(command, is_agent_return, snapshot)
+        header = command.header
 
         context = AgentContext(
             session_id=header.session_id,
@@ -163,8 +174,10 @@ class GatewayProcessor:
                 getattr(context, "_is_suspended", False)
             ) and not is_terminal_state(task_result.status)
             if has_source_agent and not is_suspended:
+                # raw_command, not the inbound-restored one: the reply is the
+                # outbound direction and must not inherit the inbound merge.
                 await self._enqueue_callback(
-                    command,
+                    raw_command,
                     task_result.status,
                     task_result.reply_data,
                     content=task_result.content,
@@ -210,7 +223,7 @@ class GatewayProcessor:
 
             if has_source_agent:
                 await self._enqueue_callback(
-                    command,
+                    raw_command,
                     AgentState.FAILED.value,
                     {"error": str(e)},
                     reply_header=reply_header,
@@ -221,8 +234,36 @@ class GatewayProcessor:
             )
             raise
 
-    async def _resolve_reply_header(
+    async def _load_execution_snapshot(
         self, command: GatewayCommand
+    ) -> Optional[dict[str, Any]]:
+        """Read the execution record the original dispatch wrote.
+
+        Fetched once per resume and shared by both restore directions.
+        Fail-soft: a registry error degrades to "no record", which each caller
+        then handles as its own no-op.
+        """
+        header = command.header
+        try:
+            from by_framework.core.registry import WorkerRegistry
+
+            return await WorkerRegistry(self.redis).get_execution_by_message_id(
+                header.message_id, session_id=header.session_id
+            )
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            self.logger.warning(
+                "[%s] Could not load the execution record of resumed execution "
+                "%s: %s",
+                self.worker_id,
+                header.message_id,
+                error,
+            )
+            return None
+
+    def _resolve_reply_header(
+        self,
+        command: GatewayCommand,
+        snapshot: Optional[dict[str, Any]],
     ) -> Optional[MessageHeader]:
         """Return the header describing the caller this execution owes a reply
         to, or None when nobody is waiting.
@@ -243,36 +284,51 @@ class GatewayProcessor:
         caller ever sent. A snapshot missing the field (an execution recorded
         before it existed) degrades to an empty dict rather than leaking the
         waking message's metadata to the caller.
+
+        This is the OUTBOUND direction only. What the handler itself reads is
+        ``_restore_inbound_metadata``, which merges rather than replaces —
+        and which must run even when this returns None, since a
+        client-dispatched root has no caller but still has its own metadata
+        to get back.
         """
         header = command.header
         if not isinstance(command, ResumeCommand):
             return header if header.source_agent_type else None
 
-        execution: Optional[dict[str, Any]] = None
-        try:
-            from by_framework.core.registry import WorkerRegistry
-
-            execution = await WorkerRegistry(self.redis).get_execution_by_message_id(
-                header.message_id, session_id=header.session_id
-            )
-        except Exception as error:  # pylint: disable=broad-exception-caught
-            self.logger.warning(
-                "[%s] Could not resolve the caller of resumed execution %s: %s",
-                self.worker_id,
-                header.message_id,
-                error,
-            )
-            return None
-
-        caller_agent_type = str((execution or {}).get("source_agent_type", "") or "")
+        caller_agent_type = str((snapshot or {}).get("source_agent_type", "") or "")
         if not caller_agent_type or caller_agent_type == CLIENT_SOURCE_AGENT_TYPE:
             return None
         return replace(
             header,
             source_agent_type=caller_agent_type,
-            parent_message_id=str((execution or {}).get("parent_message_id", "") or ""),
-            task_group_id=str((execution or {}).get("task_group_id", "") or ""),
-            metadata=dict((execution or {}).get("metadata") or {}),
+            parent_message_id=str((snapshot or {}).get("parent_message_id", "") or ""),
+            task_group_id=str((snapshot or {}).get("task_group_id", "") or ""),
+            metadata=dict((snapshot or {}).get("metadata") or {}),
+        )
+
+    @staticmethod
+    def _restore_inbound_metadata(
+        command: GatewayCommand,
+        is_agent_return: bool,
+        snapshot: Optional[dict[str, Any]],
+    ) -> GatewayCommand:
+        """Give a resumed handler its own dispatch metadata back.
+
+        Mirrors ``GatewayWorker._restore_inbound_metadata``, including its
+        merge-don't-replace rule and its no-mutation rule; see that docstring
+        for why the inbound direction differs from the outbound one.
+        """
+        if not is_agent_return:
+            return command
+        return replace(
+            command,
+            header=replace(
+                command.header,
+                metadata=merge_resume_metadata(
+                    (snapshot or {}).get("metadata"),
+                    command.header.metadata,
+                ),
+            ),
         )
 
     async def _enqueue_callback(

--- a/src/by_framework/worker/processor.py
+++ b/src/by_framework/worker/processor.py
@@ -233,6 +233,16 @@ class GatewayProcessor:
         for the same reason as there, ``CLIENT_SOURCE_AGENT_TYPE`` is not a
         caller. It is what a client writes on a root execution's record, and
         nothing consumes its control stream.
+
+        Four fields come from that snapshot, not from the waking message:
+        ``source_agent_type``, ``parent_message_id``, ``task_group_id`` and
+        ``metadata``. The last one is restored as a full replacement rather
+        than a merge, exactly as ``GatewayWorker._resolve_reply_command``
+        does it: the waking message (an ``ask_user`` answer, or a sub-call's
+        reply) is transient plumbing for that one hop, not something the
+        caller ever sent. A snapshot missing the field (an execution recorded
+        before it existed) degrades to an empty dict rather than leaking the
+        waking message's metadata to the caller.
         """
         header = command.header
         if not isinstance(command, ResumeCommand):
@@ -262,6 +272,7 @@ class GatewayProcessor:
             source_agent_type=caller_agent_type,
             parent_message_id=str((execution or {}).get("parent_message_id", "") or ""),
             task_group_id=str((execution or {}).get("task_group_id", "") or ""),
+            metadata=dict((execution or {}).get("metadata") or {}),
         )
 
     async def _enqueue_callback(

--- a/src/by_framework/worker/runner.py
+++ b/src/by_framework/worker/runner.py
@@ -625,11 +625,33 @@ class WorkerRunner:
             if registry:
                 if existing_execution:
                     if hasattr(registry, "update_execution_status"):
+                        status_fields: dict[str, Any] = {
+                            "worker_id": self.worker.worker_id
+                        }
+                        if not isinstance(command, ResumeCommand):
+                            # The dispatch metadata, recorded by whoever is
+                            # executing the message rather than by whoever
+                            # sent it: header.metadata IS the dispatch
+                            # metadata by definition, so this is correct for
+                            # every dispatcher — including a client root
+                            # dispatch and a TS/Java caller, neither of which
+                            # writes the field (see context.py's
+                            # initialize_execution, which does, and is kept
+                            # because it is the only record that exists
+                            # before a callee is ever picked up).
+                            # _handle_message reads it back to restore what
+                            # this execution was originally asked for once it
+                            # resumes.
+                            #
+                            # A ResumeCommand must NOT write it: the waking
+                            # message's metadata would overwrite the very
+                            # original this exists to preserve.
+                            status_fields["metadata"] = dict(header.metadata)
                         await registry.update_execution_status(
                             execution_id,
                             header.session_id,
                             "RUNNING",
-                            worker_id=self.worker.worker_id,
+                            **status_fields,
                         )
                 elif hasattr(registry, "save_execution"):
                     await registry.save_execution(
@@ -641,6 +663,12 @@ class WorkerRunner:
                             "parent_message_id": header.parent_message_id or "",
                             "worker_id": self.worker.worker_id,
                             "target_agent_type": header.target_agent_type,
+                            # Same reason as the update branch above. This one
+                            # is the no-existing-record fallback, so there is
+                            # no stored original to protect and no ResumeCommand
+                            # guard to make: whatever woke this is all this
+                            # execution has ever been told.
+                            "metadata": dict(header.metadata),
                             "stream_name": stream_name,
                             "redis_message_id": msg_id,
                             "status": "RUNNING",

--- a/src/by_framework/worker/worker.py
+++ b/src/by_framework/worker/worker.py
@@ -59,6 +59,7 @@ from by_framework.trace.span_recorder import TraceSpan, str_to_uint64
 from by_framework.worker.context import AgentContext, current_agent_context_var
 from by_framework.worker.heartbeat import WorkerHeartbeat
 
+from ._resume_metadata import merge_resume_metadata
 from .sandbox.hook_sandbox import active_workspace
 
 
@@ -378,6 +379,47 @@ class GatewayWorker(ABC):
         )
 
     @staticmethod
+    def _restore_inbound_metadata(
+        command: GatewayCommand,
+        is_agent_return: bool,
+        execution: Optional["RunningExecution"],
+    ) -> GatewayCommand:
+        """Give a resumed handler its own dispatch metadata back.
+
+        The mirror image of ``_resolve_reply_command``, and deliberately not
+        the same rule. That one rebuilds the header this execution *sends*;
+        this one rebuilds the header it *reads*. A resumed handler otherwise
+        sees only the metadata of whatever woke it up — an ``ask_user``
+        answer's, or a sub-call's reply — and everything the execution was
+        originally dispatched with is gone from the moment it first suspends.
+
+        Merged, not replaced (the opposite of the outbound direction): this
+        agent IS the addressee of the waking message, so its metadata is real
+        payload here rather than someone else's plumbing. Original dispatch
+        metadata is the base, the waking message wins on collisions. See
+        ``_resume_metadata.py`` for why the framework's per-hop trace keys are
+        excluded from the base.
+
+        Returns a NEW command — never mutates. ``prepare_command_for_processing``
+        returns the *same* object for the base worker (only ``ByaiWorker``
+        rebuilds it), so mutating the header here would also rewrite
+        ``raw_command``'s and leak this merge into the reply that goes out.
+        """
+        if not is_agent_return:
+            return command
+        snapshot = getattr(execution, "existing_data", None) or {}
+        return replace(
+            command,
+            header=replace(
+                command.header,
+                metadata=merge_resume_metadata(
+                    snapshot.get("metadata"),
+                    command.header.metadata,
+                ),
+            ),
+        )
+
+    @staticmethod
     def _apply_suspended_status(
         task_result: AgentTaskResult,
         context: Optional[AgentContext],
@@ -682,6 +724,7 @@ class GatewayWorker(ABC):
         is_agent_return = isinstance(raw_command, ResumeCommand)
         reply_command = self._resolve_reply_command(raw_command, execution)
         has_source_agent = reply_command is not None
+        command = self._restore_inbound_metadata(command, is_agent_return, execution)
 
         # Get workspace dir from workspace_manager if available
         # Note: We don't use hasattr check because it doesn't work well with mocks

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1341,6 +1341,34 @@ async def test_client_send_message_ask_agent_does_not_query_registry_for_resume_
 
 
 @pytest.mark.asyncio
+async def test_client_root_dispatch_records_its_metadata_on_the_execution():
+    """A root execution's own dispatch metadata has to be on its record.
+
+    The agent will suspend (an `ask_user` round is the common case) and come
+    back on a ResumeCommand carrying the *callee's* metadata; the only way it
+    can still read what the client originally sent is for the client to have
+    recorded it here.
+    """
+    mock_redis = AsyncMock()
+    mock_registry = AsyncMock()
+
+    client = GatewayClient(redis_client=mock_redis, registry=mock_registry)
+    await client.send_message(
+        target_agent_type="langgraph_agent",
+        session_id="s1",
+        content="hello",
+        action_type="ASK_AGENT",
+        message_id="msg-new",
+        target_worker_id="worker-42",
+        metadata={"tenant": "acme", "req": "r-1"},
+    )
+
+    initialized = mock_registry.initialize_execution.await_args.args[0]
+    assert initialized["metadata"]["tenant"] == "acme"
+    assert initialized["metadata"]["req"] == "r-1"
+
+
+@pytest.mark.asyncio
 async def test_client_send_message_resume_falls_back_when_registry_lacks_lookup():
     """A registry double/implementation without get_execution_by_message_id
     must not blow up a RESUME send -- mirror the defensive hasattr() guard
@@ -1349,6 +1377,7 @@ async def test_client_send_message_resume_falls_back_when_registry_lacks_lookup(
     mock_redis = AsyncMock()
 
     class RegistryWithoutLookup:
+
         async def initialize_execution(self, execution):
             return None
 

--- a/tests/integration/test_nested_chain.py
+++ b/tests/integration/test_nested_chain.py
@@ -228,11 +228,16 @@ class ChainAgent(GatewayWorker):
         self.dispatch_metadata = dispatch_metadata
         self.dispatch_calls = 0
         self.resume_payloads: list[Any] = []
+        # What each invocation was actually handed, so a test can assert on
+        # the inbound direction (what this agent reads) as well as on the
+        # outbound one (what it sends).
+        self.seen_metadata: list[dict] = []
 
     def get_agent_types(self) -> list[str]:
         return [self.agent_type]
 
     async def process_command(self, command, context: Any):
+        self.seen_metadata.append(dict(command.header.metadata))
         if isinstance(command, ResumeCommand):
             self.resume_payloads.append(command.reply_data)
             return {
@@ -262,11 +267,13 @@ class AskingMiddleAgent(GatewayWorker):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.user_answers: list[Any] = []
+        self.seen_metadata: list[dict] = []
 
     def get_agent_types(self) -> list[str]:
         return ["agent-b"]
 
     async def process_command(self, command, context: Any):
+        self.seen_metadata.append(dict(command.header.metadata))
         if isinstance(command, ResumeCommand):
             self.user_answers.append(command.content)
             return {
@@ -500,6 +507,10 @@ class TestSubAgentAsksTheUser(unittest.IsolatedAsyncioTestCase):
                     session_id=self.session_id,
                     trace_id="trace-ask",
                     target_agent_type="agent-a",
+                    # A's OWN request metadata — distinct from the metadata A
+                    # passes down to B, and never forwarded to B. A must be
+                    # able to read it again after B wakes it back up.
+                    metadata={"root": "from-client"},
                 ),
                 content="start",
             ).to_redis_payload(),
@@ -575,6 +586,15 @@ class TestSubAgentAsksTheUser(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(reply_metadata["agent"], "agent-b")
         self.assertNotIn("client_tag", reply_metadata)
 
+        # The INBOUND direction, which is a different rule: B is the addressee
+        # of the client's answer, so that answer's metadata is payload for B
+        # rather than someone else's plumbing. B reads its own dispatch
+        # metadata AND the answer's, with the answer winning collisions.
+        b_resumed_with = self.agent_b.seen_metadata[1]
+        self.assertEqual(b_resumed_with["tag"], "keep")
+        self.assertEqual(b_resumed_with["caller"], "should-not-leak")
+        self.assertEqual(b_resumed_with["client_tag"], "should-not-leak")
+
         await self._step("agent-a")
 
         self.assertEqual(
@@ -583,6 +603,29 @@ class TestSubAgentAsksTheUser(unittest.IsolatedAsyncioTestCase):
         )
         # Both links have unwound: nothing is left parked in the wait index.
         self.assertEqual(_wait_members(self.redis, self.session_id), [])
+
+    async def test_a_reads_its_own_root_metadata_after_b_wakes_it(self):
+        """The reported bug: A's own metadata vanished once B woke it.
+
+        A never gets its request metadata back from B — B replies with what A
+        dispatched B *with*, not with what A itself was dispatched with. The
+        only copy is on A's own execution record, which is why the worker
+        picking a message up records its metadata rather than relying on
+        whoever sent it (a client root dispatch writes no such field).
+        """
+        await self._step("agent-a")
+        await self._step("agent-b")
+        b_dispatch = _dispatched_message_id(self.redis, "agent-b")
+        await self._answer_the_user_prompt(b_dispatch)
+        await self._step("agent-b")
+        await self._step("agent-a")
+
+        a_resumed_with = self.agent_a.seen_metadata[1]
+        # What the client dispatched A with, still readable after the suspend.
+        self.assertEqual(a_resumed_with["root"], "from-client")
+        # And B's reply metadata layered on top.
+        self.assertEqual(a_resumed_with["agent"], "agent-b")
+        self.assertEqual(a_resumed_with["tag"], "from-agent-b")
 
     async def test_a_resume_naming_the_wrong_execution_cannot_reach_a(self):
         """The contract the whole path rests on, pinned as a test.
@@ -713,6 +756,111 @@ class TestRootExecutionAsksTheUser(unittest.IsolatedAsyncioTestCase):
         # Nobody else can close this stream: believing it owes an agent a reply
         # is exactly what stops the root from emitting the end event.
         self.assertIn(EventType.APP_STREAM_RESPONSE.value, events)
+
+
+class AskThenDelegateAgent(GatewayWorker):
+    """Suspends on a human first, then calls a sub-agent once resumed."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.seen_metadata: list[dict] = []
+
+    def get_agent_types(self) -> list[str]:
+        return ["agent-b"]
+
+    async def process_command(self, command, context: Any):
+        self.seen_metadata.append(dict(command.header.metadata))
+        if isinstance(command, ResumeCommand):
+            await context.call_agent(
+                target_agent_type="agent-c",
+                content="delegate",
+                wait_for_reply=True,
+            )
+            return {"status": AgentState.QUEUED.value}
+        return await context.ask_user("which colour?")
+
+
+class TestTracePlumbingSurvivesTheInboundRestore(unittest.IsolatedAsyncioTestCase):
+    """Restoring a hop's metadata must not restore its span ids with it.
+
+    The framework injects `trace_parent_span_id`, `framework_parent_span_id`
+    and `langfuse_parent_observation_id` into every dispatch's metadata, so a
+    stored copy describes the dispatch that created the execution — not the
+    hop resuming it now. `AgentContext._resolve_call_langfuse_parent_id()`
+    reads that key straight off the current command as its last-resort
+    fallback, so letting the stale value back in would parent a post-resume
+    call to an observation from before the suspend.
+    """
+
+    session_id = "sess-trace"
+
+    async def asyncSetUp(self):
+        self.redis = FakeRedis()
+        self.registry = WorkerRegistry(self.redis)
+        self.agent = AskThenDelegateAgent(
+            "worker-b", self.redis, self.registry, WorkspaceManagerStub()
+        )
+        self.runner = WorkerRunner(self.redis, self.agent, group_name="test-group")
+        await self.runner.setup_streams()
+        for agent_type in ("agent-b", "agent-c"):
+            await self.redis.sadd(
+                RedisKeys.agent_type_members(agent_type), self.agent.worker_id
+            )
+        await self.redis.set(RedisKeys.worker_online_lease(self.agent.worker_id), "1")
+
+        await self.redis.xadd(
+            RedisKeys.ctrl_stream("agent-b"),
+            AskAgentCommand(
+                header=MessageHeader(
+                    message_id="msg-root",
+                    session_id=self.session_id,
+                    trace_id="trace-plumbing",
+                    target_agent_type="agent-b",
+                    metadata={
+                        "tenant": "acme",
+                        "langfuse_parent_observation_id": "observation-before-suspend",
+                    },
+                ),
+                content="start",
+            ).to_redis_payload(),
+        )
+
+    async def _step(self):
+        await self.runner._run_once()
+        await self.runner.wait_for_tasks()
+
+    async def test_a_call_made_after_a_resume_does_not_reuse_the_stale_parent(self):
+        await self._step()
+        await self.redis.xadd(
+            RedisKeys.ctrl_stream("agent-b"),
+            ResumeCommand(
+                header=MessageHeader(
+                    message_id="msg-root",
+                    session_id=self.session_id,
+                    trace_id="trace-plumbing",
+                    target_agent_type="agent-b",
+                ),
+                content="Pink",
+            ).to_redis_payload(),
+        )
+        await self._step()
+
+        dispatched = _ctrl_messages(self.redis, "agent-c")
+        self.assertEqual(len(dispatched), 1)
+        header = dispatched[0]["header"]
+        self.assertNotEqual(
+            header["langfuse_parent_observation_id"], "observation-before-suspend"
+        )
+        self.assertNotEqual(
+            header["metadata"].get("langfuse_parent_observation_id"),
+            "observation-before-suspend",
+        )
+        # The business half of the same stored metadata IS restored, which is
+        # what makes the exclusion a filter rather than a switch: `tenant`
+        # comes back, the span id sitting next to it in the same dict does not.
+        resumed_with = self.agent.seen_metadata[1]
+        self.assertEqual(resumed_with["tenant"], "acme")
+        self.assertNotIn("langfuse_parent_observation_id", resumed_with)
 
 
 if __name__ == "__main__":

--- a/tests/worker/test_gateway_worker.py
+++ b/tests/worker/test_gateway_worker.py
@@ -1113,6 +1113,188 @@ async def test_resumed_root_execution_replies_to_nobody(tmp_path):
     assert _ctrl_stream_replies(redis_mock, "agent-b") == []
 
 
+class InboundMetadataWorker(GatewayWorker):
+    """Records what the handler is actually handed, header and context alike."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.seen_metadata = None
+        self.seen_context_metadata = None
+
+    def get_agent_types(self):
+        return ["structured_agent"]
+
+    async def process_command(self, command, context):
+        self.seen_metadata = dict(command.header.metadata)
+        self.seen_context_metadata = dict(context.current_command.header.metadata)
+        return {"status": AgentState.COMPLETED.value, "reply_data": {"ok": True}}
+
+
+def _inbound_resume(metadata):
+    return ResumeCommand(
+        header=MessageHeader(
+            message_id="msg-b",
+            session_id="sess-chain",
+            trace_id="trace-chain",
+            source_agent_type="agent-c",
+            target_agent_type="structured_agent",
+            parent_message_id="msg-c",
+            metadata=metadata,
+        ),
+        status=AgentState.COMPLETED.value,
+        reply_data={"from": "c"},
+    )
+
+
+def _inbound_execution(snapshot_fields, stored_metadata):
+    existing_data = {
+        "execution_id": "exec-b",
+        "message_id": "msg-b",
+        "session_id": "sess-chain",
+        "status": AgentState.WAITING_AGENT.value,
+        "source_agent_type": "agent-a",
+        "parent_message_id": "msg-a",
+        **snapshot_fields,
+    }
+    if stored_metadata is not None:
+        existing_data["metadata"] = stored_metadata
+    return RunningExecution(
+        execution_id="exec-b",
+        message_id="msg-b",
+        session_id="sess-chain",
+        worker_id="test-suspend",
+        task=AsyncMock(),
+        cancel_event=AsyncMock(),
+        is_resumed=True,
+        parent_message_id="msg-a",
+        existing_data=existing_data,
+    )
+
+
+@pytest.mark.asyncio
+async def test_resumed_handler_reads_its_own_dispatch_metadata(tmp_path):
+    """The inbound mirror of _resolve_reply_command, and a different rule.
+
+    A resumed handler used to see only the metadata of whatever woke it up,
+    so everything it was originally dispatched with vanished the first time
+    it suspended. Here the original is the base and the waking message is
+    merged on top — this agent IS the addressee of that message, so its
+    metadata is payload rather than someone else's plumbing.
+    """
+    redis_mock = _mock_redis()
+    worker, snapshot_fields = _resumable_worker(
+        InboundMetadataWorker, tmp_path, redis_mock
+    )
+
+    await worker._handle_message(
+        _inbound_resume({"answer": "Pink", "tag": "from-waking"}),
+        execution=_inbound_execution(
+            snapshot_fields, {"tenant": "acme", "tag": "from-dispatch"}
+        ),
+    )
+
+    assert worker.seen_metadata["tenant"] == "acme"
+    assert worker.seen_metadata["answer"] == "Pink"
+    # The newer, more specific hop wins a collision.
+    assert worker.seen_metadata["tag"] == "from-waking"
+    # The context must not disagree with the command handed to the handler.
+    assert worker.seen_context_metadata == worker.seen_metadata
+
+
+@pytest.mark.asyncio
+async def test_inbound_restore_drops_the_snapshots_stale_trace_keys(tmp_path):
+    """Span ids describe a hop, and the stored ones describe the wrong one."""
+    redis_mock = _mock_redis()
+    worker, snapshot_fields = _resumable_worker(
+        InboundMetadataWorker, tmp_path, redis_mock
+    )
+
+    await worker._handle_message(
+        _inbound_resume({}),
+        execution=_inbound_execution(
+            snapshot_fields,
+            {
+                "tenant": "acme",
+                "trace_parent_span_id": "stale-trace",
+                "framework_parent_span_id": "stale-framework",
+                "langfuse_parent_observation_id": "stale-langfuse",
+            },
+        ),
+    )
+
+    assert worker.seen_metadata == {"tenant": "acme"}
+
+
+@pytest.mark.asyncio
+async def test_inbound_restore_degrades_when_the_snapshot_predates_the_field(
+    tmp_path,
+):
+    """An execution recorded before this existed, or by another SDK."""
+    redis_mock = _mock_redis()
+    worker, snapshot_fields = _resumable_worker(
+        InboundMetadataWorker, tmp_path, redis_mock
+    )
+
+    await worker._handle_message(
+        _inbound_resume({"client_tag": "t"}),
+        execution=_inbound_execution(snapshot_fields, None),
+    )
+
+    assert worker.seen_metadata == {"client_tag": "t"}
+
+
+@pytest.mark.asyncio
+async def test_inbound_restore_does_not_mutate_the_command_it_replies_from(
+    tmp_path,
+):
+    """The outbound reply must not inherit the inbound merge.
+
+    prepare_command_for_processing() returns the SAME object for the base
+    worker, so a header mutated in place here would also rewrite the command
+    _resolve_reply_command builds the reply from.
+    """
+    redis_mock = _mock_redis()
+    worker, snapshot_fields = _resumable_worker(
+        InboundMetadataWorker, tmp_path, redis_mock
+    )
+    raw_command = _inbound_resume({"answer": "Pink"})
+
+    await worker._handle_message(
+        raw_command,
+        execution=_inbound_execution(snapshot_fields, {"tenant": "acme"}),
+    )
+
+    assert raw_command.header.metadata == {"answer": "Pink"}
+    # And the reply that went out carries the OUTBOUND rule's result: the
+    # stored dispatch metadata wholesale, with no key from the waking message.
+    reply = _ctrl_stream_replies(redis_mock, "agent-a")[0]
+    assert reply.header.metadata["tenant"] == "acme"
+    assert "answer" not in reply.header.metadata
+
+
+@pytest.mark.asyncio
+async def test_first_dispatch_metadata_is_left_alone(tmp_path):
+    """Only a resume restores. A fresh dispatch has nothing to restore from."""
+    redis_mock = _mock_redis()
+    worker = _worker_with_workspace(InboundMetadataWorker, tmp_path, redis_mock)
+
+    await worker._handle_message(
+        AskAgentCommand(
+            header=MessageHeader(
+                message_id="msg-b",
+                session_id="sess-chain",
+                trace_id="trace-chain",
+                source_agent_type="agent-a",
+                target_agent_type="structured_agent",
+                metadata={"tenant": "acme"},
+            ),
+            content="hello",
+        )
+    )
+
+    assert worker.seen_metadata == {"tenant": "acme"}
+
+
 @pytest.mark.asyncio
 async def test_failed_suspended_execution_still_replies_to_its_caller(tmp_path):
     """Suspension only defers a reply while the execution can still produce

--- a/tests/worker/test_processor.py
+++ b/tests/worker/test_processor.py
@@ -313,3 +313,105 @@ async def test_processor_resumed_execution_replies_to_the_original_caller():
     assert reply.header.parent_message_id == "msg-middle"
     assert reply.header.task_group_id == "tg-1"
     assert reply.reply_data == {"done": True}
+
+
+async def _resume_reply_to_caller(snapshot, handler_result, waking_metadata):
+    """Drive one resumed execution through GatewayProcessor and return the
+    reply command it posted to the caller's control stream.
+
+    The waking ResumeCommand names agent-c (the sub-agent that just finished)
+    and carries its own metadata for that hop; the caller owed a reply is
+    whatever the execution snapshot names.
+    """
+    redis_mock = AsyncMock()
+    redis_mock.pipeline = MagicMock(
+        return_value=MagicMock(xadd=MagicMock(), execute=AsyncMock(return_value=[]))
+    )
+    processor = GatewayProcessor(worker_id="worker-1", redis_client=redis_mock)
+
+    async def handler(command, context):
+        return handler_result
+
+    with patch(
+        "by_framework.core.registry.WorkerRegistry.get_execution_by_message_id",
+        new_callable=AsyncMock,
+    ) as lookup:
+        lookup.return_value = snapshot
+        await processor.process(
+            ResumeCommand(
+                header=MessageHeader(
+                    message_id="msg-middle",
+                    session_id="sess-1",
+                    trace_id="trace-1",
+                    source_agent_type="agent-c",
+                    target_agent_type="agent-b",
+                    parent_message_id="msg-sub",
+                    metadata=waking_metadata,
+                ),
+                status="COMPLETED",
+                reply_data={"from": "c"},
+            ),
+            handler,
+        )
+
+    ctrl_writes = [
+        call
+        for call in redis_mock.xadd.await_args_list
+        if call.args[0] == RedisKeys.ctrl_stream("agent-a")
+    ]
+    assert len(ctrl_writes) == 1
+    reply = command_from_dict(json.loads(ctrl_writes[0].args[1]["data"]))
+    # Proves the reply went through the resume rebuild rather than straight off
+    # the incoming header: the waking command names agent-c as its source and
+    # "msg-sub" as its parent, so only the execution snapshot can put this
+    # reply on agent-a's stream carrying the caller's own id.
+    assert reply.header.message_id == "msg-caller"
+    return reply
+
+
+@pytest.mark.asyncio
+async def test_processor_resumed_reply_carries_the_callers_own_metadata():
+    """Same rule as GatewayWorker._resolve_reply_command: the caller's
+    original dispatch metadata is restored wholesale from the execution
+    snapshot. The metadata on the message that woke this execution up is
+    plumbing for that one hop and must not reach the caller."""
+    reply = await _resume_reply_to_caller(
+        snapshot={
+            "source_agent_type": "agent-a",
+            "parent_message_id": "msg-caller",
+            "task_group_id": "tg-1",
+            # A's original dispatch metadata, persisted at
+            # initialize_execution() time.
+            "metadata": {"caller": "original", "request_id": "req-1"},
+        },
+        handler_result={
+            "status": "COMPLETED",
+            "reply_data": {"done": True},
+            # This link's own metadata: overrides same-named keys from the
+            # caller's, leaves the rest alone.
+            "metadata": {"caller": "overridden", "tokens": 123},
+        },
+        waking_metadata={"caller": "should-not-leak", "from_c": "should-not-leak"},
+    )
+
+    assert reply.header.metadata["request_id"] == "req-1"
+    assert reply.header.metadata["caller"] == "overridden"
+    assert reply.header.metadata["tokens"] == 123
+    assert "from_c" not in reply.header.metadata
+
+
+@pytest.mark.asyncio
+async def test_processor_resumed_reply_metadata_is_empty_without_a_snapshot_value():
+    """An execution recorded before the snapshot carried metadata degrades to
+    an empty dict — never to the waking message's metadata."""
+    reply = await _resume_reply_to_caller(
+        snapshot={
+            "source_agent_type": "agent-a",
+            "parent_message_id": "msg-caller",
+            "task_group_id": "",
+        },
+        handler_result={"status": "COMPLETED", "reply_data": {"done": True}},
+        waking_metadata={"caller": "should-not-leak", "from_c": "should-not-leak"},
+    )
+
+    assert reply.header.metadata == {}

--- a/tests/worker/test_processor.py
+++ b/tests/worker/test_processor.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from by_framework import GatewayProcessor, RedisKeys
+from by_framework.common.constants import CLIENT_SOURCE_AGENT_TYPE
 from by_framework.core.protocol.commands import (
     AskAgentCommand,
     ResumeCommand,
@@ -415,3 +416,120 @@ async def test_processor_resumed_reply_metadata_is_empty_without_a_snapshot_valu
     )
 
     assert reply.header.metadata == {}
+
+
+async def _resumed_handler_sees(snapshot, waking_metadata):
+    """Drive one resumed execution through GatewayProcessor and return what
+    the handler was actually handed — the inbound direction.
+
+    Uses a client-dispatched root (`source_agent_type` is the client
+    sentinel, so nobody is owed a reply) on purpose: that is the case the
+    outbound resolver short-circuits to None, and the inbound restore has to
+    run anyway.
+    """
+    redis_mock = AsyncMock()
+    redis_mock.pipeline = MagicMock(
+        return_value=MagicMock(xadd=MagicMock(), execute=AsyncMock(return_value=[]))
+    )
+    processor = GatewayProcessor(worker_id="worker-1", redis_client=redis_mock)
+    seen = {}
+
+    async def handler(command, context):
+        seen["header"] = dict(command.header.metadata)
+        seen["context"] = dict(context.current_command.header.metadata)
+        return {"status": "COMPLETED", "reply_data": {"done": True}}
+
+    with patch(
+        "by_framework.core.registry.WorkerRegistry.get_execution_by_message_id",
+        new_callable=AsyncMock,
+    ) as lookup:
+        lookup.return_value = snapshot
+        await processor.process(
+            ResumeCommand(
+                header=MessageHeader(
+                    message_id="msg-root",
+                    session_id="sess-1",
+                    trace_id="trace-1",
+                    source_agent_type="agent-b",
+                    target_agent_type="agent-a",
+                    parent_message_id="msg-sub",
+                    metadata=waking_metadata,
+                ),
+                status="COMPLETED",
+                reply_data={"from": "b"},
+            ),
+            handler,
+        )
+    return seen
+
+
+@pytest.mark.asyncio
+async def test_processor_resumed_handler_reads_its_own_dispatch_metadata():
+    """The inbound direction: merged, not replaced.
+
+    Mirrors GatewayWorker._restore_inbound_metadata. The handler is the
+    addressee of the waking message, so that message's metadata is payload
+    here rather than someone else's plumbing — it layers on top of what this
+    execution was originally dispatched with instead of erasing it.
+    """
+    seen = await _resumed_handler_sees(
+        snapshot={
+            "source_agent_type": CLIENT_SOURCE_AGENT_TYPE,
+            "parent_message_id": "",
+            "metadata": {"tenant": "acme", "tag": "from-dispatch"},
+        },
+        waking_metadata={"answer": "Pink", "tag": "from-waking"},
+    )
+
+    assert seen["header"]["tenant"] == "acme"
+    assert seen["header"]["answer"] == "Pink"
+    assert seen["header"]["tag"] == "from-waking"
+    assert seen["context"] == seen["header"]
+
+
+@pytest.mark.asyncio
+async def test_processor_inbound_restore_drops_stale_trace_keys():
+    seen = await _resumed_handler_sees(
+        snapshot={
+            "source_agent_type": CLIENT_SOURCE_AGENT_TYPE,
+            "metadata": {
+                "tenant": "acme",
+                "trace_parent_span_id": "stale-trace",
+                "framework_parent_span_id": "stale-framework",
+                "langfuse_parent_observation_id": "stale-langfuse",
+            },
+        },
+        waking_metadata={},
+    )
+
+    assert seen["header"] == {"tenant": "acme"}
+
+
+@pytest.mark.asyncio
+async def test_processor_inbound_restore_degrades_without_a_snapshot_value():
+    """No stored metadata (old record, or another SDK's caller) leaves the
+    waking message's metadata exactly as it arrived."""
+    seen = await _resumed_handler_sees(
+        snapshot={"source_agent_type": CLIENT_SOURCE_AGENT_TYPE},
+        waking_metadata={"client_tag": "t"},
+    )
+
+    assert seen["header"] == {"client_tag": "t"}
+
+
+@pytest.mark.asyncio
+async def test_processor_inbound_restore_does_not_leak_into_the_reply():
+    """The two directions share a record, not a rule: the reply keeps the
+    replacement semantics even though the handler saw a merge."""
+    reply = await _resume_reply_to_caller(
+        snapshot={
+            "source_agent_type": "agent-a",
+            "parent_message_id": "msg-caller",
+            "task_group_id": "tg-1",
+            "metadata": {"caller": "original"},
+        },
+        handler_result={"status": "COMPLETED", "reply_data": {"done": True}},
+        waking_metadata={"from_c": "should-not-leak"},
+    )
+
+    assert reply.header.metadata == {"caller": "original"}

--- a/tests/worker/test_resume_metadata.py
+++ b/tests/worker/test_resume_metadata.py
@@ -1,0 +1,69 @@
+"""Unit tests for the inbound resume-metadata merge rule."""
+
+from by_framework.worker._resume_metadata import (
+    FRAMEWORK_HOP_METADATA_KEYS,
+    merge_resume_metadata,
+)
+
+
+def test_original_dispatch_metadata_is_the_base():
+    """What the execution was dispatched with survives the resume."""
+    merged = merge_resume_metadata({"tenant": "acme", "req": "r-1"}, {})
+    assert merged == {"tenant": "acme", "req": "r-1"}
+
+
+def test_waking_message_metadata_is_layered_on_top():
+    merged = merge_resume_metadata({"tenant": "acme"}, {"answer": "Pink"})
+    assert merged == {"tenant": "acme", "answer": "Pink"}
+
+
+def test_waking_message_wins_on_collision():
+    """The newer, more specific hop overrides — never the other way round."""
+    merged = merge_resume_metadata({"tag": "dispatch"}, {"tag": "waking"})
+    assert merged["tag"] == "waking"
+
+
+def test_framework_hop_keys_are_never_restored_from_the_snapshot():
+    """Stale span ids must not surface where this hop supplied none.
+
+    They describe the dispatch that created the execution, not the hop
+    resuming it, and AgentContext's langfuse fallback reads them straight off
+    the current command.
+    """
+    stored = {
+        "tenant": "acme",
+        "trace_parent_span_id": "stale-trace",
+        "framework_parent_span_id": "stale-framework",
+        "langfuse_parent_observation_id": "stale-langfuse",
+    }
+    merged = merge_resume_metadata(stored, {})
+    assert merged == {"tenant": "acme"}
+    for key in FRAMEWORK_HOP_METADATA_KEYS:
+        assert key not in merged
+
+
+def test_framework_hop_keys_from_the_waking_message_are_kept():
+    """Only the stored copy is stale; this hop's own values are current."""
+    merged = merge_resume_metadata(
+        {"trace_parent_span_id": "stale"},
+        {"trace_parent_span_id": "current"},
+    )
+    assert merged == {"trace_parent_span_id": "current"}
+
+
+def test_missing_snapshot_degrades_to_the_waking_message():
+    """Records written before this field existed, or by another SDK."""
+    assert merge_resume_metadata(None, {"client_tag": "t"}) == {"client_tag": "t"}
+    assert merge_resume_metadata({}, {"client_tag": "t"}) == {"client_tag": "t"}
+
+
+def test_both_sides_missing_is_an_empty_dict():
+    assert merge_resume_metadata(None, None) == {}
+
+
+def test_neither_input_is_mutated():
+    stored = {"tenant": "acme"}
+    incoming = {"answer": "Pink"}
+    merge_resume_metadata(stored, incoming)
+    assert stored == {"tenant": "acme"}
+    assert incoming == {"answer": "Pink"}

--- a/tests/worker/test_runner.py
+++ b/tests/worker/test_runner.py
@@ -602,6 +602,7 @@ class TestWorkerRunner(unittest.IsolatedAsyncioTestCase):
                 session_id="sess-1",
                 trace_id="trace-1",
                 target_agent_type="dummy_agent",
+                metadata={"tenant": "acme"},
             ),
             content="test",
         ).to_dict()
@@ -612,11 +613,16 @@ class TestWorkerRunner(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsNotNone(worker.seen_execution)
         self.assertFalse(worker.seen_execution.is_resumed)
+        # The dispatch metadata is recorded by the worker picking the message
+        # up, not only by whoever sent it: that is what makes it present for
+        # a client root dispatch and for a TS/Java caller, neither of which
+        # writes the field. _handle_message restores it on resume.
         worker.registry.update_execution_status.assert_awaited_once_with(
             "exec-queued",
             "sess-1",
             "RUNNING",
             worker_id="worker-1",
+            metadata={"tenant": "acme"},
         )
         self.assertTrue(redis_mock.acked)
 
@@ -659,6 +665,52 @@ class TestWorkerRunner(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(worker.seen_execution.is_resumed)
         self.assertEqual(worker.seen_execution.parent_message_id, "msg-caller")
+
+    async def test_resume_does_not_overwrite_the_recorded_dispatch_metadata(self):
+        """The stored original is the only copy — a resume must not clobber it.
+
+        The record's `metadata` is what this execution was ORIGINALLY
+        dispatched with, and `_handle_message` restores it so a resumed
+        handler can still read it. Writing the waking message's metadata over
+        it on the way in would destroy exactly what the restore exists to
+        recover, and nothing else keeps a copy.
+        """
+        redis_mock = MockRedisRunner(message_to_return=[])
+        worker = ExecutionInspectWorker()
+        worker.registry = AsyncMock()
+        worker.registry.get_execution_by_message_id.return_value = {
+            "execution_id": "exec-waiting",
+            "message_id": "msg-waiting",
+            "session_id": "sess-1",
+            "parent_message_id": "msg-caller",
+            "status": AgentState.WAITING_USER.value,
+            "metadata": {"tenant": "acme"},
+        }
+
+        runner = WorkerRunner(
+            redis_client=redis_mock, worker=worker, group_name="test_group"
+        )
+        payload = ResumeCommand(
+            header=MessageHeader(
+                message_id="msg-waiting",
+                session_id="sess-1",
+                trace_id="trace-1",
+                target_agent_type="dummy_agent",
+                metadata={"client_tag": "this-hop-only"},
+            ),
+            content="Pink",
+        ).to_dict()
+
+        await runner._process_message_from_dict(
+            RedisKeys.ctrl_stream("dummy_agent"), "1-1", payload
+        )
+
+        worker.registry.update_execution_status.assert_awaited_once_with(
+            "exec-waiting",
+            "sess-1",
+            "RUNNING",
+            worker_id="worker-1",
+        )
 
     async def test_runner_does_not_skip_waiting_agent_replay(self):
         """WAITING_AGENT is not terminal: a suspended caller must stay


### PR DESCRIPTION
## The gap

PR #137 (`559c945`) and its follow-up fixed the **outbound** half of resume metadata: the reply a resumed callee sends now carries its caller's original dispatch metadata. The **inbound** half was never touched — what the resumed handler itself reads.

A handler that suspends (`ask_user`, or a `call_agent` hop) comes back seeing only the metadata of whatever woke it up. Everything it was originally dispatched with is gone from the first suspend onward. Measured end-to-end against the real `WorkerRegistry`:

```
client dispatches A with {'tenant':'acme','req':'r-1'}
A calls B with {'caller':'agent-a','tag':'keep'}
B suspends on ask_user; a client answers with {'client_tag':'x'}

B's handler saw:
  0  {'caller':'agent-a', 'tag':'keep', ...}   first dispatch: fine
  1  {'client_tag':'x'}                        after resume: A's metadata gone

A's handler saw:
  0  {'tenant':'acme', 'req':'r-1'}            first dispatch: fine
  1  {'caller':'agent-a', 'tag':'from-agent-b'} after resume: its own metadata gone
```

## The fix

**Read side.** `_restore_inbound_metadata()` rebuilds the header the handler reads, in `GatewayWorker` and `GatewayProcessor` alike. It **merges** rather than replaces — deliberately the opposite of the outbound rule: the resumed agent *is* the addressee of the waking message, so an `ask_user` answer's metadata is payload for it rather than someone else's plumbing. Original dispatch metadata is the base; the waking message wins collisions. The rule lives in one place, `_resume_metadata.py`, because the last time `worker.py` and `processor.py` each carried their own copy of a resume rule the processor was left behind for a whole commit.

**Write side.** The restore needs a stored original for *every* execution, and no dispatcher-side patch delivers that — only `AgentContext` writes the field today, while the Python client, the `save_execution` fallback, and both other SDKs do not (TS also omits `task_group_id`; Java omits `source_agent_type` too). So the worker *executing* a message records its own `header.metadata` on first pickup: correct by definition, and correct for dispatchers this repo doesn't own. Guarded on not-a-`ResumeCommand` — a resume writing its waking metadata over the record would destroy the very original the restore recovers.

**Trace fields.** `trace_parent_span_id` / `framework_parent_span_id` / `langfuse_parent_observation_id` are filtered out of the restored base at *read* time. A stored copy describes the hop that created the execution, and `_resolve_call_langfuse_parent_id()` reads that key off the current command — restoring it would parent a post-resume call to a pre-suspend observation. Read time and not write time, because the outbound path restores the stored dict verbatim on purpose.

## Compatibility

An execution with no stored metadata degrades to the waking message's metadata unchanged — the pre-fix behaviour. No migration, no version gate; the registry stores one opaque JSON blob per execution. Mixed-version fleets are safe in both directions. Rollback is reverting the commit.

**Visible behaviour change:** a handler that treated the resumed header's metadata as "only what this hop just sent" will now see additional keys. Noted in the CHANGELOG.

## Note on the commit range

This PR carries **two** commits. `2f18808` ("restore caller metadata on the processor resume path too") was written for the previous task but never pushed and has no PR of its own — it was local-only on the branch this one is based off. It is the same subsystem and the inbound fix builds on its `_resolve_reply_header` shape, so it rides along here rather than being silently dropped or rebased out.

## Verification

- `make test` — 802 passed (root) plus all 9 `libs/*` projects green
- `make lint-changed` — 10.00/10
- `bash scripts/verify.sh` — 3/3 guards green, including `KEY_FILES.md` freshness

New coverage: the merge rule and its degrade path (unit), both worker entry points including the no-mutation guard that keeps the inbound merge out of the outbound reply, and end-to-end cases for both the reported A-side bug and the B-side `ask_user` round — plus an assertion that a `call_agent` issued after a resume does not reuse the stale span parent.

## Out of scope

TS/Java caller-side execution records (they also omit `source_agent_type` and `task_group_id`, which breaks more than metadata) — tracked by the existing suspended-parent-liveness parity tasks. The Python side is correct even with a TS/Java caller, because the callee's own worker records the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)