### PR TITLE
fix(metrics): register the collector's own metrics in the catalog

### DIFF
--- a/src/by_framework/metrics/catalog.py
+++ b/src/by_framework/metrics/catalog.py
@@ -367,6 +367,60 @@ _CATALOG: dict[str, MetricDefinition] = {
             "Instrumentation reliability signal pinpointing exporter failures."
         ),
     ),
+    # Self-monitoring for the background collector in metrics/collector.py.
+    # Exactly one process holds its Redis lock and writes history points, so
+    # these answer "is anyone still collecting?" — a gap here means the
+    # dashboards go stale silently rather than erroring.
+    "by_framework_metrics_collector_cycles_total": MetricDefinition(
+        name="by_framework_metrics_collector_cycles_total",
+        kind=MetricKind.COUNTER,
+        unit=MetricUnit.NONE,
+        labels=("result",),
+        description=(
+            "Metrics collector cycles by result "
+            "(success, snapshot_failed, lock_skipped, disabled)."
+        ),
+        interpretation=(
+            "Collector health signal: only the lock holder reports success, so "
+            "lock_skipped dominating across a fleet is expected."
+        ),
+    ),
+    "by_framework_metrics_collector_snapshot_duration_ms": MetricDefinition(
+        name="by_framework_metrics_collector_snapshot_duration_ms",
+        kind=MetricKind.HISTOGRAM,
+        unit=MetricUnit.MILLISECONDS,
+        description=(
+            "Duration of one collector snapshot build plus history write."
+        ),
+        interpretation=(
+            "Latency signal for collection itself; approaching the collection "
+            "interval means cycles are about to overlap."
+        ),
+    ),
+    "by_framework_metrics_collector_lock_held": MetricDefinition(
+        name="by_framework_metrics_collector_lock_held",
+        kind=MetricKind.GAUGE,
+        unit=MetricUnit.NONE,
+        description=(
+            "Whether this process currently holds the metrics collector lock."
+        ),
+        interpretation=(
+            "Saturation signal: should sum to 1 across the fleet — 0 means "
+            "nobody is collecting, above 1 means the lock split."
+        ),
+    ),
+    "by_framework_metrics_collector_last_success_timestamp_ms": MetricDefinition(
+        name="by_framework_metrics_collector_last_success_timestamp_ms",
+        kind=MetricKind.GAUGE,
+        unit=MetricUnit.MILLISECONDS,
+        description=(
+            "Unix timestamp in milliseconds of the last successful collection."
+        ),
+        interpretation=(
+            "Freshness signal: alert on now minus this value exceeding a few "
+            "collection intervals."
+        ),
+    ),
 }
 
 


### PR DESCRIPTION
## 问题

`make test` 在 `main` @ 549d838 上是**红的**，与任何本地改动无关：

```
FAILED tests/metrics/test_catalog.py::test_runtime_prometheus_metrics_have_catalog_metadata
E   AssertionError: assert 'by_framework_metrics_collector_cycles_total' in {...}
```

`src/by_framework/metrics/collector.py` 定义了 4 个 Prometheus 指标用于监控后台采集器自身，但从未登记进 `_CATALOG`。而 `test_catalog.py` 断言「每个导出的 `by_framework_*` 指标都必须有 catalog 元数据」，于是一直失败。

漏登记的 4 个：

| 指标 | kind |
|---|---|
| `by_framework_metrics_collector_cycles_total` | counter |
| `by_framework_metrics_collector_snapshot_duration_ms` | histogram |
| `by_framework_metrics_collector_lock_held` | gauge |
| `by_framework_metrics_collector_last_success_timestamp_ms` | gauge |

## 这不是 flake

守卫本身是健全的，只是被红着合了进来：`metrics/__init__.py:16` 无条件 `from by_framework.metrics.collector import MetricsCollector`，所以这些指标总会注册进全局 Prometheus registry，测试确定性地能看见它们——不依赖其他测试模块的导入顺序副作用。所以这里不需要再加新守卫，把缺的条目补上即可。

## 改动

只在 `_CATALOG` 末尾补 4 条 `MetricDefinition`。**无行为变更**：catalog 是给 dashboard 和 metrics API 用的元数据，这些指标本来就在导出。

description / interpretation 按这几个指标的实际语义写：采集器在 Redis 分布式锁下运行，全集群只有一个进程真正写 history point，所以

- `lock_held` 全集群求和应当等于 1（0 = 没人在采集，>1 = 锁裂了）
- `cycles_total{result="lock_skipped"}` 在集群里占多数是**预期**的，不是异常
- `last_success_timestamp_ms` 是新鲜度信号，用 `now - value` 超过若干个采集周期来告警

## 验证

在 `main` @ 549d838 之上的干净分支：

- `make test`：**801 passed, 1 skipped**（此前 800 passed + 1 failed）
- `make lint`：全部 10.00/10
- `bash scripts/verify.sh`：3 guards green

## 关联

在 #141 里我把这个失败标注为「main 上原样存在，与该 PR 无关」。本 PR 合并后那条备注即可消除。两者拆开是因为关注点无关，也便于各自独立 revert。

🤖 Generated with [Claude Code](https://claude.com/claude-code)