### PR TITLE
fix(ci): stop the test run from silently dropping optional dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,22 @@ Pre-commit hooks are configured in `.pre-commit-config.yaml` and run isort, ruff
   plugin/trace integration point must degrade to a no-op (logged) rather
   than raising.
 
+- **A rule enforced only behind an optional dependency is not enforced.** If
+  the check short-circuits when a package is missing, then whatever controls
+  the environment controls the rule — and a green run stops meaning anything.
+  Incident: `tests/metrics/test_catalog.py` asserts every exported metric has a
+  `metrics/catalog.py` entry, but returned early when `prometheus-client` was
+  absent, while `make test` synced with `--extra dev` and dropped the root
+  `observability` extra. The assertion ran against an empty registry and
+  reported success for months; four uncatalogued metrics landed on main with CI
+  green (#142, then the CI fix). Correct form: enforce the rule where the
+  optional dependency cannot reach it — here `scripts/check-metric-catalog.sh`
+  reads the source, so **every new Prometheus `Counter`/`Gauge`/`Histogram` in
+  `src/` needs a `catalog.py` entry** regardless of what is installed — and
+  make the dependent test `pytest.skip()` rather than `return`, so degrading is
+  at least visible. Test commands must sync the extras the tests exercise
+  (`make test` uses `--all-extras`); narrowing them silently deletes coverage.
+
 ## Iron rules
 
 <!-- No process rules (test invocation, release steps) have caused an

--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,22 @@ list-projects:
 		echo $$project; \
 	done
 
+# All ten projects share the workspace venv, so syncing them in a loop makes
+# each one PRUNE the previous one's dependencies — the loop used to end with a
+# venv holding only the last project's deps (and it uninstalled prometheus-client
+# on the second iteration). --all-packages resolves the whole workspace once
+# instead. The loop survives only for an explicit PROJECTS override, where
+# narrowing the venv is what the caller asked for.
 install:
-	@for project in $(PROJECTS); do \
-		echo "==> Syncing $$project"; \
-		(cd $$project && uv sync --all-extras); \
-	done
+	@if [ "$(strip $(PROJECTS))" = "$(strip $(PYTHON_PROJECTS))" ]; then \
+		echo "==> Syncing workspace (all packages, all extras)"; \
+		uv sync --all-extras --all-packages; \
+	else \
+		for project in $(PROJECTS); do \
+			echo "==> Syncing $$project (narrowed: PROJECTS override)"; \
+			(cd $$project && uv sync --all-extras); \
+		done; \
+	fi
 
 format:
 	@PROJECTS="$(PROJECTS)" ./scripts/python_quality.sh format $(FILES)
@@ -80,6 +91,18 @@ lint-changed:
 		$(MAKE) lint PROJECTS="$(PROJECTS)" FILES="$$changed_files"; \
 	fi
 
+# --all-extras, not --extra dev: `uv run` only ever adds what it is asked for,
+# it never restores an extra it was not told about. So once `install`'s old
+# per-project loop had uninstalled prometheus-client, `--extra dev` left it
+# uninstalled and the root project's whole `observability` extra stayed missing
+# for the entire test run. tests/metrics then ran against a build with no
+# Prometheus registry, where the metric catalog check short-circuits and reports
+# success without inspecting anything. State what the tests need, rather than
+# inheriting whatever `install` happened to leave behind.
+#
+# Deliberately per-project rather than --all-packages: each project must be
+# testable with only its own declared dependencies, or a package that quietly
+# leans on a sibling's deps would still pass here and break on install.
 test:
 	@set -e; for project in $(PROJECTS); do \
 		if ! find "$$project/tests" -type f \( -name 'test_*.py' -o -name '*_test.py' \) -print -quit 2>/dev/null | grep -q .; then \
@@ -87,7 +110,7 @@ test:
 			continue; \
 		fi; \
 		echo "==> Testing $$project"; \
-		(cd $$project && uv run --extra dev pytest); \
+		(cd $$project && uv run --all-extras pytest); \
 	done
 
 clean:

--- a/scripts/check-metric-catalog.sh
+++ b/scripts/check-metric-catalog.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Every Prometheus metric declared in src/ must have a catalog entry.
+#
+# metrics/catalog.py is the source of truth for metric names, units, labels and
+# interpretation; dashboards and the metrics API read from it. A metric that
+# ships without an entry is invisible there.
+#
+# Incident: metrics/collector.py's four self-monitoring metrics were never added
+# to _CATALOG (fixed in #142). tests/metrics/test_catalog.py already asserted
+# this rule, but it only inspects the *live* Prometheus registry and returns
+# early when prometheus-client is absent — and CI's `make test` was syncing the
+# root project without its `observability` extra, so the assertion ran against
+# an empty registry and reported success. The rule was right; enforcing it only
+# at runtime made it hostage to which optional dependencies happened to be
+# installed. This guard reads the source instead, so it cannot be silenced that
+# way.
+#
+# Limits: matches literal metric names passed to Counter/Gauge/Histogram within
+# two lines of the constructor. Metric names built by string concatenation or
+# f-string are not detected — none exist today, and the runtime test in
+# tests/metrics/test_catalog.py remains the backstop for those.
+
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+CATALOG="src/by_framework/metrics/catalog.py"
+SOURCE_DIR="src/by_framework"
+
+[ -f "$CATALOG" ] || { echo "OK: no $CATALOG yet"; exit 0; }
+
+declared=$(
+  grep -rh -A 2 -E '=[[:space:]]*(Counter|Gauge|Histogram)\(' \
+    "$SOURCE_DIR" --include='*.py' 2>/dev/null |
+    grep -oE '"by_framework_[a-z0-9_]+"' | tr -d '"' | sort -u
+)
+
+if [ -z "$declared" ]; then
+  echo "WARN: no Prometheus metric declarations found under $SOURCE_DIR --" >&2
+  echo "      the extraction pattern in $0 has probably drifted." >&2
+  echo "OK: metric catalog (nothing to check)"
+  exit 0
+fi
+
+fail=0
+for name in $declared; do
+  if ! grep -q "\"$name\": MetricDefinition(" "$CATALOG"; then
+    fail=1
+    echo "FAIL: metric '$name' is exported but missing from $CATALOG" >&2
+    echo "      Add an entry so dashboards and /metrics API can describe it:" >&2
+    echo "" >&2
+    echo "          \"$name\": MetricDefinition(" >&2
+    echo "              name=\"$name\"," >&2
+    echo "              kind=MetricKind.COUNTER,  # or GAUGE / HISTOGRAM" >&2
+    echo "              unit=MetricUnit.NONE,     # pick the real unit" >&2
+    echo "              labels=(),                # match the declaration" >&2
+    echo "              description=\"...\"," >&2
+    echo "              interpretation=\"...\"," >&2
+    echo "          )," >&2
+    echo "" >&2
+  fi
+done
+
+[ "$fail" -eq 0 ] && echo "OK: all $(echo "$declared" | wc -l | tr -d ' ') declared metrics are catalogued"
+exit "$fail"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -35,6 +35,7 @@ CHECKS=(
   "$_MAP_DIR/check-doc-discipline.sh"
   "$_MAP_DIR/check-map-territory.sh"
   "$_MAP_DIR/check-entry-freshness.sh"
+  "$_MAP_DIR/check-metric-catalog.sh"
 )
 
 if [ "${#CHECKS[@]}" -eq 0 ]; then

--- a/tests/metrics/test_catalog.py
+++ b/tests/metrics/test_catalog.py
@@ -1,5 +1,7 @@
 """Tests for the observability metric catalog."""
 
+import pytest
+
 from by_framework.metrics import (
     PROMETHEUS_AVAILABLE,
     build_observability_diagnostics_metrics,
@@ -69,8 +71,13 @@ def test_snapshot_prometheus_exporter_matches_metric_catalog_types():
 
 def test_runtime_prometheus_metrics_have_catalog_metadata():
     """Runtime and diagnostics metrics include legacy debug metadata."""
+    # skip, not `return`: without prometheus-client this check inspects nothing,
+    # and reporting that as a pass is how an uncatalogued metric reached main
+    # while CI stayed green. A skip is at least visible in the summary.
+    # scripts/check-metric-catalog.sh enforces the same rule statically, so the
+    # coverage does not depend on this optional dependency being installed.
     if not PROMETHEUS_AVAILABLE:
-        return
+        pytest.skip("prometheus-client not installed (root 'observability' extra)")
     record_execution_started_metrics(agent_type="catalog-agent")
     record_execution_metrics(
         status="COMPLETED",
@@ -106,7 +113,12 @@ def test_runtime_prometheus_metrics_have_catalog_metadata():
                 exported_types[name] = metric_type
 
     catalog = get_metric_catalog()
-    assert exported_types
+    # Pin the runtime metrics this test just recorded. `assert exported_types`
+    # alone is satisfied by the hand-built diagnostics block below, so it stayed
+    # green even when the Prometheus registry contributed nothing at all.
+    assert "by_framework_executions_started_total" in exported_types
+    assert "by_framework_execution_total_duration_seconds" in exported_types
+    assert "by_framework_availability_routing_ms" in exported_types
     for name, metric_type in exported_types.items():
         assert name in catalog
         assert catalog[name].kind.value == metric_type


### PR DESCRIPTION
## 问题

`tests/metrics/test_catalog.py::test_runtime_prometheus_metrics_have_catalog_metadata` 断言「每个导出的 `by_framework_*` 指标都必须有 catalog 条目」，但它在 CI 里**从未检查过任何东西**：

```python
if not PROMETHEUS_AVAILABLE:
    return          # ← 不是 skip，是 return，报告为 passed
```

CI 的环境里没有 `prometheus-client`，所以这个测试直接返回、计为通过。这就是 #142 那 4 个漏登记的指标能在 CI 全绿的情况下合进 main 的原因。#142 补了数据，本 PR 修的是**为什么没人被告知**。

## 两个各自独立成立的成因

我实测复现了完整因果链（`make install` → `make test`），两个缺陷单独任一个都足以造成这个环境：

**1. `make install` 边装边剪。** 十个项目共用 workspace 根 venv，而 `cd $project && uv sync --all-extras` 循环让每一轮都卸掉上一轮的依赖：

```
==> Syncing .                          + prometheus-client==0.25.0
==> Syncing libs/by-framework-adk      Uninstalled 14 packages   - prometheus-client==0.25.0
==> Syncing libs/by-framework-agent    Uninstalled 83 packages
==> Syncing libs/by-framework-dashboard  Uninstalled 46 packages
...
```

prometheus-client 在第二轮就被卸了，循环结束时 venv 里只剩最后一个项目的依赖。改为单次 `uv sync --all-extras --all-packages` 一次性解析整个 workspace。显式 `PROJECTS` 覆盖时保留原循环——那种情况下收窄正是调用方要的。

**2. `make test` 从没要过它需要的东西。** `uv run` 只会**添加**它被告知的内容，不会恢复一个没被要求的 extra。所以一旦 install 卸掉了 prometheus-client，`--extra dev` 就再也拿不回根项目的 `observability` extra。改为 `--all-extras`。

> 刻意**不用** `--all-packages`：每个包必须能只靠自己声明的依赖跑通测试，否则某个包偷偷依赖兄弟包的依赖，在这里照样绿、装的时候才炸。

实测验证两者各自独立生效：

| 序列 | `PROMETHEUS_AVAILABLE` |
|---|---|
| 旧 install + 旧 `--extra dev` | **False**（复现 CI 盲区） |
| 新 install + 旧 `--extra dev` | True |
| 旧 install + 新 `--all-extras` | True（补回 6 个包） |

## 纵深防御

单修环境还不够——**一条只在可选依赖背后生效的规则，等于没生效**。谁控制环境谁就控制规则。所以：

**新增 `scripts/check-metric-catalog.sh`（读源码，不依赖任何包）。** 提取 `src/` 下所有传给 `Counter`/`Gauge`/`Histogram` 的字面量指标名，逐一核对 `catalog.py` 里有无条目。已双向验证：

```
$ bash scripts/check-metric-catalog.sh          # HEAD
OK: all 14 declared metrics are catalogued

$ # 把 #142 的条目撤掉后
FAIL: metric 'by_framework_metrics_collector_cycles_total' is exported but missing from ...
      Add an entry so dashboards and /metrics API can describe it:
          "by_framework_metrics_collector_cycles_total": MetricDefinition(
              ...
```

按 `GUARD_AUTHORING.md` 的要求登记两处：`verify.sh` 的 `CHECKS`（执行）+ CLAUDE.md 的 cross-cutting invariant（解释为什么）。守卫耗时 0s，verify 总预算仍在 30s 内。

**运行时测试不再静默降级。** `return` 改成 `pytest.skip()`，缺依赖时至少在 summary 里可见：

```
SKIPPED [1] tests/metrics/test_catalog.py:80: prometheus-client not installed (root 'observability' extra)
```

**测试自身不再能空转通过。** 原来的 `assert exported_types` 光靠手工构造的 diagnostics 块就能满足，即使 Prometheus registry 完全为空也过。现在改为断言它刚记录的那三个运行时指标确实出现。

## 影响面

这不只是 metrics 的事——`observability` extra 里还有 `opentelemetry-api` / `opentelemetry-sdk`，此前**所有**依赖可选依赖的代码路径在 CI 里都没被真正执行过。

## 验证

- `make test`：815 passed（root）+ 全部 libs 通过；`test_runtime_prometheus_metrics_have_catalog_metadata` 现在真正 PASSED 而非静默返回
- `make lint`：全部 10.00/10
- `bash scripts/verify.sh`：**4 guards** green（新增的那个已生效）
- 新守卫在 pre-#142 树上必红、在 HEAD 上必绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)